### PR TITLE
Increase width of MenuSelectHeading again to accommodate "Change to..."

### DIFF
--- a/src/controls/MenuSelectHeading.tsx
+++ b/src/controls/MenuSelectHeading.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles({ name: { MenuSelectHeading } })((theme) => {
       // We use a fixed width so that the Select element won't change sizes as
       // the selected option changes (which would shift other elements in the
       // menu bar)
-      width: 68,
+      width: 77,
     },
 
     menuOption: {


### PR DESCRIPTION
Whoops, though https://github.com/sjdemartini/mui-tiptap/pull/72 would be nice, it doesn't work properly as the "to" in "Change to..." gets truncated (shown when selecting a node that is not text).

This is still 1px narrower than before #72, but can't go any narrower than that it seems, unfortunately.