### PR TITLE
Fix bug interacting with and hovering over table columns in read-only mode

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -369,15 +369,21 @@ export function getEditorStyles(theme: Theme): StyleRules {
       cursor: "col-resize",
     },
 
-    // When the editor has `editable` set to `false`, the table column resize
-    // tools should be hidden
+    // When the editor has `editable` set to `false`, we'll prevent the table
+    // column resize tools from showing up or being used
     '&[contenteditable="false"]': {
       "& .column-resize-handle": {
         display: "none",
       },
 
       "&.resize-cursor": {
-        display: "none",
+        cursor: "unset",
+        // To ensure that users cannot resize tables when the editor is supposed
+        // to be read-only, we have to disable pointer events for the editor
+        // whenever the resize-cursor class is added (i.e. when a user hovers
+        // over a column border that would otherwise allow for dragging and
+        // resizing when in editable mode)
+        pointerEvents: "none",
       },
     },
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -352,37 +352,41 @@ export function getEditorStyles(theme: Theme): StyleRules {
       pointerEvents: "none",
     },
 
-    "& .column-resize-handle": {
-      position: "absolute",
-      right: -2,
-      top: -1,
-      bottom: -2,
-      width: 4,
-      // This z-index proved necessary to ensure the handle sits above the background of
-      // any cell (header and non-header)
-      zIndex: Z_INDEXES.TABLE_ELEMENT,
-      backgroundColor: theme.palette.primary.light,
-      pointerEvents: "none",
+    // Only when the editor has `editable` set to `true` should the table column
+    // resize tools should be revealed and be usable
+    '&[contenteditable="true"]': {
+      "& .column-resize-handle": {
+        position: "absolute",
+        right: -2,
+        top: -1,
+        bottom: -2,
+        width: 4,
+        // This z-index proved necessary to ensure the handle sits above the
+        // background of any cell (header and non-header)
+        zIndex: Z_INDEXES.TABLE_ELEMENT,
+        backgroundColor: theme.palette.primary.light,
+        pointerEvents: "none",
+      },
+
+      "&.resize-cursor": {
+        cursor: "col-resize",
+      },
     },
 
-    "&.resize-cursor": {
-      cursor: "col-resize",
-    },
-
-    // When the editor has `editable` set to `false`, we'll prevent the table
-    // column resize tools from showing up or being used
     '&[contenteditable="false"]': {
       "& .column-resize-handle": {
         display: "none",
       },
 
       "&.resize-cursor": {
-        cursor: "unset",
         // To ensure that users cannot resize tables when the editor is supposed
-        // to be read-only, we have to disable pointer events for the editor
-        // whenever the resize-cursor class is added (i.e. when a user hovers
-        // over a column border that would otherwise allow for dragging and
-        // resizing when in editable mode)
+        // to be read-only, we have to disable pointer events for the entire
+        // editor whenever the resize-cursor class is added (i.e. when a user
+        // hovers over a column border that would otherwise allow for dragging
+        // and resizing when in editable mode). This is because the underlying
+        // prosemirror-tables `columnResizing` plugin doesn't know/care about
+        // `editable` state, and so adds the "resize-cursor" class and tries to
+        // listen for events regardless.
         pointerEvents: "none",
       },
     },


### PR DESCRIPTION
There was a mistake in the original approach, since setting `"display: none"` on `&.resize-cursor` would actually be hiding the entire ProseMirror document, as opposed to some cursor element. This didn't appear very obviously in Chrome (though there were times where you could get it to flash slightly when hovering over a column divider), but in Firefox it was much more drastic, where the content would disappear/reappear, causing the page scroll position to rapidly/unexpectedly change any time a user's cursor crossed over a column border.

Also, it was still possible to drag and resize a column, despite it being in read-only mode and not showing a resize cursor, since the editor and the table were still responding to pointer events (and the underlying prosemirror-tables `columnResizing` plugin doesn't know/care about `editable` state). This now turns off pointer events to the entire table if the `"resize-cursor"` class appears, which more thoroughly prevents any column resizing from happening. Fortunately, the table cells themselves are still selectable via the `tableEditing` plugin, so users can highlight vertically/horizontally across table cells even in read-only mode, since `"resize-cursor"` only appears when hovering specifically over the border.
