### PR TITLE
Reduce fixed width of SelectHeading component

### DIFF
--- a/src/controls/MenuSelectHeading.tsx
+++ b/src/controls/MenuSelectHeading.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles({ name: { MenuSelectHeading } })((theme) => {
       // We use a fixed width so that the Select element won't change sizes as
       // the selected option changes (which would shift other elements in the
       // menu bar)
-      width: 78,
+      width: 68,
     },
 
     menuOption: {


### PR DESCRIPTION
Now that the caret icon and padding are narrower (thanks to `MenuSelect`), the overall width can be narrower.