### PR TITLE
Add allowContantExport option to eslint-plugin-react-refresh

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -97,7 +97,10 @@
         "additionalHooks": "(useUpdateEffect)"
       }
     ],
-    "react-refresh/only-export-components": "warn",
+    "react-refresh/only-export-components": [
+      "warn",
+      { "allowConstantExport": true }
+    ],
     "tss-unused-classes/unused-classes": "warn"
   }
 }


### PR DESCRIPTION
As of 0.4.0, this option allows for exporting `const`s alongside components, since Vite supports HMR in that use-case: https://github.com/ArnaudBarre/eslint-plugin-react-refresh/tree/e92bee7ae32843d108e26b35241280b04271f8a2#allowconstantexport-v040