### PR TITLE
Replace lodash named imports with default imports

### DIFF
--- a/src/ViewLinkMenuContent.tsx
+++ b/src/ViewLinkMenuContent.tsx
@@ -1,6 +1,6 @@
 import { Button, DialogActions, Link } from "@mui/material";
 import { getMarkRange, getMarkType, type Editor } from "@tiptap/core";
-import { truncate } from "lodash";
+import truncate from "lodash/truncate";
 import { makeStyles } from "tss-react/mui";
 import useKeyDown from "./hooks/useKeyDown";
 import truncateMiddle from "./utils/truncateMiddle";

--- a/src/extensions/ResizableImageComponent.tsx
+++ b/src/extensions/ResizableImageComponent.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from "@mui/material";
 import type { NodeViewProps } from "@tiptap/core";
 import { NodeViewWrapper } from "@tiptap/react";
-import { throttle } from "lodash";
+import throttle from "lodash/throttle";
 import type { Node as ProseMirrorNode } from "prosemirror-model";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 

--- a/src/hooks/useDebouncedFocus.ts
+++ b/src/hooks/useDebouncedFocus.ts
@@ -1,5 +1,5 @@
 import type { Editor } from "@tiptap/core";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 import { useEffect, useMemo, useState } from "react";
 
 export type UseDebouncedFocusOptions = {

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -5,7 +5,7 @@ import {
   type CSSObject,
   type Theme,
 } from "@mui/material";
-import { omit } from "lodash";
+import omit from "lodash/omit";
 import { keyframes } from "tss-react";
 
 type StyleRules = Record<string, CSSObject>;

--- a/src/utils/debounceRender.tsx
+++ b/src/utils/debounceRender.tsx
@@ -10,7 +10,8 @@
  * So copied the brief source directly here instead.
  */
 import hoistNonReactStatics from "hoist-non-react-statics";
-import { debounce as _debounce, type DebounceSettings } from "lodash";
+import type { DebounceSettings } from "lodash";
+import _debounce from "lodash/debounce";
 import { Component, type ComponentType } from "react";
 
 function debounceRender<T>(


### PR DESCRIPTION
Along the lines of MUI's suggestion here https://mui.com/material-ui/guides/minimizing-bundle-size/#option-one-use-path-imports about how library developers should use default imports.

Still to do later: use default imports for MUI components, MUI icons, and react-icons.