### PR TITLE
Don't show Link and Table bubble menus when editor isn't editable

### DIFF
--- a/src/LinkBubbleMenu/index.tsx
+++ b/src/LinkBubbleMenu/index.tsx
@@ -31,7 +31,7 @@ export default function LinkBubbleMenu({
   const { classes } = useStyles();
   const editor = useRichTextEditorContext();
 
-  if (!editor) {
+  if (!editor?.isEditable) {
     return null;
   }
 

--- a/src/TableBubbleMenu.tsx
+++ b/src/TableBubbleMenu.tsx
@@ -102,7 +102,7 @@ export default function TableBubbleMenu({
     [editor]
   );
 
-  if (!editor) {
+  if (!editor?.isEditable) {
     return null;
   }
 


### PR DESCRIPTION
These menus are exclusively used for editing, so make sure they don't show up in read-only mode.