### PR TITLE
Handle editor `isEditable` state changes in extension node views

### DIFF
--- a/src/extensions/ResizableImageResizer.tsx
+++ b/src/extensions/ResizableImageResizer.tsx
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useState } from "react";
+import { makeStyles } from "tss-react/mui";
+
+type ResizableImageResizerProps = {
+  className?: string;
+  onResize: (event: MouseEvent) => void;
+};
+
+const useStyles = makeStyles({ name: { ResizableImageResizer } })((theme) => ({
+  root: {
+    position: "absolute",
+    // The `outline` styles of the selected image add 3px to the edges, so we'll
+    // position this offset by 3px outside to the bottom right
+    bottom: -3,
+    right: -3,
+    width: 12,
+    height: 12,
+    background: theme.palette.primary.main,
+    cursor: "nwse-resize",
+  },
+}));
+
+export function ResizableImageResizer({
+  onResize,
+  className,
+}: ResizableImageResizerProps) {
+  const { classes, cx } = useStyles();
+  const [mouseDown, setMouseDown] = useState(false);
+
+  useEffect(() => {
+    const handleMouseMove = (event: MouseEvent) => {
+      onResize(event);
+    };
+
+    if (mouseDown) {
+      // If the user is currently holding down the resize handle, we'll have mouse
+      // movements fire the onResize callback (since the user would be "dragging" the
+      // handle)
+      window.addEventListener("mousemove", handleMouseMove);
+    }
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+    };
+  }, [mouseDown, onResize]);
+
+  useEffect(() => {
+    const handleMouseUp = () => setMouseDown(false);
+
+    window.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, []);
+
+  const handleMouseDown = useCallback((_event: React.MouseEvent) => {
+    setMouseDown(true);
+  }, []);
+
+  return (
+    // There isn't a great role to use here (perhaps role="separator" is the
+    // closest, as described here https://stackoverflow.com/a/43022983/4543977,
+    // but we don't do keyboard-based resizing so it doesn't make sense to have
+    // it keyboard focusable)
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div
+      aria-label="resize image"
+      className={cx(classes.root, className)}
+      onMouseDown={handleMouseDown}
+    />
+  );
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,4 +2,5 @@ export {
   default as useDebouncedFocus,
   type UseDebouncedFocusOptions,
 } from "./useDebouncedFocus";
+export { default as useEditorOnEditableUpdate } from "./useEditorOnEditableUpdate";
 export { default as useKeyDown } from "./useKeyDown";

--- a/src/hooks/useDebouncedFunction.ts
+++ b/src/hooks/useDebouncedFunction.ts
@@ -1,0 +1,54 @@
+import { debounce, type DebouncedFunc, type DebounceSettings } from "lodash";
+import { useEffect, useMemo, useRef } from "react";
+
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument */
+/**
+ * A hook for creating a stable debounced version of the given function.
+ *
+ * The approach here ensures we use a `ref` for the `func`, with a stable return
+ * value, somewhat similar to
+ * https://www.developerway.com/posts/debouncing-in-react. It also provides
+ * effectively the same API as the lodash function itself.
+ *
+ * @param func The function to debounce.
+ * @param wait ms to wait between calls.
+ * @param options lodash debounce options.
+ * @returns debounced version of `func`.
+ */
+export default function useDebouncedFunction<T extends (...args: any) => any>(
+  func: T | undefined,
+  wait: number,
+  options?: DebounceSettings
+): DebouncedFunc<T> {
+  const funcRef = useRef(func);
+
+  useEffect(() => {
+    funcRef.current = func;
+  }, [func]);
+
+  const debouncedCallback = useMemo(() => {
+    const funcWrapped = (...args: any) => funcRef.current?.(...args);
+    /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument */
+
+    return debounce(funcWrapped, wait, {
+      // We have to refer to each of the `options` individually in order to ensure our
+      // useMemo dependencies are correctly/explicit, satisfying the rules of hooks. We
+      // don't want to use the `options` object in the dependency array, since it's
+      // likely to be a new object on each render.
+      ...(options?.leading !== undefined && { leading: options.leading }),
+      ...(options?.maxWait !== undefined && { maxWait: options.maxWait }),
+      ...(options?.trailing !== undefined && { trailing: options.trailing }),
+    });
+  }, [wait, options?.leading, options?.maxWait, options?.trailing]);
+
+  // When we unmount or the user changes the debouncing wait/options, we'll cancel past
+  // invocations
+  useEffect(
+    () => () => {
+      debouncedCallback.cancel();
+    },
+    [debouncedCallback]
+  );
+
+  return debouncedCallback;
+}

--- a/src/hooks/useEditorOnEditableUpdate.ts
+++ b/src/hooks/useEditorOnEditableUpdate.ts
@@ -1,0 +1,64 @@
+import type { Editor, EditorEvents } from "@tiptap/core";
+import { useEffect, useRef } from "react";
+
+export type UseEditorOnEditableUpdateOptions = {
+  editor: Editor | null;
+  /**
+   * The function that will be called when editor.isEditable is changed. Set to
+   * null or undefined to turn off the listener.
+   */
+  callback?: ((props: EditorEvents["update"]) => void) | null | undefined;
+};
+
+/**
+ * A hook for listening to changes in the Tiptap editor isEditable state, via
+ * "update" event.
+ *
+ * This can be useful inside of ReactNodeViews that depend on editor isEditable
+ * state. As described here https://github.com/ueberdosis/tiptap/issues/3775,
+ * updates to editor isEditable do not trigger re-rendering of node views. Even
+ * editor state changes external to a given ReactNodeView component will not
+ * trigger re-render (which is probably a good thing most of the time, in terms
+ * of performance). As such, this hook can listen for editor.isEditable changes
+ * and can be used to force a re-render, update state, etc.
+ */
+export default function useEditorOnEditableUpdate({
+  editor,
+  callback,
+}: UseEditorOnEditableUpdateOptions): void {
+  const callbackRef = useRef(callback);
+  const isEditableRef = useRef(editor?.isEditable);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  const hasCallback = !!callback;
+  useEffect(() => {
+    if (!editor || editor.isDestroyed || !hasCallback) {
+      return;
+    }
+
+    isEditableRef.current = editor.isEditable;
+
+    function handleUpdate(props: EditorEvents["update"]) {
+      if (
+        !editor ||
+        editor.isDestroyed ||
+        editor.isEditable === isEditableRef.current
+      ) {
+        return;
+      }
+
+      // The editable state has changed!
+      isEditableRef.current = editor.isEditable;
+      callbackRef.current?.(props);
+    }
+
+    editor.on("update", handleUpdate);
+
+    return () => {
+      editor.off("update", handleUpdate);
+    };
+  }, [editor, hasCallback]);
+}

--- a/src/hooks/useForceUpdate.ts
+++ b/src/hooks/useForceUpdate.ts
@@ -1,0 +1,21 @@
+import { useReducer } from "react";
+
+export type UseForceUpdateResult = () => void;
+
+/**
+ * A hook that returns a function to call which will perform a force re-render
+ * of the given component.
+ *
+ * This should be used very sparingly! It's typically only needed in situations
+ * where the underlying Tiptap editor has updated some state external to React
+ * and there are no alternatives to update, like Tiptap's useEditor hook itself
+ * does
+ * https://github.com/ueberdosis/tiptap/blob/b0198eb14b98db5ca691bd9bfe698ffaddbc4ded/packages/react/src/useEditor.ts#L105-L113.
+ *
+ * Implementation taken from
+ * https://legacy.reactjs.org/docs/hooks-faq.html#is-there-something-like-forceupdate
+ */
+export default function useForceUpdate(): UseForceUpdateResult {
+  const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
+  return forceUpdate;
+}


### PR DESCRIPTION
For the reasons described here https://github.com/ueberdosis/tiptap/issues/3775, when toggling editable state, the `HeadingWithAnchorComponent`'s anchor wasn't showing/hiding properly. Similarly, the resizer handle in `ResizableImageComponent` would still show up when switching to editable=false, which would momentarily allow resizing when the node shouldn't have been editable.

Originally (see the first commit in this PR), I attempted to do this via listener to `editor.on("update",...)`, but ultimately decided instead to use CSS to show/how the relevant UI. That should be more performant (and is simpler) than listening to each editor update event via JS and force re-rendering with React. I've left the utilities around from that original approach (`useEditorOnEditableUpdate`, `useForceUpdate`, `useDebouncedFunction`) in case there useful later, but they're no longer used inside mui-tiptap.