### PR TITLE
Use component as makeStyles param for MenuButton

### DIFF
--- a/src/controls/MenuButton.tsx
+++ b/src/controls/MenuButton.tsx
@@ -36,7 +36,7 @@ export type MenuButtonProps = {
 
 export const MENU_BUTTON_FONT_SIZE_DEFAULT = "1.25rem";
 
-const useStyles = makeStyles({ name: "MenuButton" })({
+const useStyles = makeStyles({ name: { MenuButton } })({
   root: {
     // Use && for additional specificity, since MUI's conditional "disabled"
     // styles also set the border


### PR DESCRIPTION
Rather than hard-coding the name separately. For consistency with other mui-tiptap components.