### PR TITLE
Anchor link bubble menu to link button when opening via button

### DIFF
--- a/src/ControlledBubbleMenu.tsx
+++ b/src/ControlledBubbleMenu.tsx
@@ -132,6 +132,7 @@ export default function ControlledBubbleMenu({
   disablePortal,
   placement = "top",
   fallbackPlacements = [
+    "top",
     "bottom",
     "top-start",
     "bottom-start",

--- a/src/LinkBubbleMenu/index.tsx
+++ b/src/LinkBubbleMenu/index.tsx
@@ -114,7 +114,7 @@ export default function LinkBubbleMenu({
     <ControlledBubbleMenu
       editor={editor}
       open={menuState !== LinkMenuState.HIDDEN}
-      anchorEl={handlerStorage.anchorEl}
+      {...handlerStorage.bubbleMenuOptions}
       {...controlledBubbleMenuProps}
     >
       <div className={classes.content}>{linkMenuContent}</div>

--- a/src/LinkBubbleMenu/index.tsx
+++ b/src/LinkBubbleMenu/index.tsx
@@ -114,6 +114,7 @@ export default function LinkBubbleMenu({
     <ControlledBubbleMenu
       editor={editor}
       open={menuState !== LinkMenuState.HIDDEN}
+      anchorEl={handlerStorage.anchorEl}
       {...controlledBubbleMenuProps}
     >
       <div className={classes.content}>{linkMenuContent}</div>

--- a/src/controls/MenuButton.tsx
+++ b/src/controls/MenuButton.tsx
@@ -1,6 +1,7 @@
 import { ToggleButton, type ToggleButtonProps } from "@mui/material";
+import type { RefObject } from "react";
 import { makeStyles } from "tss-react/mui";
-import type { SetOptional } from "type-fest";
+import type { Except, SetOptional } from "type-fest";
 import MenuButtonTooltip, {
   type MenuButtonTooltipProps,
 } from "./MenuButtonTooltip";
@@ -29,9 +30,11 @@ export type MenuButtonProps = {
   tooltipShortcutKeys?: MenuButtonTooltipProps["shortcutKeys"];
   /** The icon component to use for the button. Must accept a className. */
   IconComponent: React.ElementType<{ className: string }>;
-} & SetOptional<ToggleButtonProps, "value">;
+  /** Attaches a `ref` to the ToggleButton's root button element. */
+  buttonRef?: RefObject<HTMLButtonElement>;
+} & SetOptional<Except<ToggleButtonProps, "ref">, "value">;
 
-const useStyles = makeStyles({ name: { MenuButton } })({
+const useStyles = makeStyles({ name: "MenuButton" })({
   root: {
     // Use && for additional specificity, since MUI's conditional "disabled"
     // styles also set the border
@@ -54,6 +57,7 @@ export default function MenuButton({
   tooltipLabel,
   tooltipShortcutKeys,
   IconComponent,
+  buttonRef,
   ...toggleButtonProps
 }: MenuButtonProps) {
   const { classes } = useStyles();
@@ -63,7 +67,12 @@ export default function MenuButton({
         label={tooltipLabel}
         shortcutKeys={tooltipShortcutKeys}
       >
-        <ToggleButton size="small" value={tooltipLabel} {...toggleButtonProps}>
+        <ToggleButton
+          ref={buttonRef}
+          size="small"
+          value={tooltipLabel}
+          {...toggleButtonProps}
+        >
           <IconComponent className={classes.menuButtonIcon} />
         </ToggleButton>
       </MenuButtonTooltip>

--- a/src/controls/MenuButtonEditLink.tsx
+++ b/src/controls/MenuButtonEditLink.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@mui/icons-material";
+import { useRef } from "react";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
@@ -6,14 +7,20 @@ export type MenuButtonEditLinkProps = Partial<MenuButtonProps>;
 
 export default function MenuButtonEditLink(props: MenuButtonEditLinkProps) {
   const editor = useRichTextEditorContext();
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
   return (
     <MenuButton
+      buttonRef={buttonRef}
       tooltipLabel="Link"
       tooltipShortcutKeys={["mod", "Shift", "U"]}
       IconComponent={Link}
       selected={editor?.isActive("link")}
       disabled={!editor?.isEditable}
-      onClick={editor?.commands.openLinkBubbleMenu}
+      onClick={() =>
+        // Anchor the link bubble menu to the button, when clicking the button
+        // to open it
+        editor?.commands.openLinkBubbleMenu({ anchorEl: buttonRef.current })
+      }
       {...props}
     />
   );

--- a/src/controls/MenuButtonEditLink.tsx
+++ b/src/controls/MenuButtonEditLink.tsx
@@ -17,9 +17,12 @@ export default function MenuButtonEditLink(props: MenuButtonEditLinkProps) {
       selected={editor?.isActive("link")}
       disabled={!editor?.isEditable}
       onClick={() =>
-        // Anchor the link bubble menu to the button, when clicking the button
-        // to open it
-        editor?.commands.openLinkBubbleMenu({ anchorEl: buttonRef.current })
+        // When clicking the button to open the bubble menu, we'll place the
+        // menu below the button
+        editor?.commands.openLinkBubbleMenu({
+          anchorEl: buttonRef.current,
+          placement: "bottom",
+        })
       }
       {...props}
     />

--- a/src/extensions/LinkBubbleMenuHandler.ts
+++ b/src/extensions/LinkBubbleMenuHandler.ts
@@ -1,7 +1,7 @@
 /// <reference types="@tiptap/extension-link" />
-import type { PopperProps } from "@mui/material";
 import { Extension, getAttributes } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
+import type { LinkBubbleMenuProps } from "../LinkBubbleMenu";
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
@@ -11,15 +11,19 @@ declare module "@tiptap/core" {
        * the current cursor selection, or edit the existing link if there is
        * already a link at the current selection.
        *
-       * If the anchorEl is provided, it's used to override the anchor point for
-       * positioning the bubble menu. Each call to `openLinkBubbleMenu` will
-       * reset the anchor based on the provided argument. If not provided, the
-       * bubble menu will be anchored to the location in the editor content
-       * where the link appears or will appear.
+       * If the options are provided, they're used to override the bubble menu
+       * props, which can be useful for specific positioning needs. Each call to
+       * `openLinkBubbleMenu` will reset the options based on the provided
+       * argument, falling back to default behavior if not provided.
+       *
+       * For instance, if the anchorEl option is provided, it overrides the
+       * anchor point for positioning the bubble menu. (The default anchorEl for
+       * LinkBubbleMenu is to anchor to the location in the editor content where
+       * the link appears or will appear.)
        */
-      openLinkBubbleMenu: (options?: {
-        anchorEl?: PopperProps["anchorEl"];
-      }) => ReturnType;
+      openLinkBubbleMenu: (
+        options?: Partial<LinkBubbleMenuProps>
+      ) => ReturnType;
       /**
        * Edit an existing link in the bubble menu, to be used when currently
        * viewing a link in the already-opened bubble menu.
@@ -39,7 +43,7 @@ export enum LinkMenuState {
 
 export type LinkBubbleMenuHandlerStorage = {
   state: LinkMenuState;
-  anchorEl?: PopperProps["anchorEl"];
+  bubbleMenuOptions: Partial<LinkBubbleMenuProps> | undefined;
 };
 
 const LinkBubbleMenuHandler = Extension.create<
@@ -51,14 +55,14 @@ const LinkBubbleMenuHandler = Extension.create<
   addStorage() {
     return {
       state: LinkMenuState.HIDDEN,
-      anchorEl: undefined,
+      bubbleMenuOptions: undefined,
     };
   },
 
   addCommands() {
     return {
       openLinkBubbleMenu:
-        ({ anchorEl } = {}) =>
+        (bubbleMenuOptions = {}) =>
         ({ editor, chain, dispatch }) => {
           const currentMenuState = this.storage.state;
 
@@ -95,7 +99,7 @@ const LinkBubbleMenuHandler = Extension.create<
             // this happens automatically for the Tiptap built-in commands
             // called with `chain()` above.
             this.storage.state = newMenuState;
-            this.storage.anchorEl = anchorEl;
+            this.storage.bubbleMenuOptions = bubbleMenuOptions;
           }
 
           return true;

--- a/src/extensions/LinkBubbleMenuHandler.ts
+++ b/src/extensions/LinkBubbleMenuHandler.ts
@@ -1,4 +1,5 @@
 /// <reference types="@tiptap/extension-link" />
+import type { PopperProps } from "@mui/material";
 import { Extension, getAttributes } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 
@@ -9,8 +10,16 @@ declare module "@tiptap/core" {
        * Open/show the link bubble menu. Create a link if one doesn't exist at
        * the current cursor selection, or edit the existing link if there is
        * already a link at the current selection.
+       *
+       * If the anchorEl is provided, it's used to override the anchor point for
+       * positioning the bubble menu. Each call to `openLinkBubbleMenu` will
+       * reset the anchor based on the provided argument. If not provided, the
+       * bubble menu will be anchored to the location in the editor content
+       * where the link appears or will appear.
        */
-      openLinkBubbleMenu: () => ReturnType;
+      openLinkBubbleMenu: (options?: {
+        anchorEl?: PopperProps["anchorEl"];
+      }) => ReturnType;
       /**
        * Edit an existing link in the bubble menu, to be used when currently
        * viewing a link in the already-opened bubble menu.
@@ -30,6 +39,7 @@ export enum LinkMenuState {
 
 export type LinkBubbleMenuHandlerStorage = {
   state: LinkMenuState;
+  anchorEl?: PopperProps["anchorEl"];
 };
 
 const LinkBubbleMenuHandler = Extension.create<
@@ -41,13 +51,14 @@ const LinkBubbleMenuHandler = Extension.create<
   addStorage() {
     return {
       state: LinkMenuState.HIDDEN,
+      anchorEl: undefined,
     };
   },
 
   addCommands() {
     return {
       openLinkBubbleMenu:
-        () =>
+        ({ anchorEl } = {}) =>
         ({ editor, chain, dispatch }) => {
           const currentMenuState = this.storage.state;
 
@@ -84,6 +95,7 @@ const LinkBubbleMenuHandler = Extension.create<
             // this happens automatically for the Tiptap built-in commands
             // called with `chain()` above.
             this.storage.state = newMenuState;
+            this.storage.anchorEl = anchorEl;
           }
 
           return true;


### PR DESCRIPTION
Resolves https://github.com/sjdemartini/mui-tiptap/issues/53 (see comment here https://github.com/sjdemartini/mui-tiptap/issues/53#issuecomment-1595937019)

Now, the `openLinkBubbleMenu` editor command takes an optional `anchorEl` option. If the `anchorEl` is provided, it's used to override the anchor point for positioning the bubble menu. Each call to `openLinkBubbleMenu` will reset the anchor based on the provided argument. If not provided, the bubble menu will be anchored to the location in the editor content where the link appears or will appear (as was previously always the case, with out the ability to override).

Now the `MenuButtonEditLink` uses the `anchorEl` option to anchor the menu button to the `MenuButtonEditLink`, so that when clicking to open the menu, it appears right next to where you clicked:

### Screenshots
#### Clicking the button:

![Screenshot 2023-06-23 at 9 39 57 AM](https://github.com/sjdemartini/mui-tiptap/assets/1647130/fd37a3ca-ed64-4fa8-971d-0d50c3ec8a42)

#### Clicking an existing link directly (or using the shortcut key to open the menu):

![Screenshot 2023-06-23 at 9 40 15 AM](https://github.com/sjdemartini/mui-tiptap/assets/1647130/c4277332-78ba-4fb7-88d9-d087177f3c28)
