### PR TITLE
Allow prop overrides and styling for MenuDivider

### DIFF
--- a/src/MenuDivider.tsx
+++ b/src/MenuDivider.tsx
@@ -1,14 +1,23 @@
-import { Divider, styled } from "@mui/material";
+import { Divider, type DividerProps } from "@mui/material";
+import { makeStyles } from "tss-react/mui";
 
-const StyledDivider = styled(Divider)(({ theme }) => ({
-  height: 18,
-  margin: theme.spacing(0, 0.5),
+// The orientation of our menu dividers will always be vertical
+export type MenuDividerProps = Omit<DividerProps, "orientation">;
+
+const useStyles = makeStyles({ name: { MenuDivider } })((theme) => ({
+  root: {
+    height: 18,
+    margin: theme.spacing(0, 0.5),
+  },
 }));
 
-/**
- * Renders a vertical line divider to separate different sections of your menu
- * bar and implicitly group separate controls.
- */
-export default function MenuDivider() {
-  return <StyledDivider orientation="vertical" />;
+export default function MenuDivider(props: MenuDividerProps) {
+  const { classes, cx } = useStyles();
+  return (
+    <Divider
+      orientation="vertical"
+      {...props}
+      className={cx(classes.root, props.className)}
+    />
+  );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export {
   type LinkBubbleMenuProps,
 } from "./LinkBubbleMenu";
 export { default as MenuBar, type MenuBarProps } from "./MenuBar";
-export { default as MenuDivider } from "./MenuDivider";
+export { default as MenuDivider, type MenuDividerProps } from "./MenuDivider";
 export {
   default as RichTextContent,
   type RichTextContentProps,


### PR DESCRIPTION
Now users can use `sx={{ borderColor: 'red' }}` for instance, or pass in their own `className`, etc.

No change in UI.