### PR TITLE
Mark package as being side-effect-free

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "sideEffects": false,
   "scripts": {
     "build": "pnpm clean && tsc --project tsconfig.build.json && tsc --project tsconfig.build-esm.json",
     "clean": "rimraf dist coverage",


### PR DESCRIPTION
For tree-shaking purposes with Webpack since we don't rely on any global side effects
(https://webpack.js.org/guides/tree-shaking/,
https://sgom.es/posts/2020-06-15-everything-you-never-wanted-to-know-about-side-effects/)