### PR TITLE
Show each font family option with that font-family CSS style, and change empty/tooltip label to "Font"

### DIFF
--- a/src/controls/MenuSelectFontFamily.tsx
+++ b/src/controls/MenuSelectFontFamily.tsx
@@ -50,7 +50,7 @@ export interface MenuSelectFontFamilyProps
   hideUnsetOption?: boolean;
   /**
    * What to render in the Select when no font-family is currently set for the
-   * selected text. By default shows "Font family".
+   * selected text. By default shows "Font".
    */
   emptyLabel?: React.ReactNode;
 }
@@ -68,7 +68,7 @@ export default function MenuSelectFontFamily({
   options,
   hideUnsetOption = false,
   unsetOptionLabel = "Default",
-  emptyLabel = "Font family",
+  emptyLabel = "Font",
   ...menuSelectProps
 }: MenuSelectFontFamilyProps) {
   const editor = useRichTextEditorContext();
@@ -99,7 +99,7 @@ export default function MenuSelectFontFamily({
       }}
       displayEmpty
       aria-label="Font families"
-      tooltipTitle="Font family"
+      tooltipTitle="Font"
       {...menuSelectProps}
       // We don't want to pass any non-string falsy values here, always falling
       // back to ""

--- a/src/controls/MenuSelectFontFamily.tsx
+++ b/src/controls/MenuSelectFontFamily.tsx
@@ -113,7 +113,9 @@ export default function MenuSelectFontFamily({
 
       {options.map((fontFamilyOption) => (
         <MenuItem key={fontFamilyOption.value} value={fontFamilyOption.value}>
-          {fontFamilyOption.label ?? fontFamilyOption.value}
+          <span style={{ fontFamily: fontFamilyOption.value }}>
+            {fontFamilyOption.label ?? fontFamilyOption.value}
+          </span>
         </MenuItem>
       ))}
     </MenuSelect>

--- a/src/demo/EditorMenuControls.tsx
+++ b/src/demo/EditorMenuControls.tsx
@@ -40,16 +40,7 @@ export default function EditorMenuControls() {
           { label: "Cursive", value: "cursive" },
           { label: "Monospace", value: "monospace" },
           { label: "Serif", value: "serif" },
-          { label: "Roboto", value: "" },
         ]}
-        // Display our default font "Roboto" as the rendered label when no font
-        // is currently set
-        emptyLabel="Roboto"
-        // We provide a custom "Roboto" option above where the value is "" and
-        // will unset the font-family (and we place that alphabetically amongst
-        // the options), so we don't need a separate "Default" unsetting option
-        // shown
-        hideUnsetOption
       />
 
       <MenuDivider />


### PR DESCRIPTION
Rather than showing each option in the default font, we'll show each option in that option's font-family style.

Also, this changes the default emptyLabel and tooltipTitle to "Font", as that's the more familiar name that Outlook, Google Docs, etc. use.

Example:

![Screenshot 2023-08-09 at 5 20 39 PM](https://github.com/sjdemartini/mui-tiptap/assets/1647130/40cd09e8-7ccd-4066-a57b-4abb272767bb)

