### PR TITLE
Make the MenuSelectFontSize and MenuSelectHeading components more configurable

### DIFF
--- a/src/controls/MenuSelect.tsx
+++ b/src/controls/MenuSelect.tsx
@@ -61,6 +61,7 @@ export default function MenuSelect<T>({
       margin="none"
       variant="outlined"
       size="small"
+      {...selectProps}
       onMouseEnter={(...args) => {
         setTooltipOpen(true);
         selectProps.onMouseEnter?.(...args);
@@ -73,7 +74,6 @@ export default function MenuSelect<T>({
         setTooltipOpen(false);
         selectProps.onClick?.(...args);
       }}
-      {...selectProps}
       inputProps={{
         ...selectProps.inputProps,
         className: cx(classes.input, selectProps.inputProps?.className),

--- a/src/controls/MenuSelectFontSize.tsx
+++ b/src/controls/MenuSelectFontSize.tsx
@@ -34,6 +34,11 @@ export interface MenuSelectFontSizeProps
    * back to its default. By default false.
    */
   hideUnsetOption?: boolean;
+  /**
+   * What to render in the Select when no font-size is currently set for the
+   * selected text. By default, uses the FormatSize MUI icon.
+   */
+  emptyValue?: React.ReactNode;
 }
 
 const useStyles = makeStyles({ name: { MenuSelectFontSize } })({
@@ -89,6 +94,7 @@ export default function MenuSelectFontSize({
   sizeOptions = DEFAULT_FONT_SIZE_SELECT_OPTIONS,
   hideUnsetOption = false,
   unsetOptionContent = "Default",
+  emptyValue,
   ...menuSelectProps
 }: MenuSelectFontSizeProps) {
   const { classes, cx } = useStyles();
@@ -118,7 +124,7 @@ export default function MenuSelectFontSize({
           // this does, so it's visually similar to other menu button controls,
           // more intuitive, and more meaningful and compact than some other
           // placeholder value here
-          return <FormatSize className={classes.fontSizeIcon} />;
+          return emptyValue ?? <FormatSize className={classes.fontSizeIcon} />;
         }
         return stripPxFromValue(value);
       }}

--- a/src/controls/MenuSelectHeading.tsx
+++ b/src/controls/MenuSelectHeading.tsx
@@ -3,19 +3,16 @@ import { MenuItem, type SelectChangeEvent } from "@mui/material";
 import type { Heading, Level } from "@tiptap/extension-heading";
 import { useCallback, useMemo } from "react";
 import { makeStyles } from "tss-react/mui";
+import type { Except } from "type-fest";
 import { useRichTextEditorContext } from "../context";
 import { getEditorStyles } from "../styles";
 import MenuButtonTooltip from "./MenuButtonTooltip";
-import MenuSelect from "./MenuSelect";
+import MenuSelect, { type MenuSelectProps } from "./MenuSelect";
 
-export type MenuSelectHeadingProps = {
-  /**
-   * Set a tooltip title used when hovering over the select element itself. By
-   * default, no tooltip is used for the main select element. (Tooltips are
-   * shown per-option in the dropdown.)
-   */
-  tooltipTitle?: string;
-};
+export type MenuSelectHeadingProps = Except<
+  MenuSelectProps<HeadingOptionValue | "">,
+  "value" | "children"
+>;
 
 const useStyles = makeStyles({ name: { MenuSelectHeading } })((theme) => {
   const editorStyles = getEditorStyles(theme);
@@ -77,7 +74,7 @@ const HEADING_OPTION_VALUES = {
   Heading6: "Heading 6",
 } as const;
 
-type HeadingOptionValue =
+export type HeadingOptionValue =
   (typeof HEADING_OPTION_VALUES)[keyof typeof HEADING_OPTION_VALUES];
 
 const HEADING_OPTION_VALUE_TO_LEVEL = {
@@ -98,7 +95,7 @@ const LEVEL_TO_HEADING_OPTION_VALUE = {
 } as const;
 
 export default function MenuSelectHeading({
-  tooltipTitle,
+  ...menuSelectProps
 }: MenuSelectHeadingProps) {
   const { classes, cx } = useStyles();
   const editor = useRichTextEditorContext();
@@ -160,7 +157,6 @@ export default function MenuSelectHeading({
     // below since we have `displayEmpty=true`, and the types don't properly
     // handle that scenario.
     <MenuSelect<HeadingOptionValue | "">
-      tooltipTitle={tooltipTitle}
       onChange={handleHeadingType}
       disabled={
         !editor?.isEditable ||
@@ -174,9 +170,14 @@ export default function MenuSelectHeading({
         return selected;
       }}
       aria-label="Heading type"
+      {...menuSelectProps}
       value={selectedValue}
       inputProps={{
-        className: classes.selectInput,
+        ...menuSelectProps.inputProps,
+        className: cx(
+          classes.selectInput,
+          menuSelectProps.inputProps?.className
+        ),
       }}
     >
       <MenuItem

--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -114,6 +114,7 @@ export {
 } from "./MenuSelectFontSize";
 export {
   default as MenuSelectHeading,
+  type HeadingOptionValue,
   type MenuSelectHeadingProps,
 } from "./MenuSelectHeading";
 export {


### PR DESCRIPTION
There are three new `MenuSelectFontSize` props to control (1) `unsetOptionContent` what text we display for the "unset" option, and (2) `hideUnsetOption` whether to hide that dropdown option entirely, and (3) `emptyValue` what to render for the Select itself when no font-size is set for the current text (to override showing the FormatSize icon).

Also, we now allow essentially all `MenuSelect` (and thus `Select`) props to be provided for both `MenuSelectFontSize` and `MenuSelectHeading`. This includes `tooltipTitle`, `sx`, `className`, etc to do styling.

For instance:

```tsx
<MenuSelectFontSize
  emptyValue="16"  // Display "16" if unset since that's effectively our default font size
  unsetOptionContent={<span>Reset</span>}
  tooltipTitle="Change font size"
  sx={{ "& .MuiSelect-select": { width: 80 } }}
/>
```


![Screenshot 2023-07-14 at 12 58 58 PM](https://github.com/sjdemartini/mui-tiptap/assets/1647130/97ee83b9-f767-4f4e-84fb-f37b80c4e2b8)
