### PR TITLE
Change ControlledBubbleMenu container behavior, and allow overrides

### DIFF
--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: false
@@ -121,8 +121,7 @@ dependencies:
     version: 2.0.3(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3)(react-dom@18.2.0)(react@18.2.0)
   mui-tiptap:
     specifier: file:../
-    version: >-
-      file:..(@emotion/react@11.11.0)(@mui/icons-material@5.11.16)(@mui/material@5.12.3)(@tiptap/core@2.0.3)(@tiptap/extension-blockquote@2.0.3)(@tiptap/extension-bold@2.0.3)(@tiptap/extension-bullet-list@2.0.3)(@tiptap/extension-code-block@2.0.3)(@tiptap/extension-code@2.0.3)(@tiptap/extension-document@2.0.3)(@tiptap/extension-dropcursor@2.0.3)(@tiptap/extension-gapcursor@2.0.3)(@tiptap/extension-hard-break@2.0.3)(@tiptap/extension-heading@2.0.3)(@tiptap/extension-history@2.0.3)(@tiptap/extension-image@2.0.3)(@tiptap/extension-italic@2.0.3)(@tiptap/extension-link@2.0.3)(@tiptap/extension-list-item@2.0.3)(@tiptap/extension-ordered-list@2.0.3)(@tiptap/extension-paragraph@2.0.3)(@tiptap/extension-placeholder@2.0.3)(@tiptap/extension-strike@2.0.3)(@tiptap/extension-subscript@2.0.3)(@tiptap/extension-superscript@2.0.3)(@tiptap/extension-table-cell@2.0.3)(@tiptap/extension-table-header@2.0.3)(@tiptap/extension-table-row@2.0.3)(@tiptap/extension-table@2.0.3)(@tiptap/extension-task-item@2.0.3)(@tiptap/extension-task-list@2.0.3)(@tiptap/extension-text@2.0.3)(@tiptap/pm@2.0.3)(@tiptap/react@2.0.3)(react-dom@18.2.0)(react-icons@4.3.1)(react@18.2.0)
+    version: file:..(@emotion/react@11.11.0)(@mui/icons-material@5.11.16)(@mui/material@5.12.3)(@tiptap/core@2.0.3)(@tiptap/extension-heading@2.0.3)(@tiptap/extension-image@2.0.3)(@tiptap/extension-link@2.0.3)(@tiptap/extension-table@2.0.3)(@tiptap/pm@2.0.3)(@tiptap/react@2.0.3)(react-dom@18.2.0)(react-icons@4.3.1)(react@18.2.0)
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -2318,11 +2317,11 @@ packages:
     engines: {node: '>= 6'}
     dev: false
 
-  ? file:..(@emotion/react@11.11.0)(@mui/icons-material@5.11.16)(@mui/material@5.12.3)(@tiptap/core@2.0.3)(@tiptap/extension-blockquote@2.0.3)(@tiptap/extension-bold@2.0.3)(@tiptap/extension-bullet-list@2.0.3)(@tiptap/extension-code-block@2.0.3)(@tiptap/extension-code@2.0.3)(@tiptap/extension-document@2.0.3)(@tiptap/extension-dropcursor@2.0.3)(@tiptap/extension-gapcursor@2.0.3)(@tiptap/extension-hard-break@2.0.3)(@tiptap/extension-heading@2.0.3)(@tiptap/extension-history@2.0.3)(@tiptap/extension-image@2.0.3)(@tiptap/extension-italic@2.0.3)(@tiptap/extension-link@2.0.3)(@tiptap/extension-list-item@2.0.3)(@tiptap/extension-ordered-list@2.0.3)(@tiptap/extension-paragraph@2.0.3)(@tiptap/extension-placeholder@2.0.3)(@tiptap/extension-strike@2.0.3)(@tiptap/extension-subscript@2.0.3)(@tiptap/extension-superscript@2.0.3)(@tiptap/extension-table-cell@2.0.3)(@tiptap/extension-table-header@2.0.3)(@tiptap/extension-table-row@2.0.3)(@tiptap/extension-table@2.0.3)(@tiptap/extension-task-item@2.0.3)(@tiptap/extension-task-list@2.0.3)(@tiptap/extension-text@2.0.3)(@tiptap/pm@2.0.3)(@tiptap/react@2.0.3)(react-dom@18.2.0)(react-icons@4.3.1)(react@18.2.0)
-  : resolution: {directory: .., type: directory}
+  file:..(@emotion/react@11.11.0)(@mui/icons-material@5.11.16)(@mui/material@5.12.3)(@tiptap/core@2.0.3)(@tiptap/extension-heading@2.0.3)(@tiptap/extension-image@2.0.3)(@tiptap/extension-link@2.0.3)(@tiptap/extension-table@2.0.3)(@tiptap/pm@2.0.3)(@tiptap/react@2.0.3)(react-dom@18.2.0)(react-icons@4.3.1)(react@18.2.0):
+    resolution: {directory: .., type: directory}
     id: file:..
     name: mui-tiptap
-    version: 1.0.0-alpha.11
+    version: 1.0.0-beta.3
     engines: {pnpm: '>=8'}
     requiresBuild: true
     peerDependencies:
@@ -2330,34 +2329,10 @@ packages:
       '@mui/icons-material': ^5.0.0
       '@mui/material': ^5.0.1
       '@tiptap/core': ^2.0.0-beta.210
-      '@tiptap/extension-blockquote': ^2.0.0-beta.210
-      '@tiptap/extension-bold': ^2.0.0-beta.210
-      '@tiptap/extension-bullet-list': ^2.0.0-beta.210
-      '@tiptap/extension-code': ^2.0.0-beta.210
-      '@tiptap/extension-code-block': ^2.0.0-beta.210
-      '@tiptap/extension-document': ^2.0.0-beta.210
-      '@tiptap/extension-dropcursor': ^2.0.0-beta.210
-      '@tiptap/extension-gapcursor': ^2.0.0-beta.210
-      '@tiptap/extension-hard-break': ^2.0.0-beta.210
       '@tiptap/extension-heading': ^2.0.0-beta.210
-      '@tiptap/extension-history': ^2.0.0-beta.210
       '@tiptap/extension-image': ^2.0.0-beta.210
-      '@tiptap/extension-italic': ^2.0.0-beta.210
       '@tiptap/extension-link': ^2.0.0-beta.210
-      '@tiptap/extension-list-item': ^2.0.0-beta.210
-      '@tiptap/extension-ordered-list': ^2.0.0-beta.210
-      '@tiptap/extension-paragraph': ^2.0.0-beta.210
-      '@tiptap/extension-placeholder': ^2.0.0-beta.210
-      '@tiptap/extension-strike': ^2.0.0-beta.210
-      '@tiptap/extension-subscript': ^2.0.0-beta.210
-      '@tiptap/extension-superscript': ^2.0.0-beta.210
       '@tiptap/extension-table': ^2.0.0-beta.210
-      '@tiptap/extension-table-cell': ^2.0.0-beta.210
-      '@tiptap/extension-table-header': ^2.0.0-beta.210
-      '@tiptap/extension-table-row': ^2.0.0-beta.210
-      '@tiptap/extension-task-item': ^2.0.0-beta.210
-      '@tiptap/extension-task-list': ^2.0.0-beta.210
-      '@tiptap/extension-text': ^2.0.0-beta.210
       '@tiptap/pm': ^2.0.0-beta.210
       '@tiptap/react': ^2.0.0-beta.210
       react: ^16.8.0 || ^17.0.2 || ^18.0.0
@@ -2368,34 +2343,10 @@ packages:
       '@mui/icons-material': 5.11.16(@mui/material@5.12.3)(@types/react@18.0.28)(react@18.2.0)
       '@mui/material': 5.12.3(@emotion/react@11.11.0)(@emotion/styled@11.11.0)(@types/react@18.0.28)(react-dom@18.2.0)(react@18.2.0)
       '@tiptap/core': 2.0.3(@tiptap/pm@2.0.3)
-      '@tiptap/extension-blockquote': 2.0.3(@tiptap/core@2.0.3)
-      '@tiptap/extension-bold': 2.0.3(@tiptap/core@2.0.3)
-      '@tiptap/extension-bullet-list': 2.0.3(@tiptap/core@2.0.3)
-      '@tiptap/extension-code': 2.0.3(@tiptap/core@2.0.3)
-      '@tiptap/extension-code-block': 2.0.3(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3)
-      '@tiptap/extension-document': 2.0.3(@tiptap/core@2.0.3)
-      '@tiptap/extension-dropcursor': 2.0.3(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3)
-      '@tiptap/extension-gapcursor': 2.0.3(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3)
-      '@tiptap/extension-hard-break': 2.0.3(@tiptap/core@2.0.3)
       '@tiptap/extension-heading': 2.0.3(@tiptap/core@2.0.3)
-      '@tiptap/extension-history': 2.0.3(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3)
       '@tiptap/extension-image': 2.0.3(@tiptap/core@2.0.3)
-      '@tiptap/extension-italic': 2.0.3(@tiptap/core@2.0.3)
       '@tiptap/extension-link': 2.0.3(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3)
-      '@tiptap/extension-list-item': 2.0.3(@tiptap/core@2.0.3)
-      '@tiptap/extension-ordered-list': 2.0.3(@tiptap/core@2.0.3)
-      '@tiptap/extension-paragraph': 2.0.3(@tiptap/core@2.0.3)
-      '@tiptap/extension-placeholder': 2.0.3(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3)
-      '@tiptap/extension-strike': 2.0.3(@tiptap/core@2.0.3)
-      '@tiptap/extension-subscript': 2.0.3(@tiptap/core@2.0.3)
-      '@tiptap/extension-superscript': 2.0.3(@tiptap/core@2.0.3)
       '@tiptap/extension-table': 2.0.3(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3)
-      '@tiptap/extension-table-cell': 2.0.3(@tiptap/core@2.0.3)
-      '@tiptap/extension-table-header': 2.0.3(@tiptap/core@2.0.3)
-      '@tiptap/extension-table-row': 2.0.3(@tiptap/core@2.0.3)
-      '@tiptap/extension-task-item': 2.0.3(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3)
-      '@tiptap/extension-task-list': 2.0.3(@tiptap/core@2.0.3)
-      '@tiptap/extension-text': 2.0.3(@tiptap/core@2.0.3)
       '@tiptap/pm': 2.0.3(@tiptap/core@2.0.3)
       '@tiptap/react': 2.0.3(@tiptap/core@2.0.3)(@tiptap/pm@2.0.3)(react-dom@18.2.0)(react@18.2.0)
       encodeurl: 1.0.2

--- a/src/ControlledBubbleMenu.tsx
+++ b/src/ControlledBubbleMenu.tsx
@@ -25,14 +25,21 @@ export type ControlledBubbleMenuProps = {
    */
   anchorEl?: PopperProps["anchorEl"];
   /**
-   * To override the HTML element container into which the bubble menu Popper
-   * portal children (DOM content) are appended. By default, uses the HTML
-   * element where the editor is rendered/bound, so the Popper DOM node is a
-   * sibling of the ProseMirror editor node. That default helps ensure that if,
-   * for instance, the editor appears within a modal, this bubble menu still
-   * appears on top of *that*.
+   * To override the HTML element into which the bubble menu Popper portal
+   * children (DOM content) are appended. Uses MUI's Popper default if not
+   * provided (the body of the top-level document object).
+   *
+   * Can be useful to override with a reference to a modal/dialog's element
+   * (like the `ref` of a MUI <Dialog />), for instance, so that this bubble
+   * menu can still appear on top of that, without needing to use messy z-index
+   * overrides.
    */
   container?: PopperProps["container"];
+  /**
+   * If true, the `children` will be under the DOM hierarchy of the parent
+   * component of the ControlledBubbleMenu.
+   */
+  disablePortal?: PopperProps["disablePortal"];
   /**
    * The placement to use for this bubble menu. By default "top". See
    * https://popper.js.org/docs/v2/constructors/#options (and
@@ -108,6 +115,7 @@ export default function ControlledBubbleMenu({
   children,
   anchorEl,
   container,
+  disablePortal,
   placement = "top",
   fallbackPlacements = [
     "bottom",
@@ -196,15 +204,8 @@ export default function ControlledBubbleMenu({
       ]}
       anchorEl={anchorEl ?? defaultAnchorEl}
       className={cx(controlledBubbleMenuClasses.root, classes.root, className)}
-      // Put the portal children within the same DOM context as the editor. This
-      // helps ensure that if, for instance, the editor appears within a modal,
-      // this bubble menu appears on top of *that*. (We can't merely set a
-      // z-index, since we don't want all bubble menus to appear on top of all
-      // modals and other high z-index elements; we just want bubble menus from
-      // editors within modals to appear on top of their modals.)
-      container={
-        typeof container === "undefined" ? editor.options.element : container
-      }
+      container={container}
+      disablePortal={disablePortal}
       transition
     >
       {({ TransitionProps }) => (

--- a/src/ControlledBubbleMenu.tsx
+++ b/src/ControlledBubbleMenu.tsx
@@ -20,10 +20,19 @@ export type ControlledBubbleMenuProps = {
   open: boolean;
   children: React.ReactNode;
   /**
-   * To override the anchor element to which the bubble menu is positioned, if desired.
+   * To override the anchor element to which the bubble menu is positioned.
    * By default, uses the current cursor position and selection.
    */
   anchorEl?: PopperProps["anchorEl"];
+  /**
+   * To override the HTML element container into which the bubble menu Popper
+   * portal children (DOM content) are appended. By default, uses the HTML
+   * element where the editor is rendered/bound, so the Popper DOM node is a
+   * sibling of the ProseMirror editor node. That default helps ensure that if,
+   * for instance, the editor appears within a modal, this bubble menu still
+   * appears on top of *that*.
+   */
+  container?: PopperProps["container"];
   /**
    * The placement to use for this bubble menu. By default "top". See
    * https://popper.js.org/docs/v2/constructors/#options (and
@@ -98,6 +107,7 @@ export default function ControlledBubbleMenu({
   classes: overrideClasses = {},
   children,
   anchorEl,
+  container,
   placement = "top",
   fallbackPlacements = [
     "bottom",
@@ -186,18 +196,14 @@ export default function ControlledBubbleMenu({
       ]}
       anchorEl={anchorEl ?? defaultAnchorEl}
       className={cx(controlledBubbleMenuClasses.root, classes.root, className)}
-      // Put the portal children within the same DOM context as the editor. We
-      // do this somewhat hackily using the parent of the editor's parent, which
-      // gets us outside of any clipping containers used around the editor, like
-      // when we wrap it with an <OutlinedField />. This helps ensure that if,
-      // for instance, the editor appears within a modal, this bubble menu
-      // appears on top of *that*. (We can't merely set a z-index, since we
-      // don't want all bubble menus to appear on top of all modals; we just
-      // want bubble menus from editors within modals to appear on top of their
-      // modals.)
-      // TODO(Steven DeMartini): Make this logic cleaner and more predictable
+      // Put the portal children within the same DOM context as the editor. This
+      // helps ensure that if, for instance, the editor appears within a modal,
+      // this bubble menu appears on top of *that*. (We can't merely set a
+      // z-index, since we don't want all bubble menus to appear on top of all
+      // modals and other high z-index elements; we just want bubble menus from
+      // editors within modals to appear on top of their modals.)
       container={
-        editor.options.element.parentElement?.parentElement ?? undefined
+        typeof container === "undefined" ? editor.options.element : container
       }
       transition
     >


### PR DESCRIPTION
Users can now provide their own `container` or use `disablePortal` with the `ControlledBubbleMenu` (and by extension the `LinkBubbleMenu` and `TableBubbleMenu`). If not provided, it will fall back to MUI's default now (which is typically `document.body`). We used to use a hacky approach of getting an ancestor element of the editor, but that had some flaws (see commit messages for details), and this allows for more customization and the right behavior outside of modals.

With modals, like when placing the editor inside a MUI `<Dialog />`, it will be best to use an approach like the following to ensure the bubble menus appear properly "on top" of the modal:

```tsx
<Dialog open={open} ref={dialogRef}>
  <RichTextEditor ...>
    {() => (
      <>
        <LinkBubbleMenu container={dialogRef.current} />
        <TableBubbleMenu container={dialogRef.current} />
      </>
    )}
  </RichTextEditor>
</Dialog>
```