### PR TITLE
Add new `MenuSelectTextAlign` component for TextAlign, using new `MenuSelect` component for improved styles

### DIFF
--- a/src/controls/MenuButtonTooltip.tsx
+++ b/src/controls/MenuButtonTooltip.tsx
@@ -33,7 +33,7 @@ export type MenuButtonTooltipProps = {
   contentWrapperClassName?: string;
   /** The menu element for which we're showing a tooltip when hovering. */
   children: React.ReactNode;
-};
+} & Pick<TooltipProps, "open" | "onOpen" | "onClose">;
 
 const useStyles = makeStyles({ name: { MenuButtonTooltip } })((theme) => ({
   titleContainer: {
@@ -67,6 +67,7 @@ export default function MenuButtonTooltip({
   placement = "top",
   contentWrapperClassName,
   children,
+  ...otherTooltipProps
 }: MenuButtonTooltipProps) {
   const { classes } = useStyles();
   return (
@@ -88,6 +89,7 @@ export default function MenuButtonTooltip({
       }
       placement={placement}
       arrow
+      {...otherTooltipProps}
     >
       {/* Use a span around the children so we show a tooltip even if the
       element inside is disabled */}

--- a/src/controls/MenuHeadingSelect.tsx
+++ b/src/controls/MenuHeadingSelect.tsx
@@ -1,15 +1,23 @@
 /// <reference types="@tiptap/extension-paragraph" />
-import { MenuItem, Select, type SelectChangeEvent } from "@mui/material";
+import { MenuItem, type SelectChangeEvent } from "@mui/material";
 import type { Heading, Level } from "@tiptap/extension-heading";
 import { useCallback, useMemo } from "react";
 import { makeStyles } from "tss-react/mui";
 import { useRichTextEditorContext } from "../context";
 import { getEditorStyles } from "../styles";
 import MenuButtonTooltip from "./MenuButtonTooltip";
+import MenuSelect from "./MenuSelect";
 
 const useStyles = makeStyles({ name: { MenuHeadingSelect } })((theme) => {
   const editorStyles = getEditorStyles(theme);
   return {
+    selectInput: {
+      // We use a fixed width so that the Select element won't change sizes as
+      // the selected option changes (which would shift other elements in the
+      // menu bar)
+      width: 78,
+    },
+
     menuOption: {
       // These styles ensure the item fills its MenuItem container, and the
       // tooltip appears in the same place when hovering over the item generally
@@ -140,10 +148,7 @@ export default function MenuHeadingSelect() {
     // need it to support "" as a possible value in the `renderValue` function
     // below since we have `displayEmpty=true`, and the types don't properly
     // handle that scenario.
-    <Select<HeadingOptionValue | "">
-      margin="none"
-      variant="outlined"
-      size="small"
+    <MenuSelect<HeadingOptionValue | "">
       onChange={handleHeadingType}
       disabled={
         !editor?.isEditable ||
@@ -158,21 +163,8 @@ export default function MenuHeadingSelect() {
       }}
       aria-label="Heading type"
       value={selectedValue}
-      // We use a fixed width so that the Select element won't change sizes as
-      // the selected option changes (which would shift other elements in the
-      // menu bar)
-      inputProps={{ sx: { py: "3px", fontSize: "0.9em", width: 78 } }}
-      // Always show the dropdown options directly below the select input,
-      // aligned to left-most edge
-      MenuProps={{
-        anchorOrigin: {
-          vertical: "bottom",
-          horizontal: "left",
-        },
-        transformOrigin: {
-          vertical: "top",
-          horizontal: "left",
-        },
+      inputProps={{
+        className: classes.selectInput,
       }}
     >
       <MenuItem
@@ -308,6 +300,6 @@ export default function MenuHeadingSelect() {
           </MenuButtonTooltip>
         </MenuItem>
       )}
-    </Select>
+    </MenuSelect>
   );
 }

--- a/src/controls/MenuSelect.tsx
+++ b/src/controls/MenuSelect.tsx
@@ -4,7 +4,7 @@ import MenuButtonTooltip from "./MenuButtonTooltip";
 
 export type MenuSelectProps<T> = SelectProps<T> & {
   /** An optional tooltip to show when hovering over this Select. */
-  tooltipLabel?: string;
+  tooltipTitle?: string;
 };
 
 const useStyles = makeStyles({ name: { MenuSelect } })((theme) => {
@@ -45,7 +45,7 @@ const useStyles = makeStyles({ name: { MenuSelect } })((theme) => {
 
 /** A Select that is styled to work well with other menu bar controls. */
 export default function MenuSelect<T>({
-  tooltipLabel,
+  tooltipTitle,
   ...selectProps
 }: MenuSelectProps<T>) {
   const { classes, cx } = useStyles();
@@ -80,7 +80,7 @@ export default function MenuSelect<T>({
       }}
     />
   );
-  return tooltipLabel ? (
+  return tooltipTitle ? (
     <MenuButtonTooltip
       label="Align"
       contentWrapperClassName={classes.rootTooltipWrapper}

--- a/src/controls/MenuSelect.tsx
+++ b/src/controls/MenuSelect.tsx
@@ -1,4 +1,5 @@
 import { Select, type SelectProps } from "@mui/material";
+import { useState } from "react";
 import { makeStyles } from "tss-react/mui";
 import MenuButtonTooltip from "./MenuButtonTooltip";
 
@@ -49,11 +50,29 @@ export default function MenuSelect<T>({
   ...selectProps
 }: MenuSelectProps<T>) {
   const { classes, cx } = useStyles();
+  // We use a controlled tooltip here because otherwise it seems the tooltip can
+  // get stuck open after selecting something (as it can re-trigger the
+  // Tooltip's onOpen upon clicking a MenuItem). We instead trigger it to
+  // open/close based on interaction specifically with the Select (not the usual
+  // Tooltip onOpen/onClose)
+  const [tooltipOpen, setTooltipOpen] = useState(false);
   const select = (
     <Select<T>
       margin="none"
       variant="outlined"
       size="small"
+      onMouseEnter={(...args) => {
+        setTooltipOpen(true);
+        selectProps.onMouseEnter?.(...args);
+      }}
+      onMouseLeave={(...args) => {
+        setTooltipOpen(false);
+        selectProps.onMouseLeave?.(...args);
+      }}
+      onClick={(...args) => {
+        setTooltipOpen(false);
+        selectProps.onClick?.(...args);
+      }}
       {...selectProps}
       inputProps={{
         ...selectProps.inputProps,
@@ -84,6 +103,7 @@ export default function MenuSelect<T>({
     <MenuButtonTooltip
       label="Align"
       contentWrapperClassName={classes.rootTooltipWrapper}
+      open={tooltipOpen}
     >
       {select}
     </MenuButtonTooltip>

--- a/src/controls/MenuSelect.tsx
+++ b/src/controls/MenuSelect.tsx
@@ -1,0 +1,93 @@
+import { Select, type SelectProps } from "@mui/material";
+import { makeStyles } from "tss-react/mui";
+import MenuButtonTooltip from "./MenuButtonTooltip";
+
+export type MenuSelectProps<T> = SelectProps<T> & {
+  /** An optional tooltip to show when hovering over this Select. */
+  tooltipLabel?: string;
+};
+
+const useStyles = makeStyles({ name: { MenuSelect } })((theme) => {
+  return {
+    rootTooltipWrapper: {
+      display: "inline-flex",
+    },
+
+    selectRoot: {
+      // Don't show the default outline when not hovering or focused, for better
+      // style consistency with the MenuButtons
+      "&:not(:hover):not(.Mui-focused) .MuiOutlinedInput-notchedOutline": {
+        borderWidth: 0,
+      },
+    },
+
+    select: {
+      // Increase specificity to override MUI's styles
+      "&&&": {
+        paddingLeft: theme.spacing(1),
+        paddingRight: theme.spacing(3),
+      },
+    },
+
+    selectDropdownIcon: {
+      // Move the caret icon closer to the right than default so the button is
+      // more compact
+      right: 1,
+    },
+
+    input: {
+      paddingTop: "3px",
+      paddingBottom: "3px",
+      fontSize: "0.9em",
+    },
+  };
+});
+
+/** A Select that is styled to work well with other menu bar controls. */
+export default function MenuSelect<T>({
+  tooltipLabel,
+  ...selectProps
+}: MenuSelectProps<T>) {
+  const { classes, cx } = useStyles();
+  const select = (
+    <Select<T>
+      margin="none"
+      variant="outlined"
+      size="small"
+      {...selectProps}
+      inputProps={{
+        ...selectProps.inputProps,
+        className: cx(classes.input, selectProps.inputProps?.className),
+      }}
+      // Always show the dropdown options directly below the select input,
+      // aligned to left-most edge
+      MenuProps={{
+        anchorOrigin: {
+          vertical: "bottom",
+          horizontal: "left",
+        },
+        transformOrigin: {
+          vertical: "top",
+          horizontal: "left",
+        },
+        ...selectProps.MenuProps,
+      }}
+      className={cx(classes.selectRoot, selectProps.className)}
+      classes={{
+        ...selectProps.classes,
+        select: cx(classes.select, selectProps.classes?.select),
+        icon: cx(classes.selectDropdownIcon, selectProps.classes?.icon),
+      }}
+    />
+  );
+  return tooltipLabel ? (
+    <MenuButtonTooltip
+      label="Align"
+      contentWrapperClassName={classes.rootTooltipWrapper}
+    >
+      {select}
+    </MenuButtonTooltip>
+  ) : (
+    select
+  );
+}

--- a/src/controls/MenuSelectTextAlign.tsx
+++ b/src/controls/MenuSelectTextAlign.tsx
@@ -16,6 +16,10 @@ import MenuButtonTooltip, {
 import type { TextAlignOptions } from "@tiptap/extension-text-align";
 import MenuSelect from "./MenuSelect";
 
+export type MenuSelectTextAlignProps = {
+  tooltipTitle?: string;
+};
+
 const useStyles = makeStyles({ name: { MenuSelectTextAlign } })({
   menuItem: {
     paddingLeft: 0,
@@ -68,7 +72,9 @@ const ALIGNMENT_OPTIONS: {
   },
 ];
 
-export default function MenuSelectTextAlign() {
+export default function MenuSelectTextAlign({
+  tooltipTitle,
+}: MenuSelectTextAlignProps) {
   const { classes } = useStyles();
   const editor = useRichTextEditorContext();
 
@@ -104,7 +110,7 @@ export default function MenuSelectTextAlign() {
 
   return (
     <MenuSelect<string>
-      tooltipLabel="Align"
+      tooltipTitle={tooltipTitle ?? "Align"}
       onChange={handleAlignmentSelect}
       disabled={
         !editor?.isEditable ||

--- a/src/controls/MenuSelectTextAlign.tsx
+++ b/src/controls/MenuSelectTextAlign.tsx
@@ -2,7 +2,7 @@ import FormatAlignCenterIcon from "@mui/icons-material/FormatAlignCenter";
 import FormatAlignJustifyIcon from "@mui/icons-material/FormatAlignJustify";
 import FormatAlignLeftIcon from "@mui/icons-material/FormatAlignLeft";
 import FormatAlignRightIcon from "@mui/icons-material/FormatAlignRight";
-import { MenuItem, Select, type SelectChangeEvent } from "@mui/material";
+import { MenuItem, type SelectChangeEvent } from "@mui/material";
 import { useCallback, useMemo } from "react";
 import { makeStyles } from "tss-react/mui";
 import { useRichTextEditorContext } from "../context";
@@ -14,45 +14,26 @@ import MenuButtonTooltip, {
 // without needing to list extension-text-align as a peer dependency.
 // eslint-disable-next-line import/no-extraneous-dependencies
 import type { TextAlignOptions } from "@tiptap/extension-text-align";
+import MenuSelect from "./MenuSelect";
 
-const useStyles = makeStyles({ name: { MenuSelectTextAlign } })((theme) => {
-  return {
-    rootTooltipWrapper: {
-      display: "inline-flex",
-    },
+const useStyles = makeStyles({ name: { MenuSelectTextAlign } })({
+  menuItem: {
+    paddingLeft: 0,
+    paddingRight: 0,
+  },
 
-    select: {
-      // Increase specificity to override MUI's styles
-      "&&&": {
-        paddingLeft: theme.spacing(1),
-        paddingRight: theme.spacing(3),
-      },
-    },
+  menuOption: {
+    // These styles ensure the item fills its MenuItem container, and the
+    // tooltip appears in the same place when hovering over the item generally
+    // (not just the text of the item)
+    display: "flex",
+    width: "100%",
+    justifyContent: "center",
+  },
 
-    selectDropdownIcon: {
-      // Move the caret icon closer to the right than default so the button is
-      // more compact
-      right: 1,
-    },
-
-    menuItem: {
-      paddingLeft: 0,
-      paddingRight: 0,
-    },
-
-    menuOption: {
-      // These styles ensure the item fills its MenuItem container, and the
-      // tooltip appears in the same place when hovering over the item generally
-      // (not just the text of the item)
-      display: "flex",
-      width: "100%",
-      justifyContent: "center",
-    },
-
-    menuButtonIcon: {
-      fontSize: "1.25rem",
-    },
-  };
+  menuButtonIcon: {
+    fontSize: "1.25rem",
+  },
 });
 
 const ALIGNMENT_OPTIONS: {
@@ -122,89 +103,59 @@ export default function MenuSelectTextAlign() {
     "";
 
   return (
-    <MenuButtonTooltip
-      label="Align"
-      contentWrapperClassName={classes.rootTooltipWrapper}
-    >
-      <Select<string>
-        margin="none"
-        variant="outlined"
-        size="small"
-        onChange={handleAlignmentSelect}
-        disabled={
-          !editor?.isEditable ||
-          !Array.from(enabledAlignments).some((alignment) =>
-            editor.can().setTextAlign(alignment)
-          )
+    <MenuSelect<string>
+      tooltipLabel="Align"
+      onChange={handleAlignmentSelect}
+      disabled={
+        !editor?.isEditable ||
+        !Array.from(enabledAlignments).some((alignment) =>
+          editor.can().setTextAlign(alignment)
+        )
+      }
+      aria-label="Text alignment"
+      value={selectedValue}
+      // Override the rendering of the selected value so that we don't show
+      // tooltips on hovering (like we do for the menu options)
+      renderValue={(selectedValue) => {
+        let content;
+        if (selectedValue === "left") {
+          content = <FormatAlignLeftIcon className={classes.menuButtonIcon} />;
+        } else if (selectedValue === "center") {
+          content = (
+            <FormatAlignCenterIcon className={classes.menuButtonIcon} />
+          );
+        } else if (selectedValue === "right") {
+          content = <FormatAlignRightIcon className={classes.menuButtonIcon} />;
+        } else if (selectedValue === "justify") {
+          content = (
+            <FormatAlignJustifyIcon className={classes.menuButtonIcon} />
+          );
+        } else {
+          content = selectedValue;
         }
-        aria-label="Text alignment"
-        value={selectedValue}
-        inputProps={{ sx: { py: "3px", fontSize: "0.9em" } }}
-        // Always show the dropdown options directly below the select input,
-        // aligned to left-most edge
-        MenuProps={{
-          anchorOrigin: {
-            vertical: "bottom",
-            horizontal: "left",
-          },
-          transformOrigin: {
-            vertical: "top",
-            horizontal: "left",
-          },
-        }}
-        classes={{
-          select: classes.select,
-          icon: classes.selectDropdownIcon,
-        }}
-        // Override the rendering of the selected value so that we don't show
-        // tooltips on hovering (like we do for the menu options)
-        renderValue={(selectedValue) => {
-          let content;
-          if (selectedValue === "left") {
-            content = (
-              <FormatAlignLeftIcon className={classes.menuButtonIcon} />
-            );
-          } else if (selectedValue === "center") {
-            content = (
-              <FormatAlignCenterIcon className={classes.menuButtonIcon} />
-            );
-          } else if (selectedValue === "right") {
-            content = (
-              <FormatAlignRightIcon className={classes.menuButtonIcon} />
-            );
-          } else if (selectedValue === "justify") {
-            content = (
-              <FormatAlignJustifyIcon className={classes.menuButtonIcon} />
-            );
-          } else {
-            content = selectedValue;
-          }
 
-          return <span className={classes.menuOption}>{content}</span>;
-        }}
-      >
-        {ALIGNMENT_OPTIONS.filter((alignmentOption) =>
-          enabledAlignments.has(alignmentOption.alignment)
-        ).map((alignmentOption) => (
-          <MenuItem
-            key={alignmentOption.alignment}
-            value={alignmentOption.alignment}
-            disabled={!editor?.can().setTextAlign(alignmentOption.alignment)}
-            className={classes.menuItem}
+        return <span className={classes.menuOption}>{content}</span>;
+      }}
+    >
+      {ALIGNMENT_OPTIONS.filter((alignmentOption) =>
+        enabledAlignments.has(alignmentOption.alignment)
+      ).map((alignmentOption) => (
+        <MenuItem
+          key={alignmentOption.alignment}
+          value={alignmentOption.alignment}
+          disabled={!editor?.can().setTextAlign(alignmentOption.alignment)}
+          className={classes.menuItem}
+        >
+          <MenuButtonTooltip
+            label={alignmentOption.label}
+            shortcutKeys={alignmentOption.shortcutKeys}
+            placement="right"
+            contentWrapperClassName={classes.menuOption}
           >
-            <MenuButtonTooltip
-              label={alignmentOption.label}
-              shortcutKeys={alignmentOption.shortcutKeys}
-              placement="right"
-              contentWrapperClassName={classes.menuOption}
-            >
-              <alignmentOption.IconComponent
-                className={classes.menuButtonIcon}
-              />
-            </MenuButtonTooltip>
-          </MenuItem>
-        ))}
-      </Select>
-    </MenuButtonTooltip>
+            <alignmentOption.IconComponent className={classes.menuButtonIcon} />
+          </MenuButtonTooltip>
+        </MenuItem>
+      ))}
+    </MenuSelect>
   );
 }

--- a/src/controls/MenuSelectTextAlign.tsx
+++ b/src/controls/MenuSelectTextAlign.tsx
@@ -1,0 +1,210 @@
+import FormatAlignCenterIcon from "@mui/icons-material/FormatAlignCenter";
+import FormatAlignJustifyIcon from "@mui/icons-material/FormatAlignJustify";
+import FormatAlignLeftIcon from "@mui/icons-material/FormatAlignLeft";
+import FormatAlignRightIcon from "@mui/icons-material/FormatAlignRight";
+import { MenuItem, Select, type SelectChangeEvent } from "@mui/material";
+import { useCallback, useMemo } from "react";
+import { makeStyles } from "tss-react/mui";
+import { useRichTextEditorContext } from "../context";
+import MenuButtonTooltip, {
+  type MenuButtonTooltipProps,
+} from "./MenuButtonTooltip";
+// We'll import just the type for TextAlignOptions, which we don't expose
+// externally but only utilize within the component below, so allow this import
+// without needing to list extension-text-align as a peer dependency.
+// eslint-disable-next-line import/no-extraneous-dependencies
+import type { TextAlignOptions } from "@tiptap/extension-text-align";
+
+const useStyles = makeStyles({ name: { MenuSelectTextAlign } })((theme) => {
+  return {
+    rootTooltipWrapper: {
+      display: "inline-flex",
+    },
+
+    select: {
+      // Increase specificity to override MUI's styles
+      "&&&": {
+        paddingLeft: theme.spacing(1),
+        paddingRight: theme.spacing(3),
+      },
+    },
+
+    selectDropdownIcon: {
+      // Move the caret icon closer to the right than default so the button is
+      // more compact
+      right: 1,
+    },
+
+    menuItem: {
+      paddingLeft: 0,
+      paddingRight: 0,
+    },
+
+    menuOption: {
+      // These styles ensure the item fills its MenuItem container, and the
+      // tooltip appears in the same place when hovering over the item generally
+      // (not just the text of the item)
+      display: "flex",
+      width: "100%",
+      justifyContent: "center",
+    },
+
+    menuButtonIcon: {
+      fontSize: "1.25rem",
+    },
+  };
+});
+
+const ALIGNMENT_OPTIONS: {
+  alignment: string;
+  label: string;
+  shortcutKeys: MenuButtonTooltipProps["shortcutKeys"];
+  IconComponent: React.ElementType<{ className: string }>;
+}[] = [
+  {
+    alignment: "left",
+    label: "Left",
+    shortcutKeys: ["mod", "Shift", "L"],
+    IconComponent: FormatAlignLeftIcon,
+  },
+  {
+    alignment: "center",
+    label: "Center",
+    shortcutKeys: ["mod", "Shift", "E"],
+    IconComponent: FormatAlignCenterIcon,
+  },
+  {
+    alignment: "right",
+    label: "Right",
+    shortcutKeys: ["mod", "Shift", "R"],
+    IconComponent: FormatAlignRightIcon,
+  },
+  {
+    alignment: "justify",
+    label: "Justify",
+    shortcutKeys: ["mod", "Shift", "J"],
+    IconComponent: FormatAlignJustifyIcon,
+  },
+];
+
+export default function MenuSelectTextAlign() {
+  const { classes } = useStyles();
+  const editor = useRichTextEditorContext();
+
+  const handleAlignmentSelect: (event: SelectChangeEvent) => void = useCallback(
+    (event) => {
+      const alignment = event.target.value;
+      editor?.chain().setTextAlign(alignment).focus().run();
+    },
+    [editor]
+  );
+
+  // Figure out which settings the user has enabled with the heading extension
+  const textAlignExtensionOptions = useMemo(() => {
+    const textAlignExtension = editor?.extensionManager.extensions.find(
+      (extension) => extension.name == "textAlign"
+    );
+    return textAlignExtension?.options as TextAlignOptions | undefined;
+  }, [editor]);
+
+  const enabledAlignments: Set<TextAlignOptions["alignments"][0]> =
+    useMemo(() => {
+      return new Set(textAlignExtensionOptions?.alignments);
+    }, [textAlignExtensionOptions]);
+
+  const selectedValue =
+    Array.from(enabledAlignments).find((alignment) =>
+      editor?.isActive({ textAlign: alignment })
+    ) ??
+    textAlignExtensionOptions?.defaultAlignment ??
+    // Fall back to empty string, though this shouldn't happen if the TextAlign
+    // extension is used in a standard way
+    "";
+
+  return (
+    <MenuButtonTooltip
+      label="Align"
+      contentWrapperClassName={classes.rootTooltipWrapper}
+    >
+      <Select<string>
+        margin="none"
+        variant="outlined"
+        size="small"
+        onChange={handleAlignmentSelect}
+        disabled={
+          !editor?.isEditable ||
+          !Array.from(enabledAlignments).some((alignment) =>
+            editor.can().setTextAlign(alignment)
+          )
+        }
+        aria-label="Text alignment"
+        value={selectedValue}
+        inputProps={{ sx: { py: "3px", fontSize: "0.9em" } }}
+        // Always show the dropdown options directly below the select input,
+        // aligned to left-most edge
+        MenuProps={{
+          anchorOrigin: {
+            vertical: "bottom",
+            horizontal: "left",
+          },
+          transformOrigin: {
+            vertical: "top",
+            horizontal: "left",
+          },
+        }}
+        classes={{
+          select: classes.select,
+          icon: classes.selectDropdownIcon,
+        }}
+        // Override the rendering of the selected value so that we don't show
+        // tooltips on hovering (like we do for the menu options)
+        renderValue={(selectedValue) => {
+          let content;
+          if (selectedValue === "left") {
+            content = (
+              <FormatAlignLeftIcon className={classes.menuButtonIcon} />
+            );
+          } else if (selectedValue === "center") {
+            content = (
+              <FormatAlignCenterIcon className={classes.menuButtonIcon} />
+            );
+          } else if (selectedValue === "right") {
+            content = (
+              <FormatAlignRightIcon className={classes.menuButtonIcon} />
+            );
+          } else if (selectedValue === "justify") {
+            content = (
+              <FormatAlignJustifyIcon className={classes.menuButtonIcon} />
+            );
+          } else {
+            content = selectedValue;
+          }
+
+          return <span className={classes.menuOption}>{content}</span>;
+        }}
+      >
+        {ALIGNMENT_OPTIONS.filter((alignmentOption) =>
+          enabledAlignments.has(alignmentOption.alignment)
+        ).map((alignmentOption) => (
+          <MenuItem
+            key={alignmentOption.alignment}
+            value={alignmentOption.alignment}
+            disabled={!editor?.can().setTextAlign(alignmentOption.alignment)}
+            className={classes.menuItem}
+          >
+            <MenuButtonTooltip
+              label={alignmentOption.label}
+              shortcutKeys={alignmentOption.shortcutKeys}
+              placement="right"
+              contentWrapperClassName={classes.menuOption}
+            >
+              <alignmentOption.IconComponent
+                className={classes.menuButtonIcon}
+              />
+            </MenuButtonTooltip>
+          </MenuItem>
+        ))}
+      </Select>
+    </MenuButtonTooltip>
+  );
+}

--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -108,3 +108,4 @@ export {
   type MenuControlsContainerProps,
 } from "./MenuControlsContainer";
 export { default as MenuHeadingSelect } from "./MenuHeadingSelect";
+export { default as MenuSelectTextAlign } from "./MenuSelectTextAlign";

--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -108,4 +108,8 @@ export {
   type MenuControlsContainerProps,
 } from "./MenuControlsContainer";
 export { default as MenuHeadingSelect } from "./MenuHeadingSelect";
-export { default as MenuSelectTextAlign } from "./MenuSelectTextAlign";
+export { default as MenuSelect, type MenuSelectProps } from "./MenuSelect";
+export {
+  default as MenuSelectTextAlign,
+  type MenuSelectTextAlignProps,
+} from "./MenuSelectTextAlign";

--- a/src/demo/EditorMenuControls.tsx
+++ b/src/demo/EditorMenuControls.tsx
@@ -1,10 +1,6 @@
 import {
   MenuButtonAddImage,
   MenuButtonAddTable,
-  MenuButtonAlignCenter,
-  MenuButtonAlignJustify,
-  MenuButtonAlignLeft,
-  MenuButtonAlignRight,
   MenuButtonBlockquote,
   MenuButtonBold,
   MenuButtonBulletedList,
@@ -27,6 +23,7 @@ import {
   MenuControlsContainer,
   MenuDivider,
   MenuHeadingSelect,
+  MenuSelectTextAlign,
 } from "../";
 import { useRichTextEditorContext } from "../context";
 import { isTouchDevice } from "../utils/platform";
@@ -55,10 +52,7 @@ export default function EditorMenuControls() {
 
       <MenuDivider />
 
-      <MenuButtonAlignLeft />
-      <MenuButtonAlignCenter />
-      <MenuButtonAlignRight />
-      <MenuButtonAlignJustify />
+      <MenuSelectTextAlign />
 
       <MenuDivider />
 

--- a/src/demo/EditorMenuControls.tsx
+++ b/src/demo/EditorMenuControls.tsx
@@ -34,6 +34,8 @@ export default function EditorMenuControls() {
     <MenuControlsContainer>
       <MenuHeadingSelect />
 
+      <MenuDivider />
+
       <MenuButtonBold />
 
       <MenuButtonItalic />


### PR DESCRIPTION
Follow-on to https://github.com/sjdemartini/mui-tiptap/pull/69, `MenuSelectTextAlign` is an alternative to the individual `MenuButtonAlign*` components, which is more horizontally compact (similar to what Google Docs uses for text alignment selection):

![Screenshot 2023-06-27 at 4 23 29 PM](https://github.com/sjdemartini/mui-tiptap/assets/1647130/d68a14dd-739e-40bf-80cc-33841e46247a)

That select component as well as `MenuHeadingSelect` (to be renamed later for consistency) now use improved/DRY styles, so they take up less visual space, and so that the unfocused/unhovered state looks more consistent with the menu buttons (no border shown).