### PR TITLE
Fix MenuSelect tooltipTitle to use prop, and allow user to specify tooltip for MenuSelectHeading

### DIFF
--- a/src/controls/MenuSelect.tsx
+++ b/src/controls/MenuSelect.tsx
@@ -101,7 +101,7 @@ export default function MenuSelect<T>({
   );
   return tooltipTitle ? (
     <MenuButtonTooltip
-      label="Align"
+      label={tooltipTitle}
       contentWrapperClassName={classes.rootTooltipWrapper}
       open={tooltipOpen}
     >

--- a/src/controls/MenuSelectHeading.tsx
+++ b/src/controls/MenuSelectHeading.tsx
@@ -8,6 +8,15 @@ import { getEditorStyles } from "../styles";
 import MenuButtonTooltip from "./MenuButtonTooltip";
 import MenuSelect from "./MenuSelect";
 
+export type MenuSelectHeadingProps = {
+  /**
+   * Set a tooltip title used when hovering over the select element itself. By
+   * default, no tooltip is used for the main select element. (Tooltips are
+   * shown per-option in the dropdown.)
+   */
+  tooltipTitle?: string;
+};
+
 const useStyles = makeStyles({ name: { MenuSelectHeading } })((theme) => {
   const editorStyles = getEditorStyles(theme);
   return {
@@ -88,7 +97,9 @@ const LEVEL_TO_HEADING_OPTION_VALUE = {
   6: HEADING_OPTION_VALUES.Heading6,
 } as const;
 
-export default function MenuSelectHeading() {
+export default function MenuSelectHeading({
+  tooltipTitle,
+}: MenuSelectHeadingProps) {
   const { classes, cx } = useStyles();
   const editor = useRichTextEditorContext();
 
@@ -149,6 +160,7 @@ export default function MenuSelectHeading() {
     // below since we have `displayEmpty=true`, and the types don't properly
     // handle that scenario.
     <MenuSelect<HeadingOptionValue | "">
+      tooltipTitle={tooltipTitle}
       onChange={handleHeadingType}
       disabled={
         !editor?.isEditable ||

--- a/src/controls/MenuSelectTextAlign.tsx
+++ b/src/controls/MenuSelectTextAlign.tsx
@@ -17,6 +17,10 @@ import type { TextAlignOptions } from "@tiptap/extension-text-align";
 import MenuSelect from "./MenuSelect";
 
 export type MenuSelectTextAlignProps = {
+  /**
+   * The tooltip title used when hovering over the select element itself. By
+   * default "Align".
+   */
   tooltipTitle?: string;
 };
 

--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -108,7 +108,10 @@ export {
   type MenuControlsContainerProps,
 } from "./MenuControlsContainer";
 export { default as MenuSelect, type MenuSelectProps } from "./MenuSelect";
-export { default as MenuSelectHeading } from "./MenuSelectHeading";
+export {
+  default as MenuSelectHeading,
+  type MenuSelectHeadingProps,
+} from "./MenuSelectHeading";
 export {
   default as MenuSelectTextAlign,
   type MenuSelectTextAlignProps,


### PR DESCRIPTION
By mistake, `MenuSelect` was ignoring the `tooltipTitle` prop's value and always using "Align" as the tooltip.

This also updates `MenuSelectHeading` to allow users to specify a `tooltipTitle` (by default none is shown).
