### PR TITLE
Avoid flushSync errors in useEffect

### DIFF
--- a/src/RichTextEditor.tsx
+++ b/src/RichTextEditor.tsx
@@ -96,7 +96,10 @@ const RichTextEditor = forwardRef<RichTextEditorRef, RichTextEditorProps>(
       if (!editor || editor.isDestroyed || editor.isEditable === editable) {
         return;
       }
-      editor.setEditable(editable);
+      // We use queueMicrotask to avoid any flushSync console errors as
+      // mentioned here (though setEditable shouldn't trigger them in practice)
+      // https://github.com/ueberdosis/tiptap/issues/3764#issuecomment-1546854730
+      queueMicrotask(() => editor.setEditable(editable));
     }, [editable, editor]);
 
     // Update content if/when it changes
@@ -110,7 +113,15 @@ const RichTextEditor = forwardRef<RichTextEditorRef, RichTextEditorProps>(
       ) {
         return;
       }
-      editor.commands.setContent(editorProps.content);
+      // We use queueMicrotask to avoid any flushSync console errors as
+      // mentioned here
+      // https://github.com/ueberdosis/tiptap/issues/3764#issuecomment-1546854730
+      queueMicrotask(() => {
+        // Validate that editorProps.content isn't undefined again to appease TS
+        if (editorProps.content !== undefined) {
+          editor.commands.setContent(editorProps.content);
+        }
+      });
     }, [editorProps.content, editor]);
 
     useEffect(() => {


### PR DESCRIPTION
https://github.com/ueberdosis/tiptap/issues/3764#issuecomment-1546854730

Otherwise updating `content` of `RichTextEditor` will give the following error (as of the recent Tiptap version bump):

```
Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.
    at RichTextEditor (http://localhost:5173/src/RichTextEditor.tsx?t=1686945132689:21:90)
```