### PR TITLE
Lint against more extraneous dependencies being imported

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -69,7 +69,13 @@
       "warn",
       { "argsIgnorePattern": "^_" } // Ignore arguments that start with an underscore
     ],
-    "import/no-extraneous-dependencies": "error",
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": ["./src/demo/**", "./src/**/__tests__/**"],
+        "includeTypes": true
+      }
+    ],
     "import/no-mutable-exports": "error",
     "import/no-unused-modules": "error",
     // Note that no-duplicates prefer-inline doesn't yet handle duplicate type

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
   "dependencies": {
     "encodeurl": "^1.0.2",
     "lodash": "^4.17.21",
-    "tss-react": "^4.8.3"
+    "tss-react": "^4.8.3",
+    "type-fest": "^3.12.0"
   },
   "peerDependencies": {
     "@emotion/react": "^11.4.1",
@@ -191,7 +192,6 @@
     "react-dom": "^18.2.0",
     "react-icons": "^4.8.0",
     "rimraf": "^5.0.0",
-    "type-fest": "^3.12.0",
     "typescript": "^5.1.3",
     "vite": "^4.3.9",
     "vitest": "^0.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   tss-react:
     specifier: ^4.8.3
     version: 4.8.3(@emotion/react@11.11.0)(react@18.2.0)
+  type-fest:
+    specifier: ^3.12.0
+    version: 3.12.0
 
 devDependencies:
   '@emotion/react':
@@ -268,9 +271,6 @@ devDependencies:
   rimraf:
     specifier: ^5.0.0
     version: 5.0.0
-  type-fest:
-    specifier: ^3.12.0
-    version: 3.12.0
   typescript:
     specifier: ^5.1.3
     version: 5.1.3
@@ -5079,7 +5079,7 @@ packages:
   /type-fest@3.12.0:
     resolution: {integrity: sha512-qj9wWsnFvVEMUDbESiilKeXeHL7FwwiFcogfhfyjmvT968RXSvnl23f1JOClTHYItsi7o501C/7qVllscUP3oA==}
     engines: {node: '>=14.16'}
-    dev: true
+    dev: false
 
   /typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}


### PR DESCRIPTION
No devDependencies should be imported in the main project without also appearing in peerDependencies. Otherwise we risk the package breaking when installed for others.

And because we publish our types with our package, even Type imports should need to be included in dependencies or peerDependencies. So `type-fest` should really be listed as a direct dependency (as it is for other major users of type-fest, like yup, snakecase-keys, etc., and as described here
https://github.com/sindresorhus/type-fest/issues/136#issuecomment-714211609).
