### PR TITLE
Remove react-icons dependency in favor of internal versions of Remix and Box icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,16 +86,16 @@ or
 yarn add mui-tiptap
 ```
 
-There are peer dependencies on [`@mui/material`](https://www.npmjs.com/package/@mui/material) and [`@mui/icons-material`](https://www.npmjs.com/package/@mui/icons-material) (and their `@emotion/` peers), [`react-icons`](https://www.npmjs.com/package/react-icons), and [`@tiptap/`](https://tiptap.dev/installation/react) packages. These should be installed automatically by default if you’re using npm 7+ or pnpm. Otherwise, if your project doesn’t already use those, you can install them with:
+There are peer dependencies on [`@mui/material`](https://www.npmjs.com/package/@mui/material) and [`@mui/icons-material`](https://www.npmjs.com/package/@mui/icons-material) (and their `@emotion/` peers), and [`@tiptap/`](https://tiptap.dev/installation/react) packages. These should be installed automatically by default if you’re using npm 7+ or pnpm. Otherwise, if your project doesn’t already use those, you can install them with:
 
 ```shell
-npm install @mui/material @mui/icons-material @emotion/react @emotion/styled react-icons @tiptap/react @tiptap/extension-heading @tiptap/extension-image @tiptap/extension-table @tiptap/pm @tiptap/core
+npm install @mui/material @mui/icons-material @emotion/react @emotion/styled @tiptap/react @tiptap/extension-heading @tiptap/extension-image @tiptap/extension-table @tiptap/pm @tiptap/core
 ```
 
 or
 
 ```shell
-yarn add @mui/material @mui/icons-material @emotion/react @emotion/styled react-icons @tiptap/react @tiptap/extension-heading @tiptap/extension-image @tiptap/extension-table @tiptap/pm @tiptap/core
+yarn add @mui/material @mui/icons-material @emotion/react @emotion/styled @tiptap/react @tiptap/extension-heading @tiptap/extension-image @tiptap/extension-table @tiptap/pm @tiptap/core
 ```
 
 ## Get started

--- a/example/package.json
+++ b/example/package.json
@@ -51,8 +51,7 @@
     "@tiptap/starter-kit": "^2.0.3",
     "mui-tiptap": "file:../",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-icons": "^4.3.1"
+    "react-dom": "^18.2.0"
   },
   "dependenciesMeta": {
     "mui-tiptap": {

--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -124,16 +124,13 @@ dependencies:
     version: 2.0.3(@tiptap/pm@2.0.3)
   mui-tiptap:
     specifier: file:../
-    version: file:..(@emotion/react@11.11.0)(@mui/icons-material@5.11.16)(@mui/material@5.12.3)(@tiptap/core@2.0.3)(@tiptap/extension-heading@2.0.3)(@tiptap/extension-image@2.0.3)(@tiptap/extension-table@2.0.3)(@tiptap/pm@2.0.3)(@tiptap/react@2.0.3)(react-dom@18.2.0)(react-icons@4.3.1)(react@18.2.0)
+    version: file:..(@emotion/react@11.11.0)(@mui/icons-material@5.11.16)(@mui/material@5.12.3)(@tiptap/core@2.0.3)(@tiptap/extension-heading@2.0.3)(@tiptap/extension-image@2.0.3)(@tiptap/extension-table@2.0.3)(@tiptap/pm@2.0.3)(@tiptap/react@2.0.3)(react-dom@18.2.0)(react@18.2.0)
   react:
     specifier: ^18.2.0
     version: 18.2.0
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
-  react-icons:
-    specifier: ^4.3.1
-    version: 4.3.1(react@18.2.0)
 
 devDependencies:
   '@types/react':
@@ -2143,14 +2140,6 @@ packages:
       scheduler: 0.23.0
     dev: false
 
-  /react-icons@4.3.1(react@18.2.0):
-    resolution: {integrity: sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==}
-    peerDependencies:
-      react: '*'
-    dependencies:
-      react: 18.2.0
-    dev: false
-
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
     dev: false
@@ -2356,7 +2345,7 @@ packages:
     engines: {node: '>= 6'}
     dev: false
 
-  file:..(@emotion/react@11.11.0)(@mui/icons-material@5.11.16)(@mui/material@5.12.3)(@tiptap/core@2.0.3)(@tiptap/extension-heading@2.0.3)(@tiptap/extension-image@2.0.3)(@tiptap/extension-table@2.0.3)(@tiptap/pm@2.0.3)(@tiptap/react@2.0.3)(react-dom@18.2.0)(react-icons@4.3.1)(react@18.2.0):
+  file:..(@emotion/react@11.11.0)(@mui/icons-material@5.11.16)(@mui/material@5.12.3)(@tiptap/core@2.0.3)(@tiptap/extension-heading@2.0.3)(@tiptap/extension-image@2.0.3)(@tiptap/extension-table@2.0.3)(@tiptap/pm@2.0.3)(@tiptap/react@2.0.3)(react-dom@18.2.0)(react@18.2.0):
     resolution: {directory: .., type: directory}
     id: file:..
     name: mui-tiptap
@@ -2375,7 +2364,6 @@ packages:
       '@tiptap/react': ^2.0.0-beta.210
       react: ^16.8.0 || ^17.0.2 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.2 || ^18.0.0
-      react-icons: ^4.3.1
     dependencies:
       '@emotion/react': 11.11.0(@types/react@18.0.28)(react@18.2.0)
       '@mui/icons-material': 5.11.16(@mui/material@5.12.3)(@types/react@18.0.28)(react@18.2.0)
@@ -2390,7 +2378,6 @@ packages:
       lodash: 4.17.21
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-icons: 4.3.1(react@18.2.0)
       tss-react: 4.8.6(@emotion/react@11.11.0)(react@18.2.0)
       type-fest: 3.12.0
     transitivePeerDependencies:

--- a/package.json
+++ b/package.json
@@ -73,8 +73,7 @@
     "@tiptap/pm": "^2.0.0-beta.210",
     "@tiptap/react": "^2.0.0-beta.210",
     "react": "^16.8.0 || ^17.0.2 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.2 || ^18.0.0",
-    "react-icons": "^4.3.1"
+    "react-dom": "^16.8.0 || ^17.0.2 || ^18.0.0"
   },
   "devDependencies": {
     "@emotion/react": "^11.11.0",
@@ -152,7 +151,6 @@
     "prosemirror-view": "^1.9.10",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^4.8.0",
     "rimraf": "^5.0.0",
     "typescript": "^5.1.6",
     "vite": "^4.3.9",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
       "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/esm/index.js"
+    },
+    "./icons": {
+      "types": "./dist/icons/index.d.ts",
+      "require": "./dist/icons/index.js",
+      "import": "./dist/esm/icons/index.js"
     }
   },
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,9 +244,6 @@ devDependencies:
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
-  react-icons:
-    specifier: ^4.8.0
-    version: 4.8.0(react@18.2.0)
   rimraf:
     specifier: ^5.0.0
     version: 5.0.0
@@ -5195,14 +5192,6 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
-    dev: true
-
-  /react-icons@4.8.0(react@18.2.0):
-    resolution: {integrity: sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==}
-    peerDependencies:
-      react: '*'
-    dependencies:
-      react: 18.2.0
     dev: true
 
   /react-is@16.13.1:

--- a/src/controls/MenuButtonAddTable.tsx
+++ b/src/controls/MenuButtonAddTable.tsx
@@ -1,5 +1,5 @@
-import { BiTable } from "react-icons/bi";
 import { useRichTextEditorContext } from "../context";
+import { Table } from "../icons";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
 export type MenuButtonAddTableProps = Partial<MenuButtonProps>;
@@ -9,7 +9,7 @@ export default function MenuButtonAddTable(props: MenuButtonAddTableProps) {
   return (
     <MenuButton
       tooltipLabel="Insert table"
-      IconComponent={BiTable}
+      IconComponent={Table}
       disabled={!editor?.isEditable || !editor.can().insertTable()}
       onClick={() =>
         editor

--- a/src/controls/MenuButtonCodeBlock.tsx
+++ b/src/controls/MenuButtonCodeBlock.tsx
@@ -1,6 +1,6 @@
 /// <reference types="@tiptap/extension-code-block" />
-import { BiCodeBlock } from "react-icons/bi";
 import { useRichTextEditorContext } from "../context";
+import { CodeBlock } from "../icons";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
 export type MenuButtonCodeBlockProps = Partial<MenuButtonProps>;
@@ -11,7 +11,7 @@ export default function MenuButtonCodeBlock(props: MenuButtonCodeBlockProps) {
     <MenuButton
       tooltipLabel="Code block"
       tooltipShortcutKeys={["mod", "Alt", "C"]}
-      IconComponent={BiCodeBlock}
+      IconComponent={CodeBlock}
       selected={editor?.isActive("codeBlock") ?? false}
       disabled={!editor?.isEditable || !editor.can().toggleCodeBlock()}
       onClick={() => editor?.chain().focus().toggleCodeBlock().run()}

--- a/src/controls/TableMenuControls.tsx
+++ b/src/controls/TableMenuControls.tsx
@@ -1,18 +1,18 @@
 import { FormatColorFill, GridOff } from "@mui/icons-material";
-import {
-  RiDeleteColumn,
-  RiDeleteRow,
-  RiInsertColumnLeft,
-  RiInsertColumnRight,
-  RiInsertRowBottom,
-  RiInsertRowTop,
-  RiLayoutColumnFill,
-  RiLayoutRowFill,
-  RiMergeCellsHorizontal,
-  RiSplitCellsHorizontal,
-} from "react-icons/ri";
 import MenuDivider from "../MenuDivider";
 import { useRichTextEditorContext } from "../context";
+import {
+  DeleteColumn,
+  DeleteRow,
+  InsertColumnLeft,
+  InsertColumnRight,
+  InsertRowBottom,
+  InsertRowTop,
+  LayoutColumnFill,
+  LayoutRowFill,
+  MergeCellsHorizontal,
+  SplitCellsHorizontal,
+} from "../icons";
 import MenuButton from "./MenuButton";
 import MenuControlsContainer from "./MenuControlsContainer";
 
@@ -52,21 +52,21 @@ export default function TableMenuControls({
     <MenuControlsContainer className={className}>
       <MenuButton
         tooltipLabel={labels?.insertColumnBefore ?? "Insert column before"}
-        IconComponent={RiInsertColumnLeft}
+        IconComponent={InsertColumnLeft}
         onClick={() => editor?.chain().focus().addColumnBefore().run()}
         disabled={!editor?.can().addColumnBefore()}
       />
 
       <MenuButton
         tooltipLabel={labels?.insertColumnAfter ?? "Insert column after"}
-        IconComponent={RiInsertColumnRight}
+        IconComponent={InsertColumnRight}
         onClick={() => editor?.chain().focus().addColumnAfter().run()}
         disabled={!editor?.can().addColumnAfter()}
       />
 
       <MenuButton
         tooltipLabel={labels?.deleteColumn ?? "Delete column"}
-        IconComponent={RiDeleteColumn}
+        IconComponent={DeleteColumn}
         onClick={() => editor?.chain().focus().deleteColumn().run()}
         disabled={!editor?.can().deleteColumn()}
       />
@@ -75,21 +75,21 @@ export default function TableMenuControls({
 
       <MenuButton
         tooltipLabel={labels?.insertRowAbove ?? "Insert row above"}
-        IconComponent={RiInsertRowTop}
+        IconComponent={InsertRowTop}
         onClick={() => editor?.chain().focus().addRowBefore().run()}
         disabled={!editor?.can().addRowBefore()}
       />
 
       <MenuButton
         tooltipLabel={labels?.insertRowBelow ?? "Insert row below"}
-        IconComponent={RiInsertRowBottom}
+        IconComponent={InsertRowBottom}
         onClick={() => editor?.chain().focus().addRowAfter().run()}
         disabled={!editor?.can().addRowAfter()}
       />
 
       <MenuButton
         tooltipLabel={labels?.deleteRow ?? "Delete row"}
-        IconComponent={RiDeleteRow}
+        IconComponent={DeleteRow}
         onClick={() => editor?.chain().focus().deleteRow().run()}
         disabled={!editor?.can().deleteRow()}
       />
@@ -98,14 +98,14 @@ export default function TableMenuControls({
 
       <MenuButton
         tooltipLabel={labels?.mergeCells ?? "Merge cells"}
-        IconComponent={RiMergeCellsHorizontal}
+        IconComponent={MergeCellsHorizontal}
         onClick={() => editor?.chain().focus().mergeCells().run()}
         disabled={!editor?.can().mergeCells()}
       />
 
       <MenuButton
         tooltipLabel={labels?.splitCell ?? "Split cell"}
-        IconComponent={RiSplitCellsHorizontal}
+        IconComponent={SplitCellsHorizontal}
         onClick={() => editor?.chain().focus().splitCell().run()}
         disabled={!editor?.can().splitCell()}
       />
@@ -114,14 +114,14 @@ export default function TableMenuControls({
 
       <MenuButton
         tooltipLabel={labels?.toggleHeaderRow ?? "Toggle header row"}
-        IconComponent={RiLayoutRowFill}
+        IconComponent={LayoutRowFill}
         onClick={() => editor?.chain().focus().toggleHeaderRow().run()}
         disabled={!editor?.can().toggleHeaderRow()}
       />
 
       <MenuButton
         tooltipLabel={labels?.toggleHeaderColumn ?? "Toggle header column"}
-        IconComponent={RiLayoutColumnFill}
+        IconComponent={LayoutColumnFill}
         onClick={() => editor?.chain().focus().toggleHeaderColumn().run()}
         disabled={!editor?.can().toggleHeaderColumn()}
       />

--- a/src/icons/CodeBlock.tsx
+++ b/src/icons/CodeBlock.tsx
@@ -1,0 +1,12 @@
+import { createSvgIcon } from "@mui/material";
+
+const CodeBlock = createSvgIcon(
+  // From https://boxicons.com/ (https://github.com/atisawd/boxicons)
+  <>
+    <path d="M20 3H4c-1.103 0-2 .897-2 2v14c0 1.103.897 2 2 2h16c1.103 0 2-.897 2-2V5c0-1.103-.897-2-2-2zM4 19V7h16l.002 12H4z"></path>
+    <path d="M9.293 9.293 5.586 13l3.707 3.707 1.414-1.414L8.414 13l2.293-2.293zm5.414 0-1.414 1.414L15.586 13l-2.293 2.293 1.414 1.414L18.414 13z"></path>
+  </>,
+  "CodeBlock"
+);
+
+export default CodeBlock;

--- a/src/icons/DeleteColumn.tsx
+++ b/src/icons/DeleteColumn.tsx
@@ -1,0 +1,9 @@
+import { createSvgIcon } from "@mui/material";
+
+const DeleteColumn = createSvgIcon(
+  // From https://remixicon.com/ (https://github.com/Remix-Design/RemixIcon)
+  <path d="M12 3C12.5523 3 13 3.44772 13 4L12.9998 11.9998C13.8355 11.372 14.8743 11 16 11C18.7614 11 21 13.2386 21 16C21 18.7614 18.7614 21 16 21C14.9681 21 14.0092 20.6874 13.2129 20.1518L13 20C13 20.5523 12.5523 21 12 21H6C5.44772 21 5 20.5523 5 20V4C5 3.44772 5.44772 3 6 3H12ZM11 5H7V19H11V5ZM19 15H13V17H19V15Z"></path>,
+  "DeleteColumn"
+);
+
+export default DeleteColumn;

--- a/src/icons/DeleteRow.tsx
+++ b/src/icons/DeleteRow.tsx
@@ -1,0 +1,9 @@
+import { createSvgIcon } from "@mui/material";
+
+const DeleteRow = createSvgIcon(
+  // From https://remixicon.com/ (https://github.com/Remix-Design/RemixIcon)
+  <path d="M20 5C20.5523 5 21 5.44772 21 6V12C21 12.5523 20.5523 13 20 13C20.628 13.8355 21 14.8743 21 16C21 18.7614 18.7614 21 16 21C13.2386 21 11 18.7614 11 16C11 14.8743 11.372 13.8355 11.9998 12.9998L4 13C3.44772 13 3 12.5523 3 12V6C3 5.44772 3.44772 5 4 5H20ZM13 15V17H19V15H13ZM19 7H5V11H19V7Z"></path>,
+  "DeleteRow"
+);
+
+export default DeleteRow;

--- a/src/icons/InsertColumnLeft.tsx
+++ b/src/icons/InsertColumnLeft.tsx
@@ -1,0 +1,9 @@
+import { createSvgIcon } from "@mui/material";
+
+const InsertColumnLeft = createSvgIcon(
+  // From https://remixicon.com/ (https://github.com/Remix-Design/RemixIcon)
+  <path d="M20 3C20.5523 3 21 3.44772 21 4V20C21 20.5523 20.5523 21 20 21H14C13.4477 21 13 20.5523 13 20V4C13 3.44772 13.4477 3 14 3H20ZM19 5H15V19H19V5ZM6 7C8.76142 7 11 9.23858 11 12C11 14.7614 8.76142 17 6 17C3.23858 17 1 14.7614 1 12C1 9.23858 3.23858 7 6 7ZM7 9H5V10.999L3 11V13L5 12.999V15H7V12.999L9 13V11L7 10.999V9Z"></path>,
+  "InsertColumnLeft"
+);
+
+export default InsertColumnLeft;

--- a/src/icons/InsertColumnRight.tsx
+++ b/src/icons/InsertColumnRight.tsx
@@ -1,0 +1,9 @@
+import { createSvgIcon } from "@mui/material";
+
+const InsertColumnRight = createSvgIcon(
+  // From https://remixicon.com/ (https://github.com/Remix-Design/RemixIcon)
+  <path d="M10 3C10.5523 3 11 3.44772 11 4V20C11 20.5523 10.5523 21 10 21H4C3.44772 21 3 20.5523 3 20V4C3 3.44772 3.44772 3 4 3H10ZM9 5H5V19H9V5ZM18 7C20.7614 7 23 9.23858 23 12C23 14.7614 20.7614 17 18 17C15.2386 17 13 14.7614 13 12C13 9.23858 15.2386 7 18 7ZM19 9H17V10.999L15 11V13L17 12.999V15H19V12.999L21 13V11L19 10.999V9Z"></path>,
+  "InsertColumnRight"
+);
+
+export default InsertColumnRight;

--- a/src/icons/InsertRowBottom.tsx
+++ b/src/icons/InsertRowBottom.tsx
@@ -1,0 +1,9 @@
+import { createSvgIcon } from "@mui/material";
+
+const InsertRowBottom = createSvgIcon(
+  // From https://remixicon.com/ (https://github.com/Remix-Design/RemixIcon)
+  <path d="M12 13C14.7614 13 17 15.2386 17 18C17 20.7614 14.7614 23 12 23C9.23858 23 7 20.7614 7 18C7 15.2386 9.23858 13 12 13ZM13 15H11V16.999L9 17V19L11 18.999V21H13V18.999L15 19V17L13 16.999V15ZM20 3C20.5523 3 21 3.44772 21 4V10C21 10.5523 20.5523 11 20 11H4C3.44772 11 3 10.5523 3 10V4C3 3.44772 3.44772 3 4 3H20ZM5 5V9H19V5H5Z"></path>,
+  "InsertRowBottom"
+);
+
+export default InsertRowBottom;

--- a/src/icons/InsertRowTop.tsx
+++ b/src/icons/InsertRowTop.tsx
@@ -1,0 +1,9 @@
+import { createSvgIcon } from "@mui/material";
+
+const InsertRowTop = createSvgIcon(
+  // From https://remixicon.com/ (https://github.com/Remix-Design/RemixIcon)
+  <path d="M20 13C20.5523 13 21 13.4477 21 14V20C21 20.5523 20.5523 21 20 21H4C3.44772 21 3 20.5523 3 20V14C3 13.4477 3.44772 13 4 13H20ZM19 15H5V19H19V15ZM12 1C14.7614 1 17 3.23858 17 6C17 8.76142 14.7614 11 12 11C9.23858 11 7 8.76142 7 6C7 3.23858 9.23858 1 12 1ZM13 3H11V4.999L9 5V7L11 6.999V9H13V6.999L15 7V5L13 4.999V3Z"></path>,
+  "InsertRowTop"
+);
+
+export default InsertRowTop;

--- a/src/icons/LayoutColumnFill.tsx
+++ b/src/icons/LayoutColumnFill.tsx
@@ -1,0 +1,9 @@
+import { createSvgIcon } from "@mui/material";
+
+const LayoutColumnFill = createSvgIcon(
+  // From https://remixicon.com/ (https://github.com/Remix-Design/RemixIcon)
+  <path d="M12 5V19H19V5H12ZM4 3H20C20.5523 3 21 3.44772 21 4V20C21 20.5523 20.5523 21 20 21H4C3.44772 21 3 20.5523 3 20V4C3 3.44772 3.44772 3 4 3Z"></path>,
+  "LayoutColumnFill"
+);
+
+export default LayoutColumnFill;

--- a/src/icons/LayoutRowFill.tsx
+++ b/src/icons/LayoutRowFill.tsx
@@ -1,0 +1,9 @@
+import { createSvgIcon } from "@mui/material";
+
+const LayoutRowFill = createSvgIcon(
+  // From https://remixicon.com/ (https://github.com/Remix-Design/RemixIcon)
+  <path d="M19 12H5V19H19V12ZM4 3H20C20.5523 3 21 3.44772 21 4V20C21 20.5523 20.5523 21 20 21H4C3.44772 21 3 20.5523 3 20V4C3 3.44772 3.44772 3 4 3Z"></path>,
+  "LayoutRowFill"
+);
+
+export default LayoutRowFill;

--- a/src/icons/MergeCellsHorizontal.tsx
+++ b/src/icons/MergeCellsHorizontal.tsx
@@ -1,0 +1,9 @@
+import { createSvgIcon } from "@mui/material";
+
+const MergeCellsHorizontal = createSvgIcon(
+  // From https://remixicon.com/ (https://github.com/Remix-Design/RemixIcon)
+  <path d="M20 3C20.5523 3 21 3.44772 21 4V20C21 20.5523 20.5523 21 20 21H4C3.44772 21 3 20.5523 3 20V4C3 3.44772 3.44772 3 4 3H20ZM11 5H5V10.999H7V9L10 12L7 15V13H5V19H11V17H13V19H19V13H17V15L14 12L17 9V10.999H19V5H13V7H11V5ZM13 13V15H11V13H13ZM13 9V11H11V9H13Z"></path>,
+  "MergeCellsHorizontal"
+);
+
+export default MergeCellsHorizontal;

--- a/src/icons/SplitCellsHorizontal.tsx
+++ b/src/icons/SplitCellsHorizontal.tsx
@@ -1,0 +1,9 @@
+import { createSvgIcon } from "@mui/material";
+
+const SplitCellsHorizontal = createSvgIcon(
+  // From https://remixicon.com/ (https://github.com/Remix-Design/RemixIcon)
+  <path d="M20 3C20.5523 3 21 3.44772 21 4V20C21 20.5523 20.5523 21 20 21H4C3.44772 21 3 20.5523 3 20V4C3 3.44772 3.44772 3 4 3H20ZM11 5H5V19H11V15H13V19H19V5H13V9H11V5ZM15 9L18 12L15 15V13H9V15L6 12L9 9V11H15V9Z"></path>,
+  "SplitCellsHorizontal"
+);
+
+export default SplitCellsHorizontal;

--- a/src/icons/Table.tsx
+++ b/src/icons/Table.tsx
@@ -1,0 +1,9 @@
+import { createSvgIcon } from "@mui/material";
+
+const Table = createSvgIcon(
+  // From https://boxicons.com/ (https://github.com/atisawd/boxicons)
+  <path d="M4 21h15.893c1.103 0 2-.897 2-2V5c0-1.103-.897-2-2-2H4c-1.103 0-2 .897-2 2v14c0 1.103.897 2 2 2zm0-2v-5h4v5H4zM14 7v5h-4V7h4zM8 7v5H4V7h4zm2 12v-5h4v5h-4zm6 0v-5h3.894v5H16zm3.893-7H16V7h3.893v5z"></path>,
+  "Table"
+);
+
+export default Table;

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -1,3 +1,8 @@
+// These icons fill some gaps in the @mui/icons-material icon set. We include
+// them directly here rather than importing from an external package to reduce
+// install size and external dependencies (see
+// https://github.com/sjdemartini/mui-tiptap/issues/119).
+export { default as CodeBlock } from "./CodeBlock";
 export { default as DeleteColumn } from "./DeleteColumn";
 export { default as DeleteRow } from "./DeleteRow";
 export { default as InsertColumnLeft } from "./InsertColumnLeft";
@@ -8,3 +13,4 @@ export { default as LayoutColumnFill } from "./LayoutColumnFill";
 export { default as LayoutRowFill } from "./LayoutRowFill";
 export { default as MergeCellsHorizontal } from "./MergeCellsHorizontal";
 export { default as SplitCellsHorizontal } from "./SplitCellsHorizontal";
+export { default as Table } from "./Table";

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -1,0 +1,10 @@
+export { default as DeleteColumn } from "./DeleteColumn";
+export { default as DeleteRow } from "./DeleteRow";
+export { default as InsertColumnLeft } from "./InsertColumnLeft";
+export { default as InsertColumnRight } from "./InsertColumnRight";
+export { default as InsertRowBottom } from "./InsertRowBottom";
+export { default as InsertRowTop } from "./InsertRowTop";
+export { default as LayoutColumnFill } from "./LayoutColumnFill";
+export { default as LayoutRowFill } from "./LayoutRowFill";
+export { default as MergeCellsHorizontal } from "./MergeCellsHorizontal";
+export { default as SplitCellsHorizontal } from "./SplitCellsHorizontal";


### PR DESCRIPTION
Resolves https://github.com/sjdemartini/mui-tiptap/issues/119. These icons fill some gaps in the `@mui/icons-material` icon set. We now include them directly rather than importing from `react-icons` or another external package to reduce both install size and external dependencies.

We now export these internally created icons in the `"mui-tiptap/icons"` namespace, so they can be used externally if desired, like `import { InsertColumnLeft } from "mui-tiptap/icons";`

UI is unchanged:
- Remix icons: 
    <img width="566" alt="image" src="https://github.com/sjdemartini/mui-tiptap/assets/1647130/8cfc3e18-5562-4e64-8dca-04b93518caf4">
- Box icons: 
    <img width="126" alt="Screenshot 2023-08-07 at 1 49 31 PM" src="https://github.com/sjdemartini/mui-tiptap/assets/1647130/24d5313a-182a-4ef5-85e4-ba2273f8ef3b">

