### PR TITLE
Change CI audit-level check to "high"

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,7 +20,7 @@ jobs:
       - run: pnpm install
 
       - name: Dependencies audit
-        run: pnpm audit --audit-level=moderate
+        run: pnpm audit --audit-level=high
 
       - name: Check for duplicate dependencies
         run: pnpm dedupe --check


### PR DESCRIPTION
Several underlying packages rely on `semver`, and it's failing `pnpm audit` currently:
https://github.com/sjdemartini/mui-tiptap/actions/runs/5351723011/jobs/9705882749

Per this advisory: https://github.com/advisories/GHSA-c2qf-rxjj-qqgw

But that's of very low concern for us, so just going to change CI to only report on `high` severity.
