### PR TITLE
Reduce bubble menu default elevation, and allow for customization of Paper props

### DIFF
--- a/src/ControlledBubbleMenu.tsx
+++ b/src/ControlledBubbleMenu.tsx
@@ -214,7 +214,7 @@ export default function ControlledBubbleMenu({
           }}
         >
           <Paper
-            elevation={10}
+            elevation={7}
             {...PaperProps}
             className={cx(
               controlledBubbleMenuClasses.paper,

--- a/src/ControlledBubbleMenu.tsx
+++ b/src/ControlledBubbleMenu.tsx
@@ -1,4 +1,11 @@
-import { Fade, Paper, Popper, useTheme, type PopperProps } from "@mui/material";
+import {
+  Fade,
+  Paper,
+  Popper,
+  useTheme,
+  type PaperProps,
+  type PopperProps,
+} from "@mui/material";
 import { isNodeSelection, posToDOMRect, type Editor } from "@tiptap/core";
 import { useCallback } from "react";
 import { makeStyles } from "tss-react/mui";
@@ -45,6 +52,11 @@ export type ControlledBubbleMenuProps = {
   className?: string;
   /** Override or extend existing styles. */
   classes?: Partial<ControlledBubbleMenuClasses>;
+  /**
+   * Override the default props for the Paper containing the bubble menu
+   * content.
+   */
+  PaperProps?: Partial<PaperProps>;
 };
 
 const controlledBubbleMenuClasses: ControlledBubbleMenuClasses =
@@ -95,6 +107,7 @@ export default function ControlledBubbleMenu({
     "bottom-end",
   ],
   flipPadding = 8,
+  PaperProps,
 }: ControlledBubbleMenuProps) {
   const { classes, cx } = useStyles(undefined, {
     props: { classes: overrideClasses },
@@ -202,7 +215,12 @@ export default function ControlledBubbleMenu({
         >
           <Paper
             elevation={10}
-            className={cx(controlledBubbleMenuClasses.paper, classes.paper)}
+            {...PaperProps}
+            className={cx(
+              controlledBubbleMenuClasses.paper,
+              classes.paper,
+              PaperProps?.className
+            )}
           >
             {children}
           </Paper>

--- a/src/TableBubbleMenu.tsx
+++ b/src/TableBubbleMenu.tsx
@@ -143,10 +143,6 @@ export default function TableBubbleMenu({
       // we add a top padding equal to what should give us enough room to avoid
       // overlapping the main menu bar.
       flipPadding={{ top: 35, left: 8, right: 8, bottom: -Infinity }}
-      PaperProps={{
-        elevation: 7,
-        ...controlledBubbleMenuProps.PaperProps,
-      }}
       {...controlledBubbleMenuProps}
     >
       {/* We debounce rendering of the controls to improve performance, since

--- a/src/TableBubbleMenu.tsx
+++ b/src/TableBubbleMenu.tsx
@@ -143,6 +143,10 @@ export default function TableBubbleMenu({
       // we add a top padding equal to what should give us enough room to avoid
       // overlapping the main menu bar.
       flipPadding={{ top: 35, left: 8, right: 8, bottom: -Infinity }}
+      PaperProps={{
+        elevation: 7,
+        ...controlledBubbleMenuProps.PaperProps,
+      }}
       {...controlledBubbleMenuProps}
     >
       {/* We debounce rendering of the controls to improve performance, since


### PR DESCRIPTION
Typically, bubble menus are interacted with alongside the content, so with an `elevation={10}` in light mode in MUI, it would tend to cast a relatively large shadow, which could be annoying (e.g. with the table menu) if you're trying to edit the content that's directly next to the menu. This adjusts it down slightly while still maintaining enough elevation to be visually distinct from the editor content.

Now users can also tweak this and other fields when they use the `TableBubbleMenu`/`LinkBubbleMenu`/`ControlledBubbleMenu`.