### PR TITLE
Change imports in demo to use top-level index

### DIFF
--- a/src/demo/Editor.tsx
+++ b/src/demo/Editor.tsx
@@ -1,11 +1,14 @@
 import { Lock, LockOpen, TextFields } from "@mui/icons-material";
 import { Box, Button, Stack, Typography } from "@mui/material";
 import { useRef, useState } from "react";
-import LinkBubbleMenu from "../LinkBubbleMenu";
-import RichTextEditor, { type RichTextEditorRef } from "../RichTextEditor";
-import RichTextReadOnly from "../RichTextReadOnly";
-import TableBubbleMenu from "../TableBubbleMenu";
-import MenuButton from "../controls/MenuButton";
+import {
+  LinkBubbleMenu,
+  MenuButton,
+  RichTextEditor,
+  RichTextReadOnly,
+  TableBubbleMenu,
+  type RichTextEditorRef,
+} from "../";
 import EditorMenuControls from "./EditorMenuControls";
 import useExtensions from "./useExtensions";
 

--- a/src/demo/EditorMenuControls.tsx
+++ b/src/demo/EditorMenuControls.tsx
@@ -22,12 +22,12 @@ import {
   MenuButtonUnindent,
   MenuControlsContainer,
   MenuDivider,
+  MenuSelectFontSize,
   MenuSelectHeading,
   MenuSelectTextAlign,
+  isTouchDevice,
+  useRichTextEditorContext,
 } from "../";
-import { useRichTextEditorContext } from "../context";
-import MenuSelectFontSize from "../controls/MenuSelectFontSize";
-import { isTouchDevice } from "../utils/platform";
 
 export default function EditorMenuControls() {
   const editor = useRichTextEditorContext();


### PR DESCRIPTION
This is more equivalent to how an external package will import (except `from "mui-tiptap"` rather than a relative path).

Makes it simpler to translate the local demo to the CodeSandbox linked from the README: https://codesandbox.io/p/sandbox/mui-tiptap-demo-3zl2l6
