### PR TITLE
[breaking change] Rename `MenuHeadingSelect` -> `MenuSelectHeading`

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ import {
   MenuButtonBold,
   MenuButtonItalic,
   MenuControlsContainer,
-  MenuHeadingSelect,
+  MenuDivider,
+  MenuSelectHeading,
   RichTextEditorProvider,
   RichTextField,
 } from "mui-tiptap";
@@ -126,7 +127,8 @@ function App() {
       <RichTextField
         controls={
           <MenuControlsContainer>
-            <MenuHeadingSelect />
+            <MenuSelectHeading />
+            <MenuDivider />
             <MenuButtonBold />
             <MenuButtonItalic />
             {/* Add more controls of your choosing here */}

--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -2321,7 +2321,7 @@ packages:
     resolution: {directory: .., type: directory}
     id: file:..
     name: mui-tiptap
-    version: 1.0.0-beta.3
+    version: 1.0.0-beta.4
     engines: {pnpm: '>=8'}
     requiresBuild: true
     peerDependencies:

--- a/example/src/PageContentWithEditor.tsx
+++ b/example/src/PageContentWithEditor.tsx
@@ -44,7 +44,7 @@ import {
   MenuButtonTaskList,
   MenuControlsContainer,
   MenuDivider,
-  MenuHeadingSelect,
+  MenuSelectHeading,
   ResizableImage,
   RichTextEditor,
   TableBubbleMenu,
@@ -151,7 +151,10 @@ export default function PageContentWithEditor() {
           extensions={extensions}
           renderControls={() => (
             <MenuControlsContainer>
-              <MenuHeadingSelect />
+              <MenuSelectHeading />
+
+              <MenuDivider />
+
               <MenuButtonBold />
               <MenuButtonItalic />
               <MenuButtonStrikethrough />

--- a/src/controls/MenuSelectHeading.tsx
+++ b/src/controls/MenuSelectHeading.tsx
@@ -8,7 +8,7 @@ import { getEditorStyles } from "../styles";
 import MenuButtonTooltip from "./MenuButtonTooltip";
 import MenuSelect from "./MenuSelect";
 
-const useStyles = makeStyles({ name: { MenuHeadingSelect } })((theme) => {
+const useStyles = makeStyles({ name: { MenuSelectHeading } })((theme) => {
   const editorStyles = getEditorStyles(theme);
   return {
     selectInput: {
@@ -88,7 +88,7 @@ const LEVEL_TO_HEADING_OPTION_VALUE = {
   6: HEADING_OPTION_VALUES.Heading6,
 } as const;
 
-export default function MenuHeadingSelect() {
+export default function MenuSelectHeading() {
   const { classes, cx } = useStyles();
   const editor = useRichTextEditorContext();
 

--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -107,8 +107,8 @@ export {
   default as MenuControlsContainer,
   type MenuControlsContainerProps,
 } from "./MenuControlsContainer";
-export { default as MenuHeadingSelect } from "./MenuHeadingSelect";
 export { default as MenuSelect, type MenuSelectProps } from "./MenuSelect";
+export { default as MenuSelectHeading } from "./MenuSelectHeading";
 export {
   default as MenuSelectTextAlign,
   type MenuSelectTextAlignProps,

--- a/src/demo/EditorMenuControls.tsx
+++ b/src/demo/EditorMenuControls.tsx
@@ -22,7 +22,7 @@ import {
   MenuButtonUnindent,
   MenuControlsContainer,
   MenuDivider,
-  MenuHeadingSelect,
+  MenuSelectHeading,
   MenuSelectTextAlign,
 } from "../";
 import { useRichTextEditorContext } from "../context";
@@ -32,7 +32,7 @@ export default function EditorMenuControls() {
   const editor = useRichTextEditorContext();
   return (
     <MenuControlsContainer>
-      <MenuHeadingSelect />
+      <MenuSelectHeading />
 
       <MenuDivider />
 


### PR DESCRIPTION
For consistency with `MenuSelectTextAlign`, and all of the `MenuButton*` components.