### PR TITLE
Remove seemingly incorrect/unneeded `"type": "module"` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "bugs": "https://github.com/sjdemartini/mui-tiptap/issues",
   "author": "Steven DeMartini <sjdemartini@users.noreply.github.com>",
   "repository": "github:sjdemartini/mui-tiptap",
-  "type": "module",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
By removing this, the package will default to being a CJS package. Other packages (e.g., tss-react, mui-datatables, MUI, react-pdf) do not specify this either.

From testing installing in a third-party application, this fixes an issue in testing code that imports `mui-tiptap` (at least when using vitest):

```
Error: Cannot find module '/path/node_modules/mui-tiptap/dist/esm/ControlledBubbleMenu' imported from /path/node_modules/mui-tiptap/dist/esm/index.js
```
