### PR TITLE
Make prop naming consistent between MenuSelect* components

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ All of the menu buttons, select components, and bubble menus allow you to overri
   aria-label="Heading types"
   tooltipTitle="Change heading type"
   labels={{
-    emptyValue: "Text...",
+    empty: "Change to…",
     paragraph: "Normal text",
     heading1: "H1",
     heading2: "H2",

--- a/README.md
+++ b/README.md
@@ -325,7 +325,24 @@ All of the menu buttons, select components, and bubble menus allow you to overri
 <summary><b>Selects</b></summary>
 
 ```tsx
-<MenuSelectFontSize aria-label="Font sizes" tooltipTitle="Change font size" />
+<MenuSelectFontFamily
+  options={[
+    { label: "Monospace", value: "monospace" },
+    { label: "Serif", value: "serif" },
+  ]}
+  aria-label="Font families"
+  emptyLabel="Font family"
+  tooltipTitle="Change font family"
+  unsetOptionLabel="Reset"
+/>
+```
+
+```tsx
+<MenuSelectFontSize
+  aria-label="Font sizes"
+  tooltipTitle="Change font size"
+  unsetOptionLabel="Reset"
+/>
 ```
 
 ```tsx

--- a/README.md
+++ b/README.md
@@ -351,13 +351,13 @@ All of the menu buttons, select components, and bubble menus allow you to overri
   tooltipTitle="Change text alignment"
   options={[
     {
-      alignment: "left",
+      value: "left",
       label: "Text-align left",
       shortcutKeys: ["mod", "Shift", "L"],
       IconComponent: MyCustomLeftAlignIcon,
     },
     {
-      alignment: "right",
+      value: "right",
       label: "Text-align right",
       shortcutKeys: ["mod", "Shift", "R"],
       IconComponent: MyCustomRightAlignIcon,

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ You can override all props for these components (e.g. to change the icon, toolti
 | [`@tiptap/extension-code`](https://tiptap.dev/api/marks/code)                                                                      | `MenuButtonCode`                                                                                                                                                                                          |
 | [`@tiptap/extension-code-block`](https://tiptap.dev/api/nodes/code-block)                                                          | `MenuButtonCodeBlock`                                                                                                                                                                                     |
 | [`@tiptap/extension-font-family`](https://tiptap.dev/api/extensions/font-family)                                                   | `MenuSelectFontFamily` (use the `options` prop to specify which font families can be selected, like `[{ label: "Monospace", value: "monospace" }, ...]` )                                                 |
-| mui-tiptap’s [`FontSize`](#fontsize)                                                                                               | `MenuSelectFontSize` (override size options with `sizeOptions` prop)                                                                                                                                      |
+| mui-tiptap’s [`FontSize`](#fontsize)                                                                                               | `MenuSelectFontSize` (use the `options` prop to override the default size options)                                                                                                                        |
 | mui-tiptap’s [`HeadingWithAnchor`](#headingwithanchor)<br />or [`@tiptap/extension-heading`](https://tiptap.dev/api/nodes/heading) | `MenuSelectHeading`                                                                                                                                                                                       |
 | [`@tiptap/extension-history`](https://tiptap.dev/api/extensions/history)                                                           | `MenuButtonRedo`, `MenuButtonUndo`                                                                                                                                                                        |
 | [`@tiptap/extension-horizontal-rule`](https://tiptap.dev/api/nodes/horizontal-rule)                                                | `MenuButtonHorizontalRule`                                                                                                                                                                                |
@@ -349,7 +349,7 @@ All of the menu buttons, select components, and bubble menus allow you to overri
 <MenuSelectTextAlign
   aria-label="Text alignments"
   tooltipTitle="Change text alignment"
-  alignmentOptions={[
+  options={[
     {
       alignment: "left",
       label: "Text-align left",

--- a/src/controls/MenuSelectFontSize.tsx
+++ b/src/controls/MenuSelectFontSize.tsx
@@ -8,8 +8,6 @@ import type { FontSizeAttrs } from "../extensions/FontSize";
 import { MENU_BUTTON_FONT_SIZE_DEFAULT } from "./MenuButton";
 import MenuSelect, { type MenuSelectProps } from "./MenuSelect";
 
-export type FontSizeSelectOption = { name: string; value: string };
-
 export interface MenuSelectFontSizeProps
   extends Except<MenuSelectProps<string>, "value" | "children"> {
   /**

--- a/src/controls/MenuSelectFontSize.tsx
+++ b/src/controls/MenuSelectFontSize.tsx
@@ -44,10 +44,10 @@ export interface MenuSelectFontSizeProps
   /** @deprecated Use `options` prop instead. */
   sizeOptions?: string[];
   /**
-   * Override the label content shown for the Select's MenuItem that allows a
-   * user to unset the font-size of the selected text. If not provided, uses
-   * "Default" as the displayed text. To hide this select option entirely, set
-   * `hideUnsetOption` to true.
+   * Override the label content shown for the Select's MenuItem option that
+   * allows a user to unset the font-size of the selected text. If not provided,
+   * uses "Default" as the displayed text. To hide this select option entirely,
+   * set `hideUnsetOption` to true.
    */
   unsetOptionLabel?: ReactNode;
   /** @deprecated Use `unsetOptionLabel` prop instead. */
@@ -61,6 +61,8 @@ export interface MenuSelectFontSizeProps
    * What to render in the Select when no font-size is currently set for the
    * selected text. By default, uses the FormatSize MUI icon.
    */
+  emptyLabel?: React.ReactNode;
+  /** @deprecated Use `emptyLabel` prop instead. */
   emptyValue?: React.ReactNode;
 }
 
@@ -118,6 +120,7 @@ export default function MenuSelectFontSize({
   hideUnsetOption = false,
   unsetOptionLabel = "Default",
   unsetOptionContent,
+  emptyLabel,
   emptyValue,
   ...menuSelectProps
 }: MenuSelectFontSizeProps) {
@@ -125,6 +128,7 @@ export default function MenuSelectFontSize({
   const editor = useRichTextEditorContext();
 
   // Handle deprecated legacy names for some props:
+  emptyLabel = emptyValue ?? emptyLabel;
   unsetOptionLabel = unsetOptionContent ?? unsetOptionLabel;
   options = sizeOptions ?? options;
   const optionObjects: FontSizeSelectOptionObject[] = (options ?? []).map(
@@ -155,7 +159,7 @@ export default function MenuSelectFontSize({
           // this does, so it's visually similar to other menu button controls,
           // more intuitive, and more meaningful and compact than some other
           // placeholder value here
-          return emptyValue ?? <FormatSize className={classes.fontSizeIcon} />;
+          return emptyLabel ?? <FormatSize className={classes.fontSizeIcon} />;
         }
         return stripPxFromValue(value);
       }}

--- a/src/controls/MenuSelectFontSize.tsx
+++ b/src/controls/MenuSelectFontSize.tsx
@@ -9,7 +9,7 @@ import type { FontSizeAttrs } from "../extensions/FontSize";
 import { MENU_BUTTON_FONT_SIZE_DEFAULT } from "./MenuButton";
 import MenuSelect, { type MenuSelectProps } from "./MenuSelect";
 
-type FontSizeSelectOptionObject = {
+export type FontSizeSelectOptionObject = {
   /**
    * The underlying `font-size` CSS value string, which can be any valid CSS
    * font-size (https://developer.mozilla.org/en-US/docs/Web/CSS/font-size); ex:

--- a/src/controls/MenuSelectHeading.tsx
+++ b/src/controls/MenuSelectHeading.tsx
@@ -34,8 +34,13 @@ export interface MenuSelectHeadingProps
     /** Label shown for the level 6 heading (h6) option. */
     heading6?: ReactNode;
     /**
-     * Label shown when the user is currently on a non-paragraph, non-heading . */
-    emptyValue?: ReactNode;
+     * Label shown when the user is currently on a non-paragraph, non-heading.
+     * By default shows "Change to…" in italics, since choosing a new option
+     * will change the node type to one of the given heading/paragraph types.
+     */
+    empty?: ReactNode;
+    /** @deprecated Use `empty` field instead. */
+    emptyValue?: React.ReactNode;
   };
 }
 
@@ -192,7 +197,9 @@ export default function MenuSelectHeading({
       renderValue={(selected) => {
         let result: ReactNode | undefined;
         if (selected === "") {
-          result = labels?.emptyValue ?? <em>Change to…</em>;
+          // Handle the deprecated `emptyValue` label name, falling back to the
+          // newer `labels.empty`, and finally our default empty label
+          result = labels?.emptyValue ?? labels?.empty ?? <em>Change to…</em>;
         } else if (selected === HEADING_OPTION_VALUES.Paragraph) {
           result = labels?.paragraph;
         } else if (selected === HEADING_OPTION_VALUES.Heading1) {

--- a/src/controls/MenuSelectTextAlign.tsx
+++ b/src/controls/MenuSelectTextAlign.tsx
@@ -50,6 +50,11 @@ export interface MenuSelectTextAlignProps
    * component will omit an option if it's not enabled in the TextAlign
    * extension's `alignments` option.
    */
+  options?: TextAlignSelectOption[];
+  // We use the more generic `options` prop name for consistency in prop naming
+  // across various `MenuSelect*` components, rather than having a unique prop
+  // name for each one.
+  /** @deprecated Use `options` prop instead. */
   alignmentOptions?: TextAlignSelectOption[];
 }
 
@@ -101,9 +106,12 @@ const DEFAULT_ALIGNMENT_OPTIONS: TextAlignSelectOption[] = [
 ];
 
 export default function MenuSelectTextAlign({
-  alignmentOptions = DEFAULT_ALIGNMENT_OPTIONS,
+  options = DEFAULT_ALIGNMENT_OPTIONS,
+  alignmentOptions,
   ...menuSelectProps
 }: MenuSelectTextAlignProps) {
+  // Handle the deprecated name for the options prop if present
+  options = alignmentOptions ?? options;
   const { classes } = useStyles();
   const editor = useRichTextEditorContext();
 
@@ -149,7 +157,7 @@ export default function MenuSelectTextAlign({
       // Override the rendering of the selected value so that we don't show
       // tooltips on hovering (like we do for the menu options)
       renderValue={(value) => {
-        const alignmentOptionForValue = alignmentOptions.find(
+        const alignmentOptionForValue = options.find(
           (option) => option.alignment === value
         );
         return (
@@ -169,7 +177,7 @@ export default function MenuSelectTextAlign({
       value={selectedValue}
       {...menuSelectProps}
     >
-      {alignmentOptions
+      {options
         .filter((alignmentOption) =>
           enabledAlignments.has(alignmentOption.alignment)
         )

--- a/src/controls/MenuSelectTextAlign.tsx
+++ b/src/controls/MenuSelectTextAlign.tsx
@@ -22,7 +22,7 @@ export type TextAlignSelectOption = {
    * Which textAlign value this option enables. Ex: "left", "right",
    * "center", "justify".
    */
-  alignment: string;
+  value: string;
   /**
    * What icon to show for this option in the select option dropdown.
    */
@@ -55,7 +55,17 @@ export interface MenuSelectTextAlignProps
   // across various `MenuSelect*` components, rather than having a unique prop
   // name for each one.
   /** @deprecated Use `options` prop instead. */
-  alignmentOptions?: TextAlignSelectOption[];
+  alignmentOptions?: {
+    /**
+     * `alignment` has been renamed `value` in the new preferred `options` prop.
+     */
+    alignment: string;
+    IconComponent: React.ElementType<{
+      className: string;
+    }>;
+    label?: string;
+    shortcutKeys?: MenuButtonTooltipProps["shortcutKeys"];
+  }[];
 }
 
 const useStyles = makeStyles({ name: { MenuSelectTextAlign } })({
@@ -80,25 +90,25 @@ const useStyles = makeStyles({ name: { MenuSelectTextAlign } })({
 
 const DEFAULT_ALIGNMENT_OPTIONS: TextAlignSelectOption[] = [
   {
-    alignment: "left",
+    value: "left",
     label: "Left",
     shortcutKeys: ["mod", "Shift", "L"],
     IconComponent: FormatAlignLeftIcon,
   },
   {
-    alignment: "center",
+    value: "center",
     label: "Center",
     shortcutKeys: ["mod", "Shift", "E"],
     IconComponent: FormatAlignCenterIcon,
   },
   {
-    alignment: "right",
+    value: "right",
     label: "Right",
     shortcutKeys: ["mod", "Shift", "R"],
     IconComponent: FormatAlignRightIcon,
   },
   {
-    alignment: "justify",
+    value: "justify",
     label: "Justify",
     shortcutKeys: ["mod", "Shift", "J"],
     IconComponent: FormatAlignJustifyIcon,
@@ -110,10 +120,15 @@ export default function MenuSelectTextAlign({
   alignmentOptions,
   ...menuSelectProps
 }: MenuSelectTextAlignProps) {
-  // Handle the deprecated name for the options prop if present
-  options = alignmentOptions ?? options;
   const { classes } = useStyles();
   const editor = useRichTextEditorContext();
+
+  // Handle the deprecated name for the `options` prop if present
+  options =
+    alignmentOptions?.map((option) => ({
+      ...option,
+      value: option.alignment,
+    })) ?? options;
 
   const handleAlignmentSelect: (event: SelectChangeEvent) => void = useCallback(
     (event) => {
@@ -158,7 +173,7 @@ export default function MenuSelectTextAlign({
       // tooltips on hovering (like we do for the menu options)
       renderValue={(value) => {
         const alignmentOptionForValue = options.find(
-          (option) => option.alignment === value
+          (option) => option.value === value
         );
         return (
           <span className={classes.menuOption}>
@@ -179,13 +194,13 @@ export default function MenuSelectTextAlign({
     >
       {options
         .filter((alignmentOption) =>
-          enabledAlignments.has(alignmentOption.alignment)
+          enabledAlignments.has(alignmentOption.value)
         )
         .map((alignmentOption) => (
           <MenuItem
-            key={alignmentOption.alignment}
-            value={alignmentOption.alignment}
-            disabled={!editor?.can().setTextAlign(alignmentOption.alignment)}
+            key={alignmentOption.value}
+            value={alignmentOption.value}
+            disabled={!editor?.can().setTextAlign(alignmentOption.value)}
             className={classes.menuItem}
           >
             <MenuButtonTooltip

--- a/src/controls/MenuSelectTextAlign.tsx
+++ b/src/controls/MenuSelectTextAlign.tsx
@@ -15,6 +15,7 @@ import MenuButtonTooltip, {
 // eslint-disable-next-line import/no-extraneous-dependencies
 import type { TextAlignOptions } from "@tiptap/extension-text-align";
 import type { Except } from "type-fest";
+import { MENU_BUTTON_FONT_SIZE_DEFAULT } from "./MenuButton";
 import MenuSelect, { type MenuSelectProps } from "./MenuSelect";
 
 export type TextAlignSelectOption = {
@@ -84,7 +85,7 @@ const useStyles = makeStyles({ name: { MenuSelectTextAlign } })({
   },
 
   menuButtonIcon: {
-    fontSize: "1.25rem",
+    fontSize: MENU_BUTTON_FONT_SIZE_DEFAULT,
   },
 });
 


### PR DESCRIPTION
- Use `options` as the prop name for Select dropdown menu-item options everywhere
- Use `value` and `label` as the main keys in the each `options` object (e.g. instead of `alignment` and `label` in `MenuSelectTextAlign`'s `alignmentOptions` prop, it's now `value` and `label` in its `options` prop)
- In addition to supporting `options` as an array of string font-size values, add support for customized labels for the `options` in `MenuSelectFontSize`, like:
    ```tsx
      <MenuSelectFontSize
        options={[
          { value: "14px" }, // Will show "14" (trimming "px" by default if no label)
          { value: "18px", label: "Eighteen" },  // Will show "Eighteen"
          { value: "24px", label: "24px" }, // Will show "24px"
        ]}
      />
    ```
- Rename `unsetOptionContent` -> `unsetOptionLabel`
- Rename `emptyValue` -> `emptyLabel`

Old prop names/structures are marked as deprecated but are still supported for backwards compatibility.