### PR TITLE
Add TextAlign menu buttons, and make HeadingWithAnchor support TextAlign

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "@tiptap/extension-task-item": "^2.0.3",
     "@tiptap/extension-task-list": "^2.0.3",
     "@tiptap/extension-text": "^2.0.3",
+    "@tiptap/extension-text-align": "^2.0.3",
     "@tiptap/extension-underline": "^2.0.3",
     "@tiptap/pm": "^2.0.3",
     "@tiptap/react": "^2.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ devDependencies:
   '@tiptap/extension-text':
     specifier: ^2.0.3
     version: 2.0.3(@tiptap/core@2.0.3)
+  '@tiptap/extension-text-align':
+    specifier: ^2.0.3
+    version: 2.0.3(@tiptap/core@2.0.3)
   '@tiptap/extension-underline':
     specifier: ^2.0.3
     version: 2.0.3(@tiptap/core@2.0.3)
@@ -1889,6 +1892,14 @@ packages:
 
   /@tiptap/extension-task-list@2.0.3(@tiptap/core@2.0.3):
     resolution: {integrity: sha512-NdW0RtMF2L96qy+j946mTB5Av6Qn5L3vGVWFmJA6/JPXr9Uj/grItCmqUQKHfPBSFow7UqBY82ODblP+GQFgew==}
+    peerDependencies:
+      '@tiptap/core': ^2.0.0
+    dependencies:
+      '@tiptap/core': 2.0.3(@tiptap/pm@2.0.3)
+    dev: true
+
+  /@tiptap/extension-text-align@2.0.3(@tiptap/core@2.0.3):
+    resolution: {integrity: sha512-VlLgqncKdjMjVjbU60/ALYhFs0wUdjAyvjDXnH1OoM/HuzbILvufPMYz4DUieJIWVJOYUKHQgg4XwBWceAM2Tw==}
     peerDependencies:
       '@tiptap/core': ^2.0.0
     dependencies:

--- a/src/controls/MenuButtonAlignCenter.tsx
+++ b/src/controls/MenuButtonAlignCenter.tsx
@@ -1,0 +1,23 @@
+/// <reference types="@tiptap/extension-text-align" />
+import FormatAlignCenterIcon from "@mui/icons-material/FormatAlignCenter";
+import { useRichTextEditorContext } from "../context";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
+
+export type MenuButtonAlignCenterProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonAlignCenter(
+  props: MenuButtonAlignCenterProps
+) {
+  const editor = useRichTextEditorContext();
+  return (
+    <MenuButton
+      tooltipLabel="Center align"
+      tooltipShortcutKeys={["mod", "Shift", "E"]}
+      IconComponent={FormatAlignCenterIcon}
+      selected={editor?.isActive({ textAlign: "center" }) ?? false}
+      disabled={!editor?.isEditable || !editor.can().setTextAlign("center")}
+      onClick={() => editor?.chain().focus().setTextAlign("center").run()}
+      {...props}
+    />
+  );
+}

--- a/src/controls/MenuButtonAlignJustify.tsx
+++ b/src/controls/MenuButtonAlignJustify.tsx
@@ -1,0 +1,23 @@
+/// <reference types="@tiptap/extension-text-align" />
+import FormatAlignJustifyIcon from "@mui/icons-material/FormatAlignJustify";
+import { useRichTextEditorContext } from "../context";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
+
+export type MenuButtonAlignJustifyProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonAlignJustify(
+  props: MenuButtonAlignJustifyProps
+) {
+  const editor = useRichTextEditorContext();
+  return (
+    <MenuButton
+      tooltipLabel="Justify"
+      tooltipShortcutKeys={["mod", "Shift", "J"]}
+      IconComponent={FormatAlignJustifyIcon}
+      selected={editor?.isActive({ textAlign: "justify" }) ?? false}
+      disabled={!editor?.isEditable || !editor.can().setTextAlign("justify")}
+      onClick={() => editor?.chain().focus().setTextAlign("justify").run()}
+      {...props}
+    />
+  );
+}

--- a/src/controls/MenuButtonAlignLeft.tsx
+++ b/src/controls/MenuButtonAlignLeft.tsx
@@ -1,0 +1,21 @@
+/// <reference types="@tiptap/extension-text-align" />
+import FormatAlignLeftIcon from "@mui/icons-material/FormatAlignLeft";
+import { useRichTextEditorContext } from "../context";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
+
+export type MenuButtonAlignLeftProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonAlignLeft(props: MenuButtonAlignLeftProps) {
+  const editor = useRichTextEditorContext();
+  return (
+    <MenuButton
+      tooltipLabel="Left align"
+      tooltipShortcutKeys={["mod", "Shift", "L"]}
+      IconComponent={FormatAlignLeftIcon}
+      selected={editor?.isActive({ textAlign: "left" }) ?? false}
+      disabled={!editor?.isEditable || !editor.can().setTextAlign("left")}
+      onClick={() => editor?.chain().focus().setTextAlign("left").run()}
+      {...props}
+    />
+  );
+}

--- a/src/controls/MenuButtonAlignRight.tsx
+++ b/src/controls/MenuButtonAlignRight.tsx
@@ -1,0 +1,21 @@
+/// <reference types="@tiptap/extension-text-align" />
+import FormatAlignRightIcon from "@mui/icons-material/FormatAlignRight";
+import { useRichTextEditorContext } from "../context";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
+
+export type MenuButtonAlignRightProps = Partial<MenuButtonProps>;
+
+export default function MenuButtonAlignRight(props: MenuButtonAlignRightProps) {
+  const editor = useRichTextEditorContext();
+  return (
+    <MenuButton
+      tooltipLabel="Right align"
+      tooltipShortcutKeys={["mod", "Shift", "R"]}
+      IconComponent={FormatAlignRightIcon}
+      selected={editor?.isActive({ textAlign: "right" }) ?? false}
+      disabled={!editor?.isEditable || !editor.can().setTextAlign("right")}
+      onClick={() => editor?.chain().focus().setTextAlign("right").run()}
+      {...props}
+    />
+  );
+}

--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -8,6 +8,22 @@ export {
   type MenuButtonAddTableProps,
 } from "./MenuButtonAddTable";
 export {
+  default as MenuButtonAlignCenter,
+  type MenuButtonAlignCenterProps,
+} from "./MenuButtonAlignCenter";
+export {
+  default as MenuButtonAlignJustify,
+  type MenuButtonAlignJustifyProps,
+} from "./MenuButtonAlignJustify";
+export {
+  default as MenuButtonAlignLeft,
+  type MenuButtonAlignLeftProps,
+} from "./MenuButtonAlignLeft";
+export {
+  default as MenuButtonAlignRight,
+  type MenuButtonAlignRightProps,
+} from "./MenuButtonAlignRight";
+export {
   default as MenuButtonBlockquote,
   type MenuButtonBlockquoteProps,
 } from "./MenuButtonBlockquote";

--- a/src/demo/EditorMenuControls.tsx
+++ b/src/demo/EditorMenuControls.tsx
@@ -1,28 +1,34 @@
-import MenuDivider from "../MenuDivider";
+import {
+  MenuButtonAddImage,
+  MenuButtonAddTable,
+  MenuButtonAlignCenter,
+  MenuButtonAlignJustify,
+  MenuButtonAlignLeft,
+  MenuButtonAlignRight,
+  MenuButtonBlockquote,
+  MenuButtonBold,
+  MenuButtonBulletedList,
+  MenuButtonCode,
+  MenuButtonCodeBlock,
+  MenuButtonEditLink,
+  MenuButtonHorizontalRule,
+  MenuButtonIndent,
+  MenuButtonItalic,
+  MenuButtonOrderedList,
+  MenuButtonRedo,
+  MenuButtonRemoveFormatting,
+  MenuButtonStrikethrough,
+  MenuButtonSubscript,
+  MenuButtonSuperscript,
+  MenuButtonTaskList,
+  MenuButtonUnderline,
+  MenuButtonUndo,
+  MenuButtonUnindent,
+  MenuControlsContainer,
+  MenuDivider,
+  MenuHeadingSelect,
+} from "../";
 import { useRichTextEditorContext } from "../context";
-import MenuButtonAddImage from "../controls/MenuButtonAddImage";
-import MenuButtonAddTable from "../controls/MenuButtonAddTable";
-import MenuButtonBlockquote from "../controls/MenuButtonBlockquote";
-import MenuButtonBold from "../controls/MenuButtonBold";
-import MenuButtonBulletedList from "../controls/MenuButtonBulletedList";
-import MenuButtonCode from "../controls/MenuButtonCode";
-import MenuButtonCodeBlock from "../controls/MenuButtonCodeBlock";
-import MenuButtonEditLink from "../controls/MenuButtonEditLink";
-import MenuButtonHorizontalRule from "../controls/MenuButtonHorizontalRule";
-import MenuButtonIndent from "../controls/MenuButtonIndent";
-import MenuButtonItalic from "../controls/MenuButtonItalic";
-import MenuButtonOrderedList from "../controls/MenuButtonOrderedList";
-import MenuButtonRedo from "../controls/MenuButtonRedo";
-import MenuButtonRemoveFormatting from "../controls/MenuButtonRemoveFormatting";
-import MenuButtonStrikethrough from "../controls/MenuButtonStrikethrough";
-import MenuButtonSubscript from "../controls/MenuButtonSubscript";
-import MenuButtonSuperscript from "../controls/MenuButtonSuperscript";
-import MenuButtonTaskList from "../controls/MenuButtonTaskList";
-import MenuButtonUnderline from "../controls/MenuButtonUnderline";
-import MenuButtonUndo from "../controls/MenuButtonUndo";
-import MenuButtonUnindent from "../controls/MenuButtonUnindent";
-import MenuControlsContainer from "../controls/MenuControlsContainer";
-import MenuHeadingSelect from "../controls/MenuHeadingSelect";
 import { isTouchDevice } from "../utils/platform";
 
 export default function EditorMenuControls() {
@@ -46,6 +52,13 @@ export default function EditorMenuControls() {
       <MenuDivider />
 
       <MenuButtonEditLink />
+
+      <MenuDivider />
+
+      <MenuButtonAlignLeft />
+      <MenuButtonAlignCenter />
+      <MenuButtonAlignRight />
+      <MenuButtonAlignJustify />
 
       <MenuDivider />
 

--- a/src/demo/useExtensions.ts
+++ b/src/demo/useExtensions.ts
@@ -25,6 +25,7 @@ import { TableRow } from "@tiptap/extension-table-row";
 import { TaskItem } from "@tiptap/extension-task-item";
 import { TaskList } from "@tiptap/extension-task-list";
 import { Text } from "@tiptap/extension-text";
+import { TextAlign } from "@tiptap/extension-text-align";
 import { Underline } from "@tiptap/extension-underline";
 import { useMemo } from "react";
 import HeadingWithAnchor from "../extensions/HeadingWithAnchor";
@@ -141,6 +142,9 @@ export default function useRecommendedExtensions({
       // Extensions
       Gapcursor,
       HeadingWithAnchor,
+      TextAlign.configure({
+        types: ["heading", "paragraph"],
+      }),
       HorizontalRule,
 
       ResizableImage,

--- a/src/extensions/HeadingWithAnchorComponent.tsx
+++ b/src/extensions/HeadingWithAnchorComponent.tsx
@@ -10,9 +10,11 @@ import slugify from "../utils/slugify";
 
 // Based on
 // https://github.com/ueberdosis/tiptap/blob/c9eb6a6299796450c7c1cfdc3552d76070c78c65/packages/extension-heading/src/heading.ts#L41-L48
-type HeadingNodeAttributes = {
+// We extend Record<string, unknown>, since we may inherit other global
+// attributes as well, aligned with ProseMirrorNode.attrs typing.
+interface HeadingNodeAttributes extends Record<string, unknown> {
   level: Level;
-};
+}
 
 interface HeadingNode extends ProseMirrorNode {
   attrs: HeadingNodeAttributes;
@@ -95,6 +97,12 @@ export default function HeadingWithAnchorComponent({
       id={headingId}
       {...extension.options.HTMLAttributes}
       className={classes.root}
+      // Handle @tiptap/extension-text-align. Ideally we'd be able to inherit
+      // this style from TextAlign's GlobalAttributes directly, but those are
+      // only applied via `renderHTML` and not the `NodeView` renderer
+      // (https://github.com/ueberdosis/tiptap/blob/6c34dec33ac39c9f037a0a72e4525f3fc6d422bf/packages/extension-text-align/src/text-align.ts#L43-L49),
+      // so we have to do this manually/redundantly here.
+      style={{ textAlign: node.attrs.textAlign }}
     >
       {/* Only render the clickable anchor element when in read-only mode (not editing) */}
       {!editor.isEditable && (


### PR DESCRIPTION
As requested in https://github.com/sjdemartini/mui-tiptap/issues/52

![Screenshot 2023-06-27 at 12 32 07 PM](https://github.com/sjdemartini/mui-tiptap/assets/1647130/78b67e46-d3d6-4963-81a0-de40188d361b)

I am separately working on a `Select` dropdown version of the TextAlign menu options (rather than individual buttons for each one), which can help conserve menu bar space, like what Google Docs does. I will roll that out later.