### PR TITLE
Allow user to override LinkBubbleMenu and TableMenuControls labels to support localization

### DIFF
--- a/src/LinkBubbleMenu/EditLinkMenuContent.tsx
+++ b/src/LinkBubbleMenu/EditLinkMenuContent.tsx
@@ -1,17 +1,43 @@
 import { Button, DialogActions, TextField, Typography } from "@mui/material";
 import { getMarkRange, getMarkType, type Editor } from "@tiptap/core";
 import encodeurl from "encodeurl";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import useKeyDown from "../hooks/useKeyDown";
 
-type Props = {
+export type EditLinkMenuContentProps = {
   editor: Editor;
   onCancel: () => void;
   onSave: ({ text, link }: { text: string; link: string }) => void;
+  /** Override default text content/labels used within the component. */
+  labels?: {
+    /** Menu title shown when adding a new link. */
+    editLinkAddTitle?: ReactNode;
+    /** Menu title shown when editing an existing link. */
+    editLinkEditTitle?: ReactNode;
+    /** Label for the input text field to edit the text content of a link. */
+    editLinkTextInputLabel?: ReactNode;
+    /** Label for the input text field to edit the href (URL) of a link. */
+    editLinkHrefInputLabel?: ReactNode;
+    /** Content shown in the button used to cancel editing/adding a link. */
+    editLinkCancelButtonLabel?: ReactNode;
+    /** Content shown in the button used to save when editing/adding a link. */
+    editLinkSaveButtonLabel?: ReactNode;
+  };
 };
 
 /** Shown when a user is adding/editing a Link for Tiptap. */
-function EditLinkMenuContent({ editor, onCancel, onSave }: Props) {
+export default function EditLinkMenuContent({
+  editor,
+  onCancel,
+  onSave,
+  labels,
+}: EditLinkMenuContentProps) {
   const existingHref = editor.isActive("link")
     ? (editor.getAttributes("link").href as string)
     : "";
@@ -41,7 +67,9 @@ function EditLinkMenuContent({ editor, onCancel, onSave }: Props) {
   // If there's already a link where the user has clicked, they're "editing",
   // otherwise the menu has been brought up to add a new link
   const isNewLink = !existingHref;
-  const editMenuTitle = isNewLink ? "Add link" : "Edit link";
+  const addLinkTitle = labels?.editLinkAddTitle ?? "Add link";
+  const editLinkTitle = labels?.editLinkEditTitle ?? "Edit link";
+  const editMenuTitle = isNewLink ? addLinkTitle : editLinkTitle;
 
   // When bringing up the Popper of the `ControlledBubbleMenu` and using
   // autoFocus on the TextField elements, it is causing a scroll jump as
@@ -121,7 +149,7 @@ function EditLinkMenuContent({ editor, onCancel, onSave }: Props) {
         value={textValue}
         disabled={isSubmitting}
         onChange={(event) => setTextValue(event.target.value)}
-        label="Text"
+        label={labels?.editLinkTextInputLabel ?? "Text"}
         margin="normal"
         size="small"
         fullWidth
@@ -133,7 +161,7 @@ function EditLinkMenuContent({ editor, onCancel, onSave }: Props) {
         value={hrefValue}
         onChange={(event) => setHrefValue(event.target.value)}
         disabled={isSubmitting}
-        label="Link"
+        label={labels?.editLinkHrefInputLabel ?? "Link"}
         margin="dense"
         size="small"
         type="url"
@@ -152,8 +180,9 @@ function EditLinkMenuContent({ editor, onCancel, onSave }: Props) {
 
       <DialogActions sx={{ px: 0 }}>
         <Button onClick={onCancel} variant="outlined" size="small">
-          Cancel
+          {labels?.editLinkCancelButtonLabel ?? "Cancel"}
         </Button>
+
         <Button
           type="submit"
           color="primary"
@@ -161,11 +190,9 @@ function EditLinkMenuContent({ editor, onCancel, onSave }: Props) {
           size="small"
           disabled={isSubmitting}
         >
-          Save
+          {labels?.editLinkSaveButtonLabel ?? "Save"}
         </Button>
       </DialogActions>
     </form>
   );
 }
-
-export default EditLinkMenuContent;

--- a/src/LinkBubbleMenu/ViewLinkMenuContent.tsx
+++ b/src/LinkBubbleMenu/ViewLinkMenuContent.tsx
@@ -1,15 +1,23 @@
 import { Button, DialogActions, Link } from "@mui/material";
 import { getMarkRange, getMarkType, type Editor } from "@tiptap/core";
 import truncate from "lodash/truncate";
+import type { ReactNode } from "react";
 import { makeStyles } from "tss-react/mui";
 import useKeyDown from "../hooks/useKeyDown";
 import truncateMiddle from "../utils/truncateMiddle";
 
-type Props = {
+export type ViewLinkMenuContentProps = {
   editor: Editor;
   onCancel: () => void;
   onEdit: () => void;
   onRemove: () => void;
+  /** Override default text content/labels used within the component. */
+  labels?: {
+    /** Content shown in the button used to start editing the link. */
+    viewLinkEditButtonLabel?: ReactNode;
+    /** Content shown in the button used to remove the link. */
+    viewLinkRemoveButtonLabel?: ReactNode;
+  };
 };
 
 const useStyles = makeStyles({ name: { ViewLinkMenuContent } })({
@@ -24,7 +32,8 @@ export default function ViewLinkMenuContent({
   onCancel,
   onEdit,
   onRemove,
-}: Props) {
+  labels,
+}: ViewLinkMenuContentProps) {
   const { classes } = useStyles();
   const linkRange = getMarkRange(
     editor.state.selection.$to,
@@ -64,7 +73,7 @@ export default function ViewLinkMenuContent({
           variant="outlined"
           size="small"
         >
-          Edit
+          {labels?.viewLinkEditButtonLabel ?? "Edit"}
         </Button>
         <Button
           onClick={onRemove}
@@ -72,7 +81,7 @@ export default function ViewLinkMenuContent({
           variant="outlined"
           size="small"
         >
-          Remove
+          {labels?.viewLinkRemoveButtonLabel ?? "Remove"}
         </Button>
       </DialogActions>
     </>

--- a/src/LinkBubbleMenu/index.tsx
+++ b/src/LinkBubbleMenu/index.tsx
@@ -9,12 +9,24 @@ import {
   LinkMenuState,
   type LinkBubbleMenuHandlerStorage,
 } from "../extensions/LinkBubbleMenuHandler";
-import EditLinkMenuContent from "./EditLinkMenuContent";
-import ViewLinkMenuContent from "./ViewLinkMenuContent";
+import EditLinkMenuContent, {
+  type EditLinkMenuContentProps,
+} from "./EditLinkMenuContent";
+import ViewLinkMenuContent, {
+  type ViewLinkMenuContentProps,
+} from "./ViewLinkMenuContent";
 
-export type LinkBubbleMenuProps = Partial<
-  Except<ControlledBubbleMenuProps, "open" | "editor" | "children">
->;
+export interface LinkBubbleMenuProps
+  extends Partial<
+    Except<ControlledBubbleMenuProps, "open" | "editor" | "children">
+  > {
+  /**
+   * Override the default text content/labels in this interface. For any value
+   * that is omitted in this object, it falls back to the default content.
+   */
+  labels?: ViewLinkMenuContentProps["labels"] &
+    EditLinkMenuContentProps["labels"];
+}
 
 const useStyles = makeStyles({ name: { LinkBubbleMenu } })((theme) => ({
   content: {
@@ -40,6 +52,7 @@ const useStyles = makeStyles({ name: { LinkBubbleMenu } })((theme) => ({
  * `useEditor`).
  */
 export default function LinkBubbleMenu({
+  labels,
   ...controlledBubbleMenuProps
 }: LinkBubbleMenuProps) {
   const { classes } = useStyles();
@@ -77,6 +90,7 @@ export default function LinkBubbleMenu({
             .focus()
             .run();
         }}
+        labels={labels}
       />
     );
   } else if (menuState === LinkMenuState.EDIT_LINK) {
@@ -120,6 +134,7 @@ export default function LinkBubbleMenu({
 
           editor.commands.closeLinkBubbleMenu();
         }}
+        labels={labels}
       />
     );
   }

--- a/src/TableBubbleMenu.tsx
+++ b/src/TableBubbleMenu.tsx
@@ -6,7 +6,9 @@ import ControlledBubbleMenu, {
   type ControlledBubbleMenuProps,
 } from "./ControlledBubbleMenu";
 import { useRichTextEditorContext } from "./context";
-import TableMenuControls from "./controls/TableMenuControls";
+import TableMenuControls, {
+  type TableMenuControlsProps,
+} from "./controls/TableMenuControls";
 import { useDebouncedFocus } from "./hooks";
 import DebounceRender, {
   type DebounceRenderProps,
@@ -26,6 +28,11 @@ export type TableBubbleMenuProps = {
    * interval, if `disableDebounce` is not true.
    */
   DebounceProps?: Except<DebounceRenderProps, "children">;
+  /**
+   * Override the default labels for any of the menu buttons. If any is omitted,
+   * it falls back to the default mui-tiptap label for that label.
+   */
+  labels?: TableMenuControlsProps["labels"];
 } & Partial<Except<ControlledBubbleMenuProps, "open" | "editor" | "children">>;
 
 const useStyles = makeStyles({
@@ -57,6 +64,7 @@ const useStyles = makeStyles({
 export default function TableBubbleMenu({
   disableDebounce = false,
   DebounceProps,
+  labels,
   ...controlledBubbleMenuProps
 }: TableBubbleMenuProps) {
   const editor = useRichTextEditorContext();
@@ -131,7 +139,9 @@ export default function TableBubbleMenu({
     return null;
   }
 
-  const controls = <TableMenuControls className={classes.controls} />;
+  const controls = (
+    <TableMenuControls className={classes.controls} labels={labels} />
+  );
 
   return (
     <ControlledBubbleMenu

--- a/src/controls/TableMenuControls.tsx
+++ b/src/controls/TableMenuControls.tsx
@@ -19,6 +19,24 @@ import MenuControlsContainer from "./MenuControlsContainer";
 export type TableMenuControlsProps = {
   /** Class applied to the root controls container element. */
   className?: string;
+  /**
+   * Override the default labels for any of the menu buttons. For any value that
+   * is omitted in this object, it falls back to the default content.
+   */
+  labels?: {
+    insertColumnBefore?: string;
+    insertColumnAfter?: string;
+    deleteColumn?: string;
+    insertRowAbove?: string;
+    insertRowBelow?: string;
+    deleteRow?: string;
+    mergeCells?: string;
+    splitCell?: string;
+    toggleHeaderRow?: string;
+    toggleHeaderColumn?: string;
+    toggleHeaderCell?: string;
+    deleteTable?: string;
+  };
 };
 
 /**
@@ -27,26 +45,27 @@ export type TableMenuControlsProps = {
  */
 export default function TableMenuControls({
   className,
+  labels,
 }: TableMenuControlsProps) {
   const editor = useRichTextEditorContext();
   return (
     <MenuControlsContainer className={className}>
       <MenuButton
-        tooltipLabel="Insert column before"
+        tooltipLabel={labels?.insertColumnBefore ?? "Insert column before"}
         IconComponent={RiInsertColumnLeft}
         onClick={() => editor?.chain().focus().addColumnBefore().run()}
         disabled={!editor?.can().addColumnBefore()}
       />
 
       <MenuButton
-        tooltipLabel="Insert column after"
+        tooltipLabel={labels?.insertColumnAfter ?? "Insert column after"}
         IconComponent={RiInsertColumnRight}
         onClick={() => editor?.chain().focus().addColumnAfter().run()}
         disabled={!editor?.can().addColumnAfter()}
       />
 
       <MenuButton
-        tooltipLabel="Delete column"
+        tooltipLabel={labels?.deleteColumn ?? "Delete column"}
         IconComponent={RiDeleteColumn}
         onClick={() => editor?.chain().focus().deleteColumn().run()}
         disabled={!editor?.can().deleteColumn()}
@@ -55,21 +74,21 @@ export default function TableMenuControls({
       <MenuDivider />
 
       <MenuButton
-        tooltipLabel="Insert row above"
+        tooltipLabel={labels?.insertRowAbove ?? "Insert row above"}
         IconComponent={RiInsertRowTop}
         onClick={() => editor?.chain().focus().addRowBefore().run()}
         disabled={!editor?.can().addRowBefore()}
       />
 
       <MenuButton
-        tooltipLabel="Insert row below"
+        tooltipLabel={labels?.insertRowBelow ?? "Insert row below"}
         IconComponent={RiInsertRowBottom}
         onClick={() => editor?.chain().focus().addRowAfter().run()}
         disabled={!editor?.can().addRowAfter()}
       />
 
       <MenuButton
-        tooltipLabel="Delete row"
+        tooltipLabel={labels?.deleteRow ?? "Delete row"}
         IconComponent={RiDeleteRow}
         onClick={() => editor?.chain().focus().deleteRow().run()}
         disabled={!editor?.can().deleteRow()}
@@ -78,14 +97,14 @@ export default function TableMenuControls({
       <MenuDivider />
 
       <MenuButton
-        tooltipLabel="Merge cells"
+        tooltipLabel={labels?.mergeCells ?? "Merge cells"}
         IconComponent={RiMergeCellsHorizontal}
         onClick={() => editor?.chain().focus().mergeCells().run()}
         disabled={!editor?.can().mergeCells()}
       />
 
       <MenuButton
-        tooltipLabel="Split cell"
+        tooltipLabel={labels?.splitCell ?? "Split cell"}
         IconComponent={RiSplitCellsHorizontal}
         onClick={() => editor?.chain().focus().splitCell().run()}
         disabled={!editor?.can().splitCell()}
@@ -94,21 +113,21 @@ export default function TableMenuControls({
       <MenuDivider />
 
       <MenuButton
-        tooltipLabel="Toggle header row"
+        tooltipLabel={labels?.toggleHeaderRow ?? "Toggle header row"}
         IconComponent={RiLayoutRowFill}
         onClick={() => editor?.chain().focus().toggleHeaderRow().run()}
         disabled={!editor?.can().toggleHeaderRow()}
       />
 
       <MenuButton
-        tooltipLabel="Toggle header column"
+        tooltipLabel={labels?.toggleHeaderColumn ?? "Toggle header column"}
         IconComponent={RiLayoutColumnFill}
         onClick={() => editor?.chain().focus().toggleHeaderColumn().run()}
         disabled={!editor?.can().toggleHeaderColumn()}
       />
 
       <MenuButton
-        tooltipLabel="Toggle header cell"
+        tooltipLabel={labels?.toggleHeaderCell ?? "Toggle header cell"}
         IconComponent={FormatColorFill}
         onClick={() => editor?.chain().focus().toggleHeaderCell().run()}
         disabled={!editor?.can().toggleHeaderCell()}
@@ -118,7 +137,7 @@ export default function TableMenuControls({
       <MenuDivider />
 
       <MenuButton
-        tooltipLabel="Delete table"
+        tooltipLabel={labels?.deleteTable ?? "Delete table"}
         IconComponent={GridOff}
         onClick={() => editor?.chain().focus().deleteTable().run()}
         disabled={!editor?.can().deleteTable()}


### PR DESCRIPTION
Toward addressing https://github.com/sjdemartini/mui-tiptap/issues/59

### Example

```tsx
              <LinkBubbleMenu
                labels={{
                  viewLinkEditButtonLabel: "Edit link",
                  viewLinkRemoveButtonLabel: "Remove link",
                  editLinkAddTitle: "Add a new link",
                  editLinkEditTitle: "Update this link",
                  editLinkCancelButtonLabel: "Cancel changes",
                  editLinkTextInputLabel: "Text content",
                  editLinkHrefInputLabel: "URL",
                  editLinkSaveButtonLabel: "Save changes",
                }}
              />
              <TableBubbleMenu
                labels={{
                  insertColumnBefore: "Add a new column before this",
                  insertColumnAfter: "Add a new column after this",
                  deleteColumn: "Remove current column",
                }}
              />
```


#### Link menu

![Screenshot 2023-07-18 at 4 59 55 PM](https://github.com/sjdemartini/mui-tiptap/assets/1647130/22cd396a-22c3-40ad-a3a1-3520ecadc746)

![Screenshot 2023-07-18 at 4 59 48 PM](https://github.com/sjdemartini/mui-tiptap/assets/1647130/77802005-8283-4e4d-b454-9a16e8d41471)

#### Table menu

![Screenshot 2023-07-18 at 5 01 14 PM](https://github.com/sjdemartini/mui-tiptap/assets/1647130/4bc2ca4b-e04d-4f86-a7c0-80f3b58cddc5)
