### PR TITLE
Don't cancel in-progress jobs for same branch

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,10 +8,6 @@ jobs:
       matrix:
         node-version: [18]
 
-    concurrency:
-      group: ${{ github.ref }}
-      cancel-in-progress: true
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
GitHub Actions allows 20 concurrent jobs as is
https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits, which is probably more than we'll ever use. This avoids the overall build being marked as "failing" (in the README CI badge) when pushing a tag that runs a "redundant" version of the build-test job, and reduces noise from "build failed" emails.