### PR TITLE
Move default content padding to within OutlinedField only

### DIFF
--- a/src/MuiTiptapContent.tsx
+++ b/src/MuiTiptapContent.tsx
@@ -37,11 +37,6 @@ const useStyles = makeStyles({ name: { MuiTiptapContent } })((theme) => {
         ...getEditorStyles(theme),
       } as CSSObject,
     },
-
-    editableEditor: {
-      // Add padding around the input area
-      padding: theme.spacing(1.5),
-    },
   };
 });
 
@@ -55,14 +50,8 @@ export default function MuiTiptapContent({ className }: MuiTiptapContentProps) {
   const { classes, cx } = useStyles();
   const editor = useMuiTiptapEditorContext();
   const editorClasses = useMemo(
-    () =>
-      cx(
-        classNames.MuiTiptapContent,
-        className,
-        classes.editor,
-        editor?.isEditable && classes.editableEditor
-      ),
-    [className, classes, editor?.isEditable, cx]
+    () => cx(classNames.MuiTiptapContent, className, classes.editor),
+    [className, classes, cx]
   );
 
   // In order to utilize the latest `editor` in effect hooks below, but avoid

--- a/src/MuiTiptapOutlinedField.tsx
+++ b/src/MuiTiptapOutlinedField.tsx
@@ -45,12 +45,17 @@ const useStyles = makeStyles<{ stickyMenuBarOffset?: number }>({
   name: { MuiTiptapOutlinedField },
 })((theme, { stickyMenuBarOffset }) => {
   return {
-    // These first classes are added to allow convenient user overrides
+    // This first class is added to allow convenient user overrides. Users can
+    // similarly override the other classes below.
     root: {},
-    content: {},
+
+    content: {
+      // Add padding around the input area, since it's contained in the outline
+      padding: theme.spacing(1.5),
+    },
 
     menuBar: {
-      padding: theme.spacing(1),
+      padding: theme.spacing(1, 1.5),
     },
 
     menuBarSticky: {

--- a/src/demo/Editor.tsx
+++ b/src/demo/Editor.tsx
@@ -48,7 +48,8 @@ export default function Editor() {
               borderTopStyle: "solid",
               borderTopWidth: 1,
               borderTopColor: (theme) => theme.palette.divider,
-              p: 1,
+              py: 1,
+              px: 1.5,
             }}
           >
             <MenuButton


### PR DESCRIPTION
We shouldn't add default padding whenever the editor is in edit mode, generally.