### PR TITLE
Make "View Link" bubble menu properly show text

### DIFF
--- a/src/LinkBubbleMenu/ViewLinkMenuContent.tsx
+++ b/src/LinkBubbleMenu/ViewLinkMenuContent.tsx
@@ -27,7 +27,7 @@ export default function ViewLinkMenuContent({
 }: Props) {
   const { classes } = useStyles();
   const linkRange = getMarkRange(
-    editor.state.selection.$from,
+    editor.state.selection.$to,
     getMarkType("link", editor.schema)
   );
   const linkText = linkRange


### PR DESCRIPTION
It seems `$from` doesn't typically properly allow us to grab the link range anymore (presumably after a Tiptap version bump), though `$to` does. This switches to `$to` so that the "view link" bubble menu shows the text content and not just the link itself.