### PR TITLE
Don't reset `RichTextEditor` document upon `content` prop changes, but do so with `RichTextReadOnly`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@
   - [Components](#components)
     - [Controls components](#controls-components)
 - [Tips and suggestions](#tips-and-suggestions)
-  - [Defining your editor `extensions`](#defining-your-editor-extensions)
+  - [Choosing your editor `extensions`](#choosing-your-editor-extensions)
+    - [Extension precedence and ordering](#extension-precedence-and-ordering)
+    - [Other extension tips](#other-extension-tips)
 - [Contributing](#contributing)
 
 </details>
@@ -302,9 +304,11 @@ Typically you will define your controls (for `RichTextEditor`’s `renderControl
 
 ## Tips and suggestions
 
-### Defining your editor `extensions`
+### Choosing your editor `extensions`
 
-[Browse Tiptap extensions](https://tiptap.dev/extensions).
+Browse [the official Tiptap extensions](https://tiptap.dev/extensions), and check out [`mui-tiptap`’s additional extensions](#tiptap-extensions). The easiest way to get started is to install and use Tiptap’s [`StarterKit` extension](https://tiptap.dev/api/extensions/starter-kit), which bundles several common Tiptap extensions.
+
+#### Extension precedence and ordering
 
 Extensions that need to be higher precedence (for their keyboard shortcuts, etc.) should come **later** in your extensions array. (See Tiptap's general notes on extension plugin precedence and ordering [here](https://github.com/ueberdosis/tiptap/issues/1547#issuecomment-890848888).) For example:
 
@@ -314,9 +318,9 @@ Extensions that need to be higher precedence (for their keyboard shortcuts, etc.
   - Otherwise, the keyboard shortcut for `Blockquote` (Cmd+Shift+B) will mistakenly toggle the bold mark (due to its “overlapping” Cmd+b shortcut). (See related Tiptap issues [here](https://github.com/ueberdosis/tiptap/issues/4005) and [here](https://github.com/ueberdosis/tiptap/issues/4006).)
 - Put the `Mention` extension after list-related extensions (`TaskList`, `TaskItem`, `BulletList`, `OrderedList`, `ListItem`, etc.) so that pressing "Enter" on a mention suggestion will select it, rather than create a new list item (when trying to @mention something within an existing list item).
 
-Other extension tips:
+#### Other extension tips
 
-- If you'd like `Subscript` and `Superscript` extensions to be mutually exclusive, so that text can't be both superscript and subscript simultaneously, use the `excludes` configuration parameter to exclude each other.
+- If you’d like [`Subscript`](https://tiptap.dev/api/marks/subscript) and [`Superscript`](https://tiptap.dev/api/marks/superscript) extensions to be mutually exclusive, so that text can't be both superscript and subscript simultaneously, use the `excludes` configuration parameter to exclude each other.
 
   - As described in [this Tiptap issue](https://github.com/ueberdosis/tiptap/pull/1436#issuecomment-1031937768). For instance:
 
@@ -328,6 +332,12 @@ Other extension tips:
       excludes: "subscript",
     });
     ```
+
+- If you’d prefer to be able to style your `Code` marks (e.g., make them bold, add links, change font size), you should extend the extension and override the `excludes` field, since by default it uses `"_"` to [make it mutually exclusive from all other marks](https://tiptap.dev/api/schema#excludes). For instance, to allow you to apply `Code` with any other inline mark, use `excludes: ""`, or to make it work with all except italics, use:
+
+  ```ts
+  Code.extend({ excludes: "italic" });
+  ```
 
 ## Contributing
 

--- a/src/RichTextReadOnly.tsx
+++ b/src/RichTextReadOnly.tsx
@@ -51,23 +51,28 @@ function RichTextReadOnlyInternal(props: RichTextReadOnlyProps) {
 /**
  * An all-in-one component to directly render read-only Tiptap editor content.
  *
- * While useEditor, RichTextEditorProvider, and RichTextContent can be used as
- * read-only via the editor's `editable` prop, this is a simpler and more
- * efficient version that only renders content and nothing more (e.g., does not
- * instantiate a toolbar, bubble menu, etc. that can't/won't be used in a
- * read-only context, and skips instantiating the editor at all if there's no
- * content to display). It can be used directly without needing the provider or
- * a separate useEditor invocation.
+ * When to use this component:
+ * - You just want to render editor HTML/JSON content directly, without any
+ *   outlined field styling, menu bar, extra setup, etc.
+ * - You want a convenient way to render content that re-renders as the
+ *   `content` prop changes.
+ *
+ * Though RichtextEditor (or useEditor, RichTextEditorProvider, and
+ * RichTextContent) can be used as read-only via the editor's `editable` prop,
+ * this is a simpler and more efficient version that only renders content and
+ * nothing more (e.g., skips instantiating the editor at all if there's no
+ * content to display, and does not contain additional rendering logic related
+ * to controls, outlined field UI state, etc.).
  *
  * Example:
  * <RichTextReadOnly content="<p>Hello world</p>" extensions={[StarterKit]} />
  */
-export default function RichTextReadOnly(editorProps: RichTextReadOnlyProps) {
-  if (!editorProps.content) {
-    // Don't bother instantiating an editor at all (for performance) if we have no
-    // content
+export default function RichTextReadOnly(props: RichTextReadOnlyProps) {
+  if (!props.content) {
+    // Don't bother instantiating an editor at all (for performance) if we have
+    // no content
     return null;
   }
 
-  return <RichTextReadOnlyInternal {...editorProps} />;
+  return <RichTextReadOnlyInternal {...props} />;
 }

--- a/src/RichTextReadOnly.tsx
+++ b/src/RichTextReadOnly.tsx
@@ -1,4 +1,5 @@
 import { useEditor, type EditorOptions } from "@tiptap/react";
+import { useEffect, useRef } from "react";
 import type { Except, SetRequired } from "type-fest";
 import RichTextContent from "./RichTextContent";
 import RichTextEditorProvider from "./RichTextEditorProvider";
@@ -13,6 +14,32 @@ function RichTextReadOnlyInternal(props: RichTextReadOnlyProps) {
     ...props,
     editable: false,
   });
+
+  // Update content if/when it changes
+  const previousContent = useRef(props.content);
+  useEffect(() => {
+    if (
+      !editor ||
+      editor.isDestroyed ||
+      props.content === undefined ||
+      props.content === previousContent.current
+    ) {
+      return;
+    }
+    // We use queueMicrotask to avoid any flushSync console errors as
+    // mentioned here
+    // https://github.com/ueberdosis/tiptap/issues/3764#issuecomment-1546854730
+    queueMicrotask(() => {
+      // Validate that props.content isn't undefined again to appease TS
+      if (props.content !== undefined) {
+        editor.commands.setContent(props.content);
+      }
+    });
+  }, [props.content, editor]);
+
+  useEffect(() => {
+    previousContent.current = props.content;
+  }, [props.content]);
 
   return (
     <RichTextEditorProvider editor={editor}>

--- a/src/demo/Editor.tsx
+++ b/src/demo/Editor.tsx
@@ -3,6 +3,7 @@ import { Box, Button, Stack, Typography } from "@mui/material";
 import { useRef, useState } from "react";
 import LinkBubbleMenu from "../LinkBubbleMenu";
 import RichTextEditor, { type RichTextEditorRef } from "../RichTextEditor";
+import RichTextReadOnly from "../RichTextReadOnly";
 import TableBubbleMenu from "../TableBubbleMenu";
 import MenuButton from "../controls/MenuButton";
 import EditorMenuControls from "./EditorMenuControls";
@@ -117,9 +118,22 @@ export default function Editor() {
       </Typography>
 
       {submittedContent ? (
-        <pre style={{ marginTop: 10, overflow: "auto", maxWidth: "100%" }}>
-          <code>{submittedContent}</code>
-        </pre>
+        <>
+          <pre style={{ marginTop: 10, overflow: "auto", maxWidth: "100%" }}>
+            <code>{submittedContent}</code>
+          </pre>
+
+          <Box mt={3}>
+            <Typography variant="overline" sx={{ mb: 2 }}>
+              Read-only saved snapshot:
+            </Typography>
+
+            <RichTextReadOnly
+              content={submittedContent}
+              extensions={extensions}
+            />
+          </Box>
+        </>
       ) : (
         <>
           Press “Save” above to show the HTML markup for the editor content.


### PR DESCRIPTION
- `RichTextEditor` now will *not* reset the editor's document content when its `content` prop changes. This should make the component more generally flexible, with the option for users to customize when/how they want to `setContent`.  See the new README section on "Re-rendering RichTextEditor when content changes" for more details and alternative approaches. (This is all related to the discussion here https://github.com/sjdemartini/mui-tiptap/issues/91#issuecomment-1629911609.)
- `RichTextReadOnly` now *will* reset the editor's document content when its `content` prop changes. This is how it should've worked all along, since it's read-only and should be treated as a more "pure" renderer.
- README has been updated with more details about when/how to use these two components.
- There are additional tips on editor extensions in the README, in a slightly improved format.