### PR TITLE
Ignore Tiptap links in markdown-link-check in README

### DIFF
--- a/.markdown-link-check-config.json
+++ b/.markdown-link-check-config.json
@@ -1,0 +1,9 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://tiptap.dev/"
+    }
+  ],
+  "timeout": "10s",
+  "retryOn429": true
+}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "format:check": "prettier --check .",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx src --fix",
     "lint:check": "eslint --ext .js,.jsx,.ts,.tsx src",
-    "md-link:check": "markdown-link-check -v -p *.md",
+    "md-link:check": "markdown-link-check -v -p *.md -c .markdown-link-check-config.json",
     "preinstall": "npx only-allow pnpm",
     "test": "vitest run",
     "test:watch": "vitest watch",


### PR DESCRIPTION
Tiptap's site is timing out a lot of the time, leading to spurious build failures like
https://github.com/sjdemartini/mui-tiptap/actions/runs/5558982096/jobs/10154638405#step:11:80

It's also slowing down the CI runs. So better to just ignore them.

The main reason we have markdown-link-check is for local markdown links (not external web pages), so this was only a nice to have.
