### PR TITLE
Generalize the styles used for read-only tables

### DIFF
--- a/src/RichTextContent.tsx
+++ b/src/RichTextContent.tsx
@@ -30,18 +30,7 @@ const useStyles = makeStyles({ name: { RichTextContent } })((theme) => {
     },
 
     // Styles applied when the editor is in read-only mode (editable=false)
-    readonly: {
-      "& .ProseMirror": {
-        // When in read-only mode, don't allow users to resize tables, by hiding
-        // the resize handle and cursor
-        "& .column-resize-handle": {
-          display: "none",
-        },
-        "&.resize-cursor": {
-          display: "none",
-        },
-      },
-    },
+    readonly: {},
 
     // Styles applied when the editor is editable (editable=true)
     editable: {},

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -365,6 +365,18 @@ export function getEditorStyles(theme: Theme): StyleRules {
       cursor: "col-resize",
     },
 
+    // When the editor has `editable` set to `false`, the table column resize
+    // tools should be hidden
+    '&[contenteditable="false"]': {
+      "& .column-resize-handle": {
+        display: "none",
+      },
+
+      "&.resize-cursor": {
+        display: "none",
+      },
+    },
+
     // Based on the example styles from https://tiptap.dev/api/extensions/placeholder,
     // this adds the placeholder text at the top
     "& p.is-editor-empty:first-of-type::before": {


### PR DESCRIPTION
This way, the styles are applied anywhere `getEditorStyles` is used "automatically", without needing style overrides via `RichTextContent`'s conditional classes.