### PR TITLE
Fix collaboration cursor "dot" color

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -301,7 +301,8 @@ export function getEditorStyles(theme: Theme): StyleRules {
 
       "& td, th": {
         minWidth: "1em",
-        border: "1px solid",
+        borderWidth: 1,
+        borderStyle: "solid",
         borderColor:
           theme.palette.mode === "dark"
             ? theme.palette.grey[500]
@@ -413,8 +414,9 @@ export function getEditorStyles(theme: Theme): StyleRules {
         left: -3,
         right: 0,
         top: -2,
+        borderWidth: 3,
+        borderStyle: "solid",
         borderColor: "inherit",
-        border: "3px solid",
       },
 
       // When hovering, show the user's name


### PR DESCRIPTION
The border color wasn't taking effect due to `border: 3px solid` coming *after* it, and so overriding the color (back to its default of "initial"). To avoid the ordering problems altogether, this changes the border CSS to be set via its individual parts rather than using the `border` shorthand partly, and `border-color` separately.
