### PR TITLE
Improve Select interfaces to handle selection containing multiple different values

### DIFF
--- a/src/controls/MenuSelectFontFamily.tsx
+++ b/src/controls/MenuSelectFontFamily.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import { makeStyles } from "tss-react/mui";
 import type { Except } from "type-fest";
 import { useRichTextEditorContext } from "../context";
+import { getAttributesForEachSelected } from "../utils/getAttributesForEachSelected";
 import MenuSelect, { type MenuSelectProps } from "./MenuSelect";
 
 export type FontFamilySelectOption = {
@@ -50,8 +51,9 @@ export interface MenuSelectFontFamilyProps
    */
   hideUnsetOption?: boolean;
   /**
-   * What to render in the Select when no font-family is currently set for the
-   * selected text. By default shows "Font".
+   * What to render in the Select when either no font-family is currently set
+   * for the selected text, or when multiple different values are set. By
+   * default shows "Font".
    */
   emptyLabel?: React.ReactNode;
 }
@@ -72,6 +74,13 @@ interface TextStyleAttrs extends ReturnType<Editor["getAttributes"]> {
   fontFamily?: string | null;
 }
 
+// Use this as a sentinel value so we can handle the case that the user's
+// selection includes multiple different font families. There won't be a visible
+// "option" in the Select for this value, and this will allow the user to set
+// the current font family to "Default" or to any of the multiple values, and
+// have it take effect. See more comments around `currentFontFamily` below.
+const MULTIPLE_FAMILIES_SELECTED_VALUE = "MULTIPLE";
+
 /** A font-family selector for use with the Tiptap FontFamily extension.  */
 export default function MenuSelectFontFamily({
   options,
@@ -83,9 +92,52 @@ export default function MenuSelectFontFamily({
   const { classes, cx } = useStyles();
   const editor = useRichTextEditorContext();
 
-  const currentAttrs: TextStyleAttrs | undefined =
-    editor?.getAttributes("textStyle");
-  const currentFontFamily = currentAttrs?.fontFamily;
+  // Determine if all of the selected content shares the same set font family.
+  // Scenarios:
+  // 1) If there is exactly one font family amongst the selected content and all
+  //    of the selected content has the font family set, we'll show that as the
+  //    current Selected value (as a user would expect).
+  // 2) If there are multiple families used in the selected content or some
+  //    selected content has font family set and other content does not, we'll
+  //    assign the Select's `value` to a sentinel variable so that users can
+  //    unset the families or can change to any given family.
+  // 3) Otherwise (no font family is set in any selected content), we'll show the
+  //    unsetOption as selected.
+  const allCurrentTextStyleAttrs: TextStyleAttrs[] = editor
+    ? getAttributesForEachSelected(editor.state, "textStyle")
+    : [];
+  const isTextStyleAppliedToEntireSelection = !!editor?.isActive("textStyle");
+  const currentFontFamilies: string[] = allCurrentTextStyleAttrs.map(
+    (attrs) => attrs.fontFamily ?? "" // Treat any null/missing font-family as ""
+  );
+  if (!isTextStyleAppliedToEntireSelection) {
+    // If there is some selected content that does not have textStyle, we can
+    // treat it the same as a selected textStyle mark with fontFamily set to
+    // null or ""
+    currentFontFamilies.push("");
+  }
+  const numUniqueCurrentFontFamilies = new Set(currentFontFamilies).size;
+
+  let currentFontFamily;
+  if (numUniqueCurrentFontFamilies === 1) {
+    // There's exactly one font family selected, so show that
+    currentFontFamily = currentFontFamilies[0];
+  } else if (numUniqueCurrentFontFamilies > 1) {
+    // There are multiple font families (either explicitly, or because some of the
+    // selection has a font family set and some does not). This is similar to what
+    // Microsoft Word and Google Docs do, for instance, showing the font family
+    // input as blank when there are multiple values. If we simply set
+    // currentFontFamily as "" here, then the "unset option" would show as
+    // selected, which would prevent the user from unsetting the font families
+    // for the selected content (since Select onChange does not fire when the
+    // currently selected option is chosen again).
+    currentFontFamily = MULTIPLE_FAMILIES_SELECTED_VALUE;
+  } else {
+    // Show as unset (empty), since there are no font families in any of the
+    // selected content. This will show the "unset option" with the
+    // unsetOptionLabel as selected, if `hideUnsetOption` is false.
+    currentFontFamily = "";
+  }
 
   return (
     <MenuSelect<string>
@@ -102,7 +154,7 @@ export default function MenuSelectFontFamily({
         !editor?.isEditable || !editor.can().setFontFamily("serif")
       }
       renderValue={(value) => {
-        if (!value) {
+        if (!value || value === MULTIPLE_FAMILIES_SELECTED_VALUE) {
           return emptyLabel;
         }
         return options.find((option) => option.value === value)?.label ?? value;
@@ -113,7 +165,6 @@ export default function MenuSelectFontFamily({
       {...menuSelectProps}
       // We don't want to pass any non-string falsy values here, always falling
       // back to ""
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       value={currentFontFamily || ""}
       inputProps={{
         ...menuSelectProps.inputProps,
@@ -127,6 +178,14 @@ export default function MenuSelectFontFamily({
         // Allow users to unset the font-family
         <MenuItem value="">{unsetOptionLabel}</MenuItem>
       )}
+
+      {/* Including a "hidden" option for "multiple selected" (we don't want a
+      user to be able to select this) allows us to avoid "you have provided an
+      out-of-range value" errors */}
+      <MenuItem
+        style={{ display: "none" }}
+        value={MULTIPLE_FAMILIES_SELECTED_VALUE}
+      />
 
       {options.map((fontFamilyOption) => (
         <MenuItem key={fontFamilyOption.value} value={fontFamilyOption.value}>

--- a/src/controls/MenuSelectFontFamily.tsx
+++ b/src/controls/MenuSelectFontFamily.tsx
@@ -2,6 +2,7 @@
 import { MenuItem } from "@mui/material";
 import type { Editor } from "@tiptap/core";
 import type { ReactNode } from "react";
+import { makeStyles } from "tss-react/mui";
 import type { Except } from "type-fest";
 import { useRichTextEditorContext } from "../context";
 import MenuSelect, { type MenuSelectProps } from "./MenuSelect";
@@ -55,6 +56,14 @@ export interface MenuSelectFontFamilyProps
   emptyLabel?: React.ReactNode;
 }
 
+const useStyles = makeStyles({ name: { MenuSelectFontFamily } })({
+  selectInput: {
+    // We use a fixed width so that the Select element won't change sizes as
+    // the selected option changes
+    width: 55,
+  },
+});
+
 // We can return any textStyle attributes when calling
 // `getAttributes("textStyle")`, but may return the font-family attribute here,
 // so add typing for that. Based on
@@ -71,6 +80,7 @@ export default function MenuSelectFontFamily({
   emptyLabel = "Font",
   ...menuSelectProps
 }: MenuSelectFontFamilyProps) {
+  const { classes, cx } = useStyles();
   const editor = useRichTextEditorContext();
 
   const currentAttrs: TextStyleAttrs | undefined =
@@ -105,6 +115,13 @@ export default function MenuSelectFontFamily({
       // back to ""
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       value={currentFontFamily || ""}
+      inputProps={{
+        ...menuSelectProps.inputProps,
+        className: cx(
+          classes.selectInput,
+          menuSelectProps.inputProps?.className
+        ),
+      }}
     >
       {!hideUnsetOption && (
         // Allow users to unset the font-family

--- a/src/controls/MenuSelectHeading.tsx
+++ b/src/controls/MenuSelectHeading.tsx
@@ -234,6 +234,7 @@ export default function MenuSelectHeading({
         return result ?? selected;
       }}
       aria-label="Text headings"
+      tooltipTitle="Styles"
       {...menuSelectProps}
       value={selectedValue}
       inputProps={{

--- a/src/extensions/HeadingWithAnchorComponent.tsx
+++ b/src/extensions/HeadingWithAnchorComponent.tsx
@@ -16,7 +16,7 @@ import slugify from "../utils/slugify";
 // https://github.com/ueberdosis/tiptap/blob/c9eb6a6299796450c7c1cfdc3552d76070c78c65/packages/extension-heading/src/heading.ts#L41-L48
 // We extend Record<string, unknown>, since we may inherit other global
 // attributes as well, aligned with ProseMirrorNode.attrs typing.
-interface HeadingNodeAttributes extends Record<string, unknown> {
+export interface HeadingNodeAttributes extends Record<string, unknown> {
   level: Level;
 }
 

--- a/src/utils/getAttributesForEachSelected.ts
+++ b/src/utils/getAttributesForEachSelected.ts
@@ -1,0 +1,44 @@
+import { getSchemaTypeNameByName } from "@tiptap/core";
+import type { MarkType, NodeType } from "@tiptap/pm/model";
+import type { EditorState } from "@tiptap/pm/state";
+import { getAttributesForMarks } from "./getAttributesForMarks";
+import { getAttributesForNodes } from "./getAttributesForNodes";
+
+/**
+ * Get the attributes of all currently selected marks and nodes of the given
+ * type or name.
+ *
+ * Returns an array of Records, with an entry for each matching mark/node that
+ * is currently selected.
+ *
+ * NOTE: This function will omit any non-matching nodes/marks in the result
+ * array. It may be useful to run `editor.isActive(typeOrName)` separately if
+ * you want to guarantee that all selected content is of the given type/name.
+ *
+ * Based directly on Tiptap's getAttributes
+ * (https://github.com/ueberdosis/tiptap/blob/f387ad3dd4c2b30eaea33fb0ba0b42e0cd39263b/packages/core/src/helpers/getAttributes.ts),
+ * but returns results for each of the matching marks and nodes, rather than
+ * just the first. This enables us to handle situations where there are multiple
+ * different attributes set for the different marks/nodes. See related issue
+ * here: https://github.com/ueberdosis/tiptap/issues/3481
+ */
+export function getAttributesForEachSelected(
+  state: EditorState,
+  typeOrName: string | NodeType | MarkType
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Record<string, any>[] {
+  const schemaType = getSchemaTypeNameByName(
+    typeof typeOrName === "string" ? typeOrName : typeOrName.name,
+    state.schema
+  );
+
+  if (schemaType === "node") {
+    return getAttributesForNodes(state, typeOrName as NodeType);
+  }
+
+  if (schemaType === "mark") {
+    return getAttributesForMarks(state, typeOrName as MarkType);
+  }
+
+  return [];
+}

--- a/src/utils/getAttributesForMarks.ts
+++ b/src/utils/getAttributesForMarks.ts
@@ -1,0 +1,41 @@
+import { getMarkType } from "@tiptap/core";
+import type { Mark, MarkType } from "@tiptap/pm/model";
+import type { EditorState } from "@tiptap/pm/state";
+
+/**
+ * Get the attributes of all currently selected marks of the given type or
+ * name.
+ *
+ * Returns an array of Records, with an entry for each matching mark that is
+ * currently selected.
+ *
+ * Based directly on Tiptap's getMarkAttributes
+ * (https://github.com/ueberdosis/tiptap/blob/f387ad3dd4c2b30eaea33fb0ba0b42e0cd39263b/packages/core/src/helpers/getMarkAttributes.ts),
+ * but returns results for each of the matching marks, rather than just the
+ * first. See related: https://github.com/ueberdosis/tiptap/issues/3481
+ */
+export function getAttributesForMarks(
+  state: EditorState,
+  typeOrName: string | MarkType
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Record<string, any>[] {
+  const type = getMarkType(typeOrName, state.schema);
+  const { from, to, empty } = state.selection;
+  const marks: Mark[] = [];
+
+  if (empty) {
+    if (state.storedMarks) {
+      marks.push(...state.storedMarks);
+    }
+
+    marks.push(...state.selection.$head.marks());
+  } else {
+    state.doc.nodesBetween(from, to, (node) => {
+      marks.push(...node.marks);
+    });
+  }
+
+  return marks
+    .filter((markItem) => markItem.type.name === type.name)
+    .map((mark) => ({ ...mark.attrs }));
+}

--- a/src/utils/getAttributesForNodes.ts
+++ b/src/utils/getAttributesForNodes.ts
@@ -1,0 +1,34 @@
+import { getNodeType } from "@tiptap/core";
+import type { Node, NodeType } from "@tiptap/pm/model";
+import type { EditorState } from "@tiptap/pm/state";
+
+/**
+ * Get the attributes of all currently selected nodes of the given type or
+ * name.
+ *
+ * Returns an array of Records, with an entry for each matching node that is
+ * currently selected.
+ *
+ * Based directly on Tiptap's getNodeAttributes
+ * (https://github.com/ueberdosis/tiptap/blob/f387ad3dd4c2b30eaea33fb0ba0b42e0cd39263b/packages/core/src/helpers/getNodeAttributes.ts),
+ * but returns results for each of the matching nodes, rather than just the
+ * first. See related: https://github.com/ueberdosis/tiptap/issues/3481
+ */
+export function getAttributesForNodes(
+  state: EditorState,
+  typeOrName: string | NodeType
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Record<string, any>[] {
+  const type = getNodeType(typeOrName, state.schema);
+  const { from, to } = state.selection;
+  const nodes: Node[] = [];
+
+  state.doc.nodesBetween(from, to, (node) => {
+    nodes.push(node);
+  });
+
+  return nodes
+    .reverse()
+    .filter((nodeItem) => nodeItem.type.name === type.name)
+    .map((node) => ({ ...node.attrs }));
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,7 @@
 export { default as DebounceRender } from "./DebounceRender";
+export { getAttributesForEachSelected } from "./getAttributesForEachSelected";
+export { getAttributesForMarks } from "./getAttributesForMarks";
+export { getAttributesForNodes } from "./getAttributesForNodes";
 export { default as keymapPluginFactory } from "./keymapPluginFactory";
 export { getModShortcutKey, isMac, isTouchDevice } from "./platform";
 export { default as slugify } from "./slugify";


### PR DESCRIPTION
Summary of changes:

- `MenuSelectHeading`: when multiple different headings are selected (and no other content), show `labels.empty` (which defaults to "Change to...") rather than showing the _first_ selected heading. This will ensure you're able to update both headings to the same heading level as the first in the selection, which wasn't possible before (since `onChange` doesn't fire if you select the same option).
    ![Screenshot 2023-08-10 at 7 50 43 PM](https://github.com/sjdemartini/mui-tiptap/assets/1647130/511a8932-70d2-40d3-b0b9-52fe0e8eab01)
- `MenuSelectHeading`: Add "Styles" as default tooltip (as shown above). This can be overridden with `tooltipTitle` prop. Formerly no tooltip was shown by default, inconsistent with other controls.
- `MenuSelectFontSize` and  `MenuSelectFontFamily`: When content with multiple different font sizes or multiple different font families are selected, respectively, show the default `emptyLabel` in that scenario. This is similar to Google Docs and Microsoft Word, where they show the font size and font family entries as blank when there is text with different values selected.
    ![mui_tiptap_font_size_and_family_demo](https://github.com/sjdemartini/mui-tiptap/assets/1647130/90f951fb-412b-436c-8d79-a6d6d08e2890)
- `MenuSelectFontFamily`: Use a fixed width (so menu bar doesn't change positioning as different font families are selected).
- `MenuSelectTextAlign`: when content with multiple different alignments is selected, render the new `emptyLabel` prop, which defaults to `""` (so the select appears blank, since there isn't an appropriate icon for that scenario). This enables you to now change all alignments to left-align in that situation, whereas before you couldn't (since it wouldn't fire `onChange`).
    ![Screenshot 2023-08-10 at 7 23 46 PM](https://github.com/sjdemartini/mui-tiptap/assets/1647130/85cad3d3-84ae-4479-a37c-24de85b9d1dd)
- Export new Tiptap editor utilities (used with the above "multiple values" behavior described above), which return the attributes of *all* matching selected nodes/marks, rather than just giving you the first, like `getAttributes` does: `getAttributesForEachSelected`, `getAttributesForMarks`, `getAttributesForNodes`


Several of the above are related to the issue filed here https://github.com/ueberdosis/tiptap/issues/3481, which is still open. This works around the existing quirks using the new utils above to ensure the Selects behave in predictable ways. 

There is still one semi-related known caveat: it's possible to "unset" the font size when you only meant to unset the font family (and vice versa), due to this underlying bug I've reported to Tiptap: https://github.com/ueberdosis/tiptap/issues/4311. This happens when the first of the selected text would end up with no formatting, but the latter stuff in the selection should've kept its formatting. Relatively minor edge case.