### PR TITLE
Make `extensions` required in props for RichTextEditor and ReadOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Or if you want full control over the UI, instead of `RichTextField`, you can bui
 
 ### Render read-only rich text content
 
-Use the `<RichTextReadOnly />` component and just pass in your HTML or ProseMirror JSON, like:
+Use the `<RichTextReadOnly />` component and just pass in your HTML or ProseMirror JSON and your configured Tiptap extensions, like:
 
 ```tsx
 <RichTextReadOnly content="<p>Hello world</p>" extensions={[StarterKit]} />

--- a/src/RichTextEditor.tsx
+++ b/src/RichTextEditor.tsx
@@ -6,11 +6,12 @@ import {
   useRef,
   type DependencyList,
 } from "react";
-import type { Except } from "type-fest";
+import type { Except, SetRequired } from "type-fest";
 import RichTextEditorProvider from "./RichTextEditorProvider";
 import RichTextField, { type RichTextFieldProps } from "./RichTextField";
 
-export type RichTextEditorProps = Partial<EditorOptions> & {
+export interface RichTextEditorProps
+  extends SetRequired<Partial<EditorOptions>, "extensions"> {
   /**
    * Render the controls content to show inside the menu bar atop the editor
    * content. Typically you will want to render a <MenuControlsContainer>
@@ -47,7 +48,7 @@ export type RichTextEditorProps = Partial<EditorOptions> & {
   editorDependencies?: DependencyList;
   /** Class applied to the root element. */
   className?: string;
-};
+}
 
 export type RichTextEditorRef = {
   editor: Editor | null;

--- a/src/RichTextReadOnly.tsx
+++ b/src/RichTextReadOnly.tsx
@@ -1,9 +1,12 @@
 import { useEditor, type EditorOptions } from "@tiptap/react";
-import type { Except } from "type-fest";
+import type { Except, SetRequired } from "type-fest";
 import RichTextContent from "./RichTextContent";
 import RichTextEditorProvider from "./RichTextEditorProvider";
 
-export type RichTextReadOnlyProps = Partial<Except<EditorOptions, "editable">>;
+export type RichTextReadOnlyProps = SetRequired<
+  Partial<Except<EditorOptions, "editable">>,
+  "extensions"
+>;
 
 function RichTextReadOnlyInternal(props: RichTextReadOnlyProps) {
   const editor = useEditor({


### PR DESCRIPTION
See discussion here https://github.com/sjdemartini/mui-tiptap/issues/91#issuecomment-1632863251

These components won't work without some extensions provided, so improve upon the typing we get from Tiptap and specify `extensions` as a required prop. Note that an empty array could still "pass" typing, but at least it's a hint that a real value is required, so shouldn't be as likely to run into a confusing error, like in https://github.com/sjdemartini/mui-tiptap/issues/91#issuecomment-1632623476. (For instance, you always need the [`Document`](https://tiptap.dev/api/nodes/document) extension at the very least.)