### PR TITLE
Allow users to override all props for all menu buttons, and include image button in demo

### DIFF
--- a/src/controls/MenuButtonAddImage.tsx
+++ b/src/controls/MenuButtonAddImage.tsx
@@ -1,12 +1,29 @@
 import { AddPhotoAlternate } from "@mui/icons-material";
-import type { ToggleButtonProps } from "@mui/material";
+import type { SetRequired } from "type-fest";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
-export type MenuButtonAddImageProps = Partial<MenuButtonProps> & {
-  onClick: NonNullable<ToggleButtonProps["onClick"]>;
-};
+/**
+ * You must provide your own `onClick` handler.
+ */
+export type MenuButtonAddImageProps = SetRequired<
+  Partial<MenuButtonProps>,
+  "onClick"
+>;
 
+/**
+ * Render a button for adding an image to the editor content. You must provide
+ * your own `onClick` prop in order to specify *how* the image is added. For
+ * instance, you might open a popup for the user to provide an image URL, or you
+ * might trigger a file upload via file input dialog.
+ *
+ * Once the image URL is ready (after the user has filled it out or after an
+ * upload has completed), you can typically use something like:
+ *
+ *   editor.chain().focus().setImage({ src: url }).run()
+ *
+ * See Tiptap's example here https://tiptap.dev/api/nodes/image.
+ */
 export default function MenuButtonAddImage({
   ...props
 }: MenuButtonAddImageProps) {
@@ -14,7 +31,7 @@ export default function MenuButtonAddImage({
 
   return (
     <MenuButton
-      tooltipLabel="Add an image"
+      tooltipLabel="Insert image"
       IconComponent={AddPhotoAlternate}
       disabled={
         !editor?.isEditable ||

--- a/src/controls/MenuButtonAddImage.tsx
+++ b/src/controls/MenuButtonAddImage.tsx
@@ -1,21 +1,20 @@
 import { AddPhotoAlternate } from "@mui/icons-material";
 import type { ToggleButtonProps } from "@mui/material";
 import { useRichTextEditorContext } from "../context";
-import MenuButton from "./MenuButton";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
-export type MenuButtonAddImageProps = {
-  tooltipLabel?: string;
+export type MenuButtonAddImageProps = Partial<MenuButtonProps> & {
   onClick: NonNullable<ToggleButtonProps["onClick"]>;
 };
 
 export default function MenuButtonAddImage({
-  tooltipLabel = "Add an image",
-  onClick,
+  ...props
 }: MenuButtonAddImageProps) {
   const editor = useRichTextEditorContext();
+
   return (
     <MenuButton
-      tooltipLabel={tooltipLabel}
+      tooltipLabel="Add an image"
       IconComponent={AddPhotoAlternate}
       disabled={
         !editor?.isEditable ||
@@ -23,7 +22,7 @@ export default function MenuButtonAddImage({
         // added to the editor currently)
         !editor.can().setImage({ src: "http://example.com" })
       }
-      onClick={onClick}
+      {...props}
     />
   );
 }

--- a/src/controls/MenuButtonAddTable.tsx
+++ b/src/controls/MenuButtonAddTable.tsx
@@ -1,8 +1,10 @@
 import { BiTable } from "react-icons/bi";
 import { useRichTextEditorContext } from "../context";
-import MenuButton from "./MenuButton";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
-export default function MenuButtonAddTable() {
+export type MenuButtonAddTableProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonAddTable(props: MenuButtonAddTableProps) {
   const editor = useRichTextEditorContext();
   return (
     <MenuButton
@@ -16,6 +18,7 @@ export default function MenuButtonAddTable() {
           .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
           .run()
       }
+      {...props}
     />
   );
 }

--- a/src/controls/MenuButtonBlockquote.tsx
+++ b/src/controls/MenuButtonBlockquote.tsx
@@ -1,9 +1,11 @@
 /// <reference types="@tiptap/extension-blockquote" />
 import { FormatQuote } from "@mui/icons-material";
 import { useRichTextEditorContext } from "../context";
-import MenuButton from "./MenuButton";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
-export default function MenuButtonBlockquote() {
+export type MenuButtonBlockquoteProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonBlockquote(props: MenuButtonBlockquoteProps) {
   const editor = useRichTextEditorContext();
   return (
     <MenuButton
@@ -13,6 +15,7 @@ export default function MenuButtonBlockquote() {
       selected={editor?.isActive("blockquote") ?? false}
       disabled={!editor?.isEditable || !editor.can().toggleBlockquote()}
       onClick={() => editor?.chain().focus().toggleBlockquote().run()}
+      {...props}
     />
   );
 }

--- a/src/controls/MenuButtonBold.tsx
+++ b/src/controls/MenuButtonBold.tsx
@@ -1,9 +1,11 @@
 /// <reference types="@tiptap/extension-bold" />
 import { FormatBold } from "@mui/icons-material";
 import { useRichTextEditorContext } from "../context";
-import MenuButton from "./MenuButton";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
-export default function MenuButtonBold() {
+export type MenuButtonBoldProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonBold(props: MenuButtonBoldProps) {
   const editor = useRichTextEditorContext();
   return (
     <MenuButton
@@ -13,6 +15,7 @@ export default function MenuButtonBold() {
       selected={editor?.isActive("bold") ?? false}
       disabled={!editor?.isEditable || !editor.can().toggleBold()}
       onClick={() => editor?.chain().focus().toggleBold().run()}
+      {...props}
     />
   );
 }

--- a/src/controls/MenuButtonBulletedList.tsx
+++ b/src/controls/MenuButtonBulletedList.tsx
@@ -1,9 +1,13 @@
 /// <reference types="@tiptap/extension-bullet-list" />
 import { FormatListBulleted } from "@mui/icons-material";
 import { useRichTextEditorContext } from "../context";
-import MenuButton from "./MenuButton";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
-export default function MenuButtonBulletedList() {
+export type MenuButtonBulletedListProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonBulletedList(
+  props: MenuButtonBulletedListProps
+) {
   const editor = useRichTextEditorContext();
   return (
     <MenuButton
@@ -13,6 +17,7 @@ export default function MenuButtonBulletedList() {
       selected={editor?.isActive("bulletList") ?? false}
       disabled={!editor?.isEditable || !editor.can().toggleBulletList()}
       onClick={() => editor?.chain().focus().toggleBulletList().run()}
+      {...props}
     />
   );
 }

--- a/src/controls/MenuButtonCode.tsx
+++ b/src/controls/MenuButtonCode.tsx
@@ -1,9 +1,11 @@
 /// <reference types="@tiptap/extension-code" />
 import { Code } from "@mui/icons-material";
 import { useRichTextEditorContext } from "../context";
-import MenuButton from "./MenuButton";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
-export default function MenuButtonCode() {
+export type MenuButtonCodeProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonCode(props: MenuButtonCodeProps) {
   const editor = useRichTextEditorContext();
   return (
     <MenuButton
@@ -13,6 +15,7 @@ export default function MenuButtonCode() {
       selected={editor?.isActive("code") ?? false}
       disabled={!editor?.isEditable || !editor.can().toggleCode()}
       onClick={() => editor?.chain().focus().toggleCode().run()}
+      {...props}
     />
   );
 }

--- a/src/controls/MenuButtonCodeBlock.tsx
+++ b/src/controls/MenuButtonCodeBlock.tsx
@@ -1,9 +1,11 @@
 /// <reference types="@tiptap/extension-code-block" />
 import { BiCodeBlock } from "react-icons/bi";
 import { useRichTextEditorContext } from "../context";
-import MenuButton from "./MenuButton";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
-export default function MenuButtonCodeBlock() {
+export type MenuButtonCodeBlockProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonCodeBlock(props: MenuButtonCodeBlockProps) {
   const editor = useRichTextEditorContext();
   return (
     <MenuButton
@@ -13,6 +15,7 @@ export default function MenuButtonCodeBlock() {
       selected={editor?.isActive("codeBlock") ?? false}
       disabled={!editor?.isEditable || !editor.can().toggleCodeBlock()}
       onClick={() => editor?.chain().focus().toggleCodeBlock().run()}
+      {...props}
     />
   );
 }

--- a/src/controls/MenuButtonEditLink.tsx
+++ b/src/controls/MenuButtonEditLink.tsx
@@ -1,8 +1,10 @@
 import { Link } from "@mui/icons-material";
 import { useRichTextEditorContext } from "../context";
-import MenuButton from "./MenuButton";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
-export default function MenuButtonEditLink() {
+export type MenuButtonEditLinkProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonEditLink(props: MenuButtonEditLinkProps) {
   const editor = useRichTextEditorContext();
   return (
     <MenuButton
@@ -12,6 +14,7 @@ export default function MenuButtonEditLink() {
       selected={editor?.isActive("link")}
       disabled={!editor?.isEditable}
       onClick={editor?.commands.openLinkBubbleMenu}
+      {...props}
     />
   );
 }

--- a/src/controls/MenuButtonIndent.tsx
+++ b/src/controls/MenuButtonIndent.tsx
@@ -1,8 +1,10 @@
 import { FormatIndentIncrease } from "@mui/icons-material";
 import { useRichTextEditorContext } from "../context";
-import MenuButton from "./MenuButton";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
-export default function MenuButtonIndent() {
+export type MenuButtonIndentProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonIndent(props: MenuButtonIndentProps) {
   const editor = useRichTextEditorContext();
   return (
     <MenuButton
@@ -11,6 +13,7 @@ export default function MenuButtonIndent() {
       IconComponent={FormatIndentIncrease}
       disabled={!editor?.isEditable || !editor.can().sinkListItem("listItem")}
       onClick={() => editor?.chain().focus().sinkListItem("listItem").run()}
+      {...props}
     />
   );
 }

--- a/src/controls/MenuButtonItalic.tsx
+++ b/src/controls/MenuButtonItalic.tsx
@@ -1,9 +1,11 @@
 /// <reference types="@tiptap/extension-italic" />
 import { FormatItalic } from "@mui/icons-material";
 import { useRichTextEditorContext } from "../context";
-import MenuButton from "./MenuButton";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
-export default function MenuButtonItalic() {
+export type MenuButtonItalicProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonItalic(props: MenuButtonItalicProps) {
   const editor = useRichTextEditorContext();
   return (
     <MenuButton
@@ -13,6 +15,7 @@ export default function MenuButtonItalic() {
       selected={editor?.isActive("italic") ?? false}
       disabled={!editor?.isEditable || !editor.can().toggleItalic()}
       onClick={() => editor?.chain().focus().toggleItalic().run()}
+      {...props}
     />
   );
 }

--- a/src/controls/MenuButtonOrderedList.tsx
+++ b/src/controls/MenuButtonOrderedList.tsx
@@ -1,9 +1,13 @@
 /// <reference types="@tiptap/extension-ordered-list" />
 import { FormatListNumbered } from "@mui/icons-material";
 import { useRichTextEditorContext } from "../context";
-import MenuButton from "./MenuButton";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
-export default function MenuButtonOrderedList() {
+export type MenuButtonOrderedListProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonOrderedList(
+  props: MenuButtonOrderedListProps
+) {
   const editor = useRichTextEditorContext();
   return (
     <MenuButton
@@ -13,6 +17,7 @@ export default function MenuButtonOrderedList() {
       selected={editor?.isActive("orderedList") ?? false}
       disabled={!editor?.isEditable || !editor.can().toggleOrderedList()}
       onClick={() => editor?.chain().focus().toggleOrderedList().run()}
+      {...props}
     />
   );
 }

--- a/src/controls/MenuButtonRemoveFormatting.tsx
+++ b/src/controls/MenuButtonRemoveFormatting.tsx
@@ -1,8 +1,12 @@
 import { FormatClear } from "@mui/icons-material";
 import { useRichTextEditorContext } from "../context";
-import MenuButton from "./MenuButton";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
-export default function MenuButtonRemoveFormatting() {
+export type MenuButtonRemoveFormattingProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonRemoveFormatting(
+  props: MenuButtonRemoveFormattingProps
+) {
   const editor = useRichTextEditorContext();
   return (
     <MenuButton
@@ -10,6 +14,7 @@ export default function MenuButtonRemoveFormatting() {
       IconComponent={FormatClear}
       disabled={!editor?.isEditable || !editor.can().unsetAllMarks()}
       onClick={() => editor?.chain().focus().unsetAllMarks().run()}
+      {...props}
     />
   );
 }

--- a/src/controls/MenuButtonStrikethrough.tsx
+++ b/src/controls/MenuButtonStrikethrough.tsx
@@ -1,9 +1,13 @@
 /// <reference types="@tiptap/extension-strike" />
 import { StrikethroughS } from "@mui/icons-material";
 import { useRichTextEditorContext } from "../context";
-import MenuButton from "./MenuButton";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
-export default function MenuButtonStrikethrough() {
+export type MenuButtonStrikethroughProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonStrikethrough(
+  props: MenuButtonStrikethroughProps
+) {
   const editor = useRichTextEditorContext();
   return (
     <MenuButton
@@ -13,6 +17,7 @@ export default function MenuButtonStrikethrough() {
       selected={editor?.isActive("strike") ?? false}
       disabled={!editor?.isEditable || !editor.can().toggleStrike()}
       onClick={() => editor?.chain().focus().toggleStrike().run()}
+      {...props}
     />
   );
 }

--- a/src/controls/MenuButtonSubscript.tsx
+++ b/src/controls/MenuButtonSubscript.tsx
@@ -1,9 +1,11 @@
 /// <reference types="@tiptap/extension-subscript" />
 import { Subscript } from "@mui/icons-material";
 import { useRichTextEditorContext } from "../context";
-import MenuButton from "./MenuButton";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
-export default function MenuButtonSubscript() {
+export type MenuButtonSubscriptProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonSubscript(props: MenuButtonSubscriptProps) {
   const editor = useRichTextEditorContext();
   return (
     <MenuButton
@@ -13,6 +15,7 @@ export default function MenuButtonSubscript() {
       selected={editor?.isActive("subscript") ?? false}
       disabled={!editor?.isEditable || !editor.can().toggleSubscript()}
       onClick={() => editor?.chain().focus().toggleSubscript().run()}
+      {...props}
     />
   );
 }

--- a/src/controls/MenuButtonSuperscript.tsx
+++ b/src/controls/MenuButtonSuperscript.tsx
@@ -1,9 +1,13 @@
 /// <reference types="@tiptap/extension-superscript" />
 import { Superscript } from "@mui/icons-material";
 import { useRichTextEditorContext } from "../context";
-import MenuButton from "./MenuButton";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
-export default function MenuButtonSuperscript() {
+export type MenuButtonSuperscriptProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonSuperscript(
+  props: MenuButtonSuperscriptProps
+) {
   const editor = useRichTextEditorContext();
   return (
     <MenuButton
@@ -13,6 +17,7 @@ export default function MenuButtonSuperscript() {
       selected={editor?.isActive("superscript") ?? false}
       disabled={!editor?.isEditable || !editor.can().toggleSuperscript()}
       onClick={() => editor?.chain().focus().toggleSuperscript().run()}
+      {...props}
     />
   );
 }

--- a/src/controls/MenuButtonTaskList.tsx
+++ b/src/controls/MenuButtonTaskList.tsx
@@ -1,9 +1,11 @@
 /// <reference types="@tiptap/extension-task-list" />
 import { Checklist } from "@mui/icons-material";
 import { useRichTextEditorContext } from "../context";
-import MenuButton from "./MenuButton";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
-export default function MenuButtonTaskList() {
+export type MenuButtonTaskListProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonTaskList(props: MenuButtonTaskListProps) {
   const editor = useRichTextEditorContext();
   return (
     <MenuButton
@@ -13,6 +15,7 @@ export default function MenuButtonTaskList() {
       selected={editor?.isActive("taskList") ?? false}
       disabled={!editor?.isEditable || !editor.can().toggleTaskList()}
       onClick={() => editor?.chain().focus().toggleTaskList().run()}
+      {...props}
     />
   );
 }

--- a/src/controls/MenuButtonUnindent.tsx
+++ b/src/controls/MenuButtonUnindent.tsx
@@ -1,8 +1,10 @@
 import { FormatIndentDecrease } from "@mui/icons-material";
 import { useRichTextEditorContext } from "../context";
-import MenuButton from "./MenuButton";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
-export default function MenuButtonUnindent() {
+export type MenuButtonUnindentProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonUnindent(props: MenuButtonUnindentProps) {
   const editor = useRichTextEditorContext();
   return (
     <MenuButton
@@ -11,6 +13,7 @@ export default function MenuButtonUnindent() {
       IconComponent={FormatIndentDecrease}
       disabled={!editor?.isEditable || !editor.can().liftListItem("listItem")}
       onClick={() => editor?.chain().focus().liftListItem("listItem").run()}
+      {...props}
     />
   );
 }

--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -3,26 +3,74 @@ export {
   default as MenuButtonAddImage,
   type MenuButtonAddImageProps,
 } from "./MenuButtonAddImage";
-export { default as MenuButtonAddTable } from "./MenuButtonAddTable";
-export { default as MenuButtonBlockquote } from "./MenuButtonBlockquote";
-export { default as MenuButtonBold } from "./MenuButtonBold";
-export { default as MenuButtonBulletedList } from "./MenuButtonBulletedList";
-export { default as MenuButtonCode } from "./MenuButtonCode";
-export { default as MenuButtonCodeBlock } from "./MenuButtonCodeBlock";
-export { default as MenuButtonEditLink } from "./MenuButtonEditLink";
-export { default as MenuButtonIndent } from "./MenuButtonIndent";
-export { default as MenuButtonItalic } from "./MenuButtonItalic";
-export { default as MenuButtonOrderedList } from "./MenuButtonOrderedList";
-export { default as MenuButtonRemoveFormatting } from "./MenuButtonRemoveFormatting";
-export { default as MenuButtonStrikethrough } from "./MenuButtonStrikethrough";
-export { default as MenuButtonSubscript } from "./MenuButtonSubscript";
-export { default as MenuButtonSuperscript } from "./MenuButtonSuperscript";
-export { default as MenuButtonTaskList } from "./MenuButtonTaskList";
+export {
+  default as MenuButtonAddTable,
+  type MenuButtonAddTableProps,
+} from "./MenuButtonAddTable";
+export {
+  default as MenuButtonBlockquote,
+  type MenuButtonBlockquoteProps,
+} from "./MenuButtonBlockquote";
+export {
+  default as MenuButtonBold,
+  type MenuButtonBoldProps,
+} from "./MenuButtonBold";
+export {
+  default as MenuButtonBulletedList,
+  type MenuButtonBulletedListProps,
+} from "./MenuButtonBulletedList";
+export {
+  default as MenuButtonCode,
+  type MenuButtonCodeProps,
+} from "./MenuButtonCode";
+export {
+  default as MenuButtonCodeBlock,
+  type MenuButtonCodeBlockProps,
+} from "./MenuButtonCodeBlock";
+export {
+  default as MenuButtonEditLink,
+  type MenuButtonEditLinkProps,
+} from "./MenuButtonEditLink";
+export {
+  default as MenuButtonIndent,
+  type MenuButtonIndentProps,
+} from "./MenuButtonIndent";
+export {
+  default as MenuButtonItalic,
+  type MenuButtonItalicProps,
+} from "./MenuButtonItalic";
+export {
+  default as MenuButtonOrderedList,
+  type MenuButtonOrderedListProps,
+} from "./MenuButtonOrderedList";
+export {
+  default as MenuButtonRemoveFormatting,
+  type MenuButtonRemoveFormattingProps,
+} from "./MenuButtonRemoveFormatting";
+export {
+  default as MenuButtonStrikethrough,
+  type MenuButtonStrikethroughProps,
+} from "./MenuButtonStrikethrough";
+export {
+  default as MenuButtonSubscript,
+  type MenuButtonSubscriptProps,
+} from "./MenuButtonSubscript";
+export {
+  default as MenuButtonSuperscript,
+  type MenuButtonSuperscriptProps,
+} from "./MenuButtonSuperscript";
+export {
+  default as MenuButtonTaskList,
+  type MenuButtonTaskListProps,
+} from "./MenuButtonTaskList";
 export {
   default as MenuButtonTooltip,
   type MenuButtonTooltipProps,
 } from "./MenuButtonTooltip";
-export { default as MenuButtonUnindent } from "./MenuButtonUnindent";
+export {
+  default as MenuButtonUnindent,
+  type MenuButtonUnindentProps,
+} from "./MenuButtonUnindent";
 export {
   default as MenuControlsContainer,
   type MenuControlsContainerProps,

--- a/src/demo/EditorMenuControls.tsx
+++ b/src/demo/EditorMenuControls.tsx
@@ -1,4 +1,6 @@
 import MenuDivider from "../MenuDivider";
+import { useRichTextEditorContext } from "../context";
+import MenuButtonAddImage from "../controls/MenuButtonAddImage";
 import MenuButtonAddTable from "../controls/MenuButtonAddTable";
 import MenuButtonBlockquote from "../controls/MenuButtonBlockquote";
 import MenuButtonBold from "../controls/MenuButtonBold";
@@ -20,6 +22,7 @@ import MenuHeadingSelect from "../controls/MenuHeadingSelect";
 import { isTouchDevice } from "../utils/platform";
 
 export default function EditorMenuControls() {
+  const editor = useRichTextEditorContext();
   return (
     <MenuControlsContainer>
       <MenuHeadingSelect />
@@ -67,6 +70,18 @@ export default function EditorMenuControls() {
       <MenuButtonCode />
 
       <MenuButtonCodeBlock />
+
+      <MenuDivider />
+
+      <MenuButtonAddImage
+        onClick={() => {
+          const url = window.prompt("Image URL");
+
+          if (url) {
+            editor?.chain().focus().setImage({ src: url }).run();
+          }
+        }}
+      />
 
       <MenuDivider />
 


### PR DESCRIPTION
As mentioned in https://github.com/sjdemartini/mui-tiptap/issues/52#issuecomment-1595936811

This also now includes the `MenuButtonAddImage` in the demo in local dev, with a `window.prompt` to get a URL from the user:

### Part 1
<img width="241" alt="image" src="https://github.com/sjdemartini/mui-tiptap/assets/1647130/17df1a5d-4d79-451f-af53-ba2f1b3ec403">

### Part 2
<img width="898" alt="image" src="https://github.com/sjdemartini/mui-tiptap/assets/1647130/992b8590-c365-4adf-9ca4-8776b7837c45">

### Part 3
<img width="635" alt="image" src="https://github.com/sjdemartini/mui-tiptap/assets/1647130/adfeecc8-2f44-4051-b38d-26f4a427bf38">
