### PR TITLE
Add error messaging if editor not provided

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,8 +1,17 @@
 import type { Editor } from "@tiptap/react";
 import { createContext, useContext } from "react";
 
-export const RichTextEditorContext = createContext<Editor | null>(null);
+export const RichTextEditorContext = createContext<Editor | null | undefined>(
+  undefined
+);
 
 export function useRichTextEditorContext(): Editor | null {
-  return useContext(RichTextEditorContext);
+  const editor = useContext(RichTextEditorContext);
+  if (editor === undefined) {
+    throw new Error(
+      "Tiptap editor not found in component context. Be sure to use <RichTextEditorProvider editor={editor} />!"
+    );
+  }
+
+  return editor;
 }


### PR DESCRIPTION
This is preferable to quietly returning `null` and just rendering no editor state/content, to help users quickly see and fix problems.