### PR TITLE
Improve snappiness of MenuBar & TableBubbleMenu with leading debounce render

### DIFF
--- a/src/MenuBar.tsx
+++ b/src/MenuBar.tsx
@@ -329,6 +329,8 @@ function MenuBarInner({
 // similar, based on some barely-noticeable delay between action/movement and menu bar
 // state.
 const MenuBar = debounceRender(MenuBarInner, 170, {
+  leading: true,
+  trailing: true,
   maxWait: 300,
 });
 

--- a/src/TableBubbleMenu.tsx
+++ b/src/TableBubbleMenu.tsx
@@ -220,6 +220,8 @@ function TableBubbleMenuInner({ editor }: TableBubbleMenuProps) {
 // require the most important re-render (or potentially having the table resize), and
 // that's relatively rarer than typing within or outside a table.
 const TableBubbleMenu = debounceRender(TableBubbleMenuInner, 400, {
+  leading: true,
+  trailing: true,
   maxWait: 750,
 });
 


### PR DESCRIPTION
We primarily care about debouncing for performance when performing many consecutive actions, but it's fine to let the first update render, which should generally make the menus feel quite a bit snappier.
