### PR TITLE
Allow users to override MenuSelectTextAlign props, options, etc.

### DIFF
--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -120,6 +120,7 @@ export {
 export {
   default as MenuSelectTextAlign,
   type MenuSelectTextAlignProps,
+  type TextAlignSelectOption,
 } from "./MenuSelectTextAlign";
 export {
   default as TableMenuControls,


### PR DESCRIPTION
This should enable users to provide their own (localized) content for each option, etc. 

Toward improving https://github.com/sjdemartini/mui-tiptap/issues/59

Example:
```tsx
      <MenuSelectTextAlign
        tooltipTitle="Change text alignment"
        alignmentOptions={[
          {
            alignment: "left",
            label: "Text-align left",
            shortcutKeys: ["mod", "Shift", "L"],
            IconComponent: FaAlignLeft,
          },
          {
            alignment: "right",
            label: "Text-align right",
            shortcutKeys: ["mod", "Shift", "R"],
            IconComponent: FaAlignRight,
          },
        ]}
      />
```

<img width="231" alt="Screenshot 2023-07-16 at 6 56 11 PM" src="https://github.com/sjdemartini/mui-tiptap/assets/1647130/9f3cefe6-55dc-4551-89e0-2450fd12acc4">

