### PR TITLE
Use matching icon colors in Select controls (in light mode)

### DIFF
--- a/src/controls/MenuSelect.tsx
+++ b/src/controls/MenuSelect.tsx
@@ -20,6 +20,15 @@ const useStyles = makeStyles({ name: { MenuSelect } })((theme) => {
       "&:not(:hover):not(.Mui-focused) .MuiOutlinedInput-notchedOutline": {
         borderWidth: 0,
       },
+
+      "& .MuiSvgIcon-root": {
+        // Ensure that if an icon is used as the `renderValue` result, it uses
+        // the same color as the default ToggleButton icon and the Select
+        // dropdown arrow icon
+        // https://github.com/mui/material-ui/blob/2cb9664b16d5a862a3796add7c8e3b088b47acb5/packages/mui-material/src/ToggleButton/ToggleButton.js#L60,
+        // https://github.com/mui/material-ui/blob/0b7beb93c9015da6e35c2a31510f679126cf0de1/packages/mui-material/src/NativeSelect/NativeSelectInput.js#L96,
+        color: theme.palette.action.active,
+      },
     },
 
     select: {

--- a/src/controls/MenuSelectTextAlign.tsx
+++ b/src/controls/MenuSelectTextAlign.tsx
@@ -76,7 +76,7 @@ export interface MenuSelectTextAlignProps
   emptyLabel?: React.ReactNode;
 }
 
-const useStyles = makeStyles({ name: { MenuSelectTextAlign } })({
+const useStyles = makeStyles({ name: { MenuSelectTextAlign } })((theme) => ({
   selectInput: {
     // We use a fixed width equal to the size of the menu button icon so that
     // the Select element won't change sizes even if we show the "blank"
@@ -101,8 +101,13 @@ const useStyles = makeStyles({ name: { MenuSelectTextAlign } })({
 
   menuButtonIcon: {
     fontSize: MENU_BUTTON_FONT_SIZE_DEFAULT,
+    // For consistency with toggle button default icon color and the Select
+    // dropdown arrow icon color
+    // https://github.com/mui/material-ui/blob/2cb9664b16d5a862a3796add7c8e3b088b47acb5/packages/mui-material/src/ToggleButton/ToggleButton.js#L60,
+    // https://github.com/mui/material-ui/blob/0b7beb93c9015da6e35c2a31510f679126cf0de1/packages/mui-material/src/NativeSelect/NativeSelectInput.js#L96
+    color: theme.palette.action.active,
   },
-});
+}));
 
 const DEFAULT_ALIGNMENT_OPTIONS: TextAlignSelectOption[] = [
   {


### PR DESCRIPTION
This ensures that (in light mode) if a Select controls component renders an icon for the current value (and for the MenuSelectTextAlign, for the options too), it matches the color of the non-selected MenuButton controls and the color of the select dropdown arrow.

Notice it was falling back to the default text color (dark grey) instead of using the lighter grey ("active") for the icons inside Selects:

| before | after |
|--------|--------|
| ![image](https://github.com/sjdemartini/mui-tiptap/assets/1647130/d73c6957-6ac7-4878-9ad2-3da63b1447b7) | ![image](https://github.com/sjdemartini/mui-tiptap/assets/1647130/abcb43ed-e945-479c-b3d8-b7b521db700c) | 

