### PR TITLE
Don't unmount `RichTextContent` when `variant` changes

### DIFF
--- a/src/FieldContainer.tsx
+++ b/src/FieldContainer.tsx
@@ -27,7 +27,7 @@ const fieldContainerClasses: FieldContainerClasses = getUtilityClasses(
 );
 
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-const useStyles = makeStyles<void, "notchedOutline">({
+const useStyles = makeStyles<void, "focused" | "disabled" | "notchedOutline">({
   name: { FieldContainer },
   uniqId: "Os7ZPW", // https://docs.tss-react.dev/nested-selectors#ssr
 })((theme, _params, classes) => {
@@ -38,6 +38,8 @@ const useStyles = makeStyles<void, "notchedOutline">({
   return {
     root: {},
 
+    // Class/styles applied to the root element if the component is using the
+    // "outlined" variant
     outlined: {
       borderRadius: theme.shape.borderRadius,
       padding: 1, //
@@ -46,28 +48,28 @@ const useStyles = makeStyles<void, "notchedOutline">({
       [`&:hover .${classes.notchedOutline}`]: {
         borderColor: theme.palette.text.primary,
       },
-    },
 
-    standard: {},
-
-    // Styles applied to the root element if the component is focused (if the
-    // `focused` prop is true).
-    focused: {
-      // Use && to trump &:hover above
-      [`&& .${classes.notchedOutline}`]: {
+      [`&.${classes.focused} .${classes.notchedOutline}`]: {
         borderColor: theme.palette.primary.main,
         borderWidth: 2,
       },
-    },
 
-    // Styles applied to the root element if the component is disabled (if the
-    // `disabled` prop is true)
-    disabled: {
-      // Use && to trump &:hover above
-      [`&& .${classes.notchedOutline}`]: {
+      [`&.${classes.disabled} .${classes.notchedOutline}`]: {
         borderColor: theme.palette.action.disabled,
       },
     },
+
+    // Class/styles applied to the root element if the component is using the
+    // "standard" variant
+    standard: {},
+
+    // Class/styles applied to the root element if the component is focused (if the
+    // `focused` prop is true)
+    focused: {},
+
+    // Styles applied to the root element if the component is disabled (if the
+    // `disabled` prop is true)
+    disabled: {},
 
     notchedOutline: {
       position: "absolute",
@@ -108,11 +110,14 @@ export default function FieldContainer({
       className={cx(
         fieldContainerClasses.root,
         classes.root,
-        focused && [fieldContainerClasses.focused, classes.focused],
-        disabled && [fieldContainerClasses.disabled, classes.disabled],
         variant === "outlined"
           ? [fieldContainerClasses.outlined, classes.outlined]
           : [fieldContainerClasses.standard, classes.standard],
+        // Note that we want focused and disabled styles of equal specificity to
+        // trump default root/outlined/standard styles, so they should be defined
+        // in this order
+        focused && [fieldContainerClasses.focused, classes.focused],
+        disabled && [fieldContainerClasses.disabled, classes.disabled],
         className
       )}
     >

--- a/src/FieldContainer.tsx
+++ b/src/FieldContainer.tsx
@@ -94,7 +94,7 @@ const useStyles = makeStyles<void, "focused" | "disabled" | "notchedOutline">({
  * `children`.
  */
 export default function FieldContainer({
-  variant,
+  variant = "outlined",
   children,
   focused,
   disabled,

--- a/src/FieldContainer.tsx
+++ b/src/FieldContainer.tsx
@@ -2,27 +2,33 @@ import type React from "react";
 import { makeStyles } from "tss-react/mui";
 import { Z_INDEXES, getUtilityClasses } from "./styles";
 
-export type OutlinedFieldClasses = ReturnType<typeof useStyles>["classes"];
+export type FieldContainerClasses = ReturnType<typeof useStyles>["classes"];
 
-export type OutlinedFieldProps = {
-  /** The content to render inside the outline. */
+export type FieldContainerProps = {
+  /**
+   * Which style to use for the field. "outlined" shows a border around the children,
+   * which updates its appearance depending on hover/focus states, like MUI's
+   * OutlinedInput. "standard" does not include any outer border.
+   */
+  variant?: "outlined" | "standard";
+  /** The content to render inside the container. */
   children: React.ReactNode;
   /** Class applied to the `root` element. */
   className?: string;
   /** Override or extend existing styles. */
-  classes?: Partial<OutlinedFieldClasses>;
+  classes?: Partial<FieldContainerClasses>;
   focused?: boolean;
   disabled?: boolean;
 };
 
-const outlinedFieldClasses: OutlinedFieldClasses = getUtilityClasses(
-  OutlinedField.name,
-  ["root", "focused", "disabled", "notchedOutline"]
+const fieldContainerClasses: FieldContainerClasses = getUtilityClasses(
+  FieldContainer.name,
+  ["root", "outlined", "standard", "focused", "disabled", "notchedOutline"]
 );
 
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
 const useStyles = makeStyles<void, "notchedOutline">({
-  name: { OutlinedField },
+  name: { FieldContainer },
   uniqId: "Os7ZPW", // https://docs.tss-react.dev/nested-selectors#ssr
 })((theme, _params, classes) => {
   // Based on the concept behind and styles of OutlinedInput and NotchedOutline
@@ -30,7 +36,9 @@ const useStyles = makeStyles<void, "notchedOutline">({
   // https://github.com/mui-org/material-ui/blob/a4972c5931e637611f6421ed2a5cc3f78207cbb2/packages/material-ui/src/OutlinedInput/OutlinedInput.js#L9-L37
   // https://github.com/mui/material-ui/blob/a4972c5931e637611f6421ed2a5cc3f78207cbb2/packages/material-ui/src/OutlinedInput/NotchedOutline.js
   return {
-    root: {
+    root: {},
+
+    outlined: {
       borderRadius: theme.shape.borderRadius,
       padding: 1, //
       position: "relative",
@@ -40,7 +48,10 @@ const useStyles = makeStyles<void, "notchedOutline">({
       },
     },
 
-    // Styles applied to the root element if the component is focused.
+    standard: {},
+
+    // Styles applied to the root element if the component is focused (if the
+    // `focused` prop is true).
     focused: {
       // Use && to trump &:hover above
       [`&& .${classes.notchedOutline}`]: {
@@ -49,7 +60,8 @@ const useStyles = makeStyles<void, "notchedOutline">({
       },
     },
 
-    // Styles applied to the root element if the component is disabled.
+    // Styles applied to the root element if the component is disabled (if the
+    // `disabled` prop is true)
     disabled: {
       // Use && to trump &:hover above
       [`&& .${classes.notchedOutline}`]: {
@@ -74,14 +86,19 @@ const useStyles = makeStyles<void, "notchedOutline">({
   };
 });
 
-/** A component used to show an outline around a given field/input child. */
-export default function OutlinedField({
+/**
+ * Renders an element with classes and styles that correspond to the state and
+ * style-variant of a user-input field, the content of which should be passed in as
+ * `children`.
+ */
+export default function FieldContainer({
+  variant,
   children,
   focused,
   disabled,
   classes: overrideClasses = {},
   className,
-}: OutlinedFieldProps) {
+}: FieldContainerProps) {
   const { classes, cx } = useStyles(undefined, {
     props: { classes: overrideClasses },
   });
@@ -89,21 +106,27 @@ export default function OutlinedField({
   return (
     <div
       className={cx(
-        outlinedFieldClasses.root,
+        fieldContainerClasses.root,
         classes.root,
-        focused && [outlinedFieldClasses.focused, classes.focused],
-        disabled && [outlinedFieldClasses.disabled, classes.disabled],
+        focused && [fieldContainerClasses.focused, classes.focused],
+        disabled && [fieldContainerClasses.disabled, classes.disabled],
+        variant === "outlined"
+          ? [fieldContainerClasses.outlined, classes.outlined]
+          : [fieldContainerClasses.standard, classes.standard],
         className
       )}
     >
       {children}
-      <div
-        className={cx(
-          outlinedFieldClasses.notchedOutline,
-          classes.notchedOutline
-        )}
-        aria-hidden
-      />
+
+      {variant === "outlined" && (
+        <div
+          className={cx(
+            fieldContainerClasses.notchedOutline,
+            classes.notchedOutline
+          )}
+          aria-hidden
+        />
+      )}
     </div>
   );
 }

--- a/src/RichTextField.tsx
+++ b/src/RichTextField.tsx
@@ -1,6 +1,6 @@
 import { makeStyles } from "tss-react/mui";
+import FieldContainer from "./FieldContainer";
 import MenuBar, { type MenuBarProps } from "./MenuBar";
-import OutlinedField from "./OutlinedField";
 import RichTextContent, { type RichTextContentProps } from "./RichTextContent";
 import { useRichTextEditorContext } from "./context";
 import useDebouncedFocus from "./hooks/useDebouncedFocus";
@@ -10,7 +10,11 @@ import DebounceRender from "./utils/DebounceRender";
 export type RichTextFieldClasses = ReturnType<typeof useStyles>["classes"];
 
 export type RichTextFieldProps = {
-  /** Which style to use for */
+  /**
+   * Which style to use for the field. "outlined" shows a border around the controls,
+   * editor, and footer, which updates depending on hover/focus states, like MUI's
+   * OutlinedInput. "standard" does not include any outer border.
+   */
   variant?: "outlined" | "standard";
   /** Class applied to the root element. */
   className?: string;
@@ -119,14 +123,25 @@ export default function RichTextField({
   });
   const editor = useRichTextEditorContext();
 
-  // Because the user interactions with the editor menu bar buttons unfocus the
-  // editor (since it's not part of the editor content), we'll debounce our
-  // visual focused state of the OutlinedField so that it doesn't "flash" when
-  // that happens
-  const isOutlinedFieldFocused = useDebouncedFocus({ editor });
+  // Because the user interactions with the editor menu bar buttons unfocus the editor
+  // (since it's not part of the editor content), we'll debounce our visual focused
+  // state so that the (outlined) field focus styles don't "flash" whenever that happens
+  const isFieldFocused = useDebouncedFocus({ editor });
 
-  const content = (
-    <>
+  return (
+    <FieldContainer
+      variant={variant}
+      focused={!disabled && isFieldFocused}
+      disabled={disabled}
+      className={cx(
+        richTextFieldClasses.root,
+        classes.root,
+        variant === "outlined"
+          ? [richTextFieldClasses.outlined, classes.outlined]
+          : [richTextFieldClasses.standard, classes.standard],
+        className
+      )}
+    >
       {controls && (
         <MenuBar
           {...MenuBarProps}
@@ -162,34 +177,6 @@ export default function RichTextField({
       />
 
       {footer}
-    </>
-  );
-
-  return variant === "outlined" ? (
-    <OutlinedField
-      focused={!disabled && isOutlinedFieldFocused}
-      disabled={disabled}
-      className={cx(
-        richTextFieldClasses.root,
-        classes.root,
-        richTextFieldClasses.outlined,
-        classes.outlined,
-        className
-      )}
-    >
-      {content}
-    </OutlinedField>
-  ) : (
-    <div
-      className={cx(
-        richTextFieldClasses.root,
-        classes.root,
-        richTextFieldClasses.standard,
-        classes.standard,
-        className
-      )}
-    >
-      {content}
-    </div>
+    </FieldContainer>
   );
 }

--- a/src/hooks/useDebouncedFocus.ts
+++ b/src/hooks/useDebouncedFocus.ts
@@ -16,7 +16,7 @@ export type UseDebouncedFocusOptions = {
  * menu bar buttons.
  *
  * This is useful for showing the focus state visually, as with the `focused`
- * prop of <OutlinedField />.
+ * prop of <FieldContainer />.
  */
 export default function useDebouncedFocus({
   editor,

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -15,8 +15,8 @@ export const Z_INDEXES = {
   // The menu bar must sit higher than the table components (like the
   // column-resize-handle and selectedCells) of the editor.
   MENU_BAR: 2,
-  // The notched outline of the OutlinedField should be at the same z-index as
-  // the menu-bar, so that it can contain/enclose it
+  // The notched outline of the "outlined" field variant should be at the same z-index
+  // as the menu-bar, so that it can contain/enclose it
   NOTCHED_OUTLINE: 2,
   // The bubble menus should appear on top of the menu bar
   BUBBLE_MENU: 3,


### PR DESCRIPTION
This consolidates the "outlined" vs "standard" DOM nodes/classes/styles into a single `FieldContainer` component, rather than conditionally rendering `<OutlinedField />` or some other DOM node.  With conditional-rendering approach, the `{content}` was being unmounted whenever the variant changed, which could cause a visual glitch as all Tiptap React node-views would have to re-render (so for instance, images and heading nodes would be temporarily empty during the transition).

**Breaking change**: the internal component `OutlinedField` has been renamed to `FieldContainer`. The associated utility classes like `MuiTiptap-OutlinedField-root`, `MuiTiptap-OutlinedField-notchedOutline`, etc are now named as `MuiTiptap-FieldContainer-root`, `MuiTiptap-FieldContainer-notchedOutline`, etc.