### PR TITLE
Don't use ".." import path internally to fix ESM import error

### DIFF
--- a/src/controls/MenuButtonColorPicker.tsx
+++ b/src/controls/MenuButtonColorPicker.tsx
@@ -11,12 +11,13 @@ import {
 import { useEffect, useState, type ReactNode } from "react";
 import { makeStyles } from "tss-react/mui";
 import type { Except } from "type-fest";
-import { MenuButton, Z_INDEXES, type MenuButtonProps } from "..";
+import { Z_INDEXES } from "../styles";
 import {
   ColorPicker,
   type ColorPickerProps,
   type SwatchColorOption,
 } from "./ColorPicker";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
 export interface MenuButtonColorPickerProps
   // Omit the default `color`, `value`, and `onChange` toggle button props so

--- a/src/controls/MenuButtonHighlightColor.tsx
+++ b/src/controls/MenuButtonHighlightColor.tsx
@@ -1,6 +1,6 @@
 /// <reference types="@tiptap/extension-highlight" />
 import { BorderColor } from "@mui/icons-material";
-import { useRichTextEditorContext } from "..";
+import { useRichTextEditorContext } from "../context";
 import {
   MenuButtonColorPicker,
   type MenuButtonColorPickerProps,

--- a/src/controls/MenuButtonHighlightToggle.tsx
+++ b/src/controls/MenuButtonHighlightToggle.tsx
@@ -1,6 +1,7 @@
 /// <reference types="@tiptap/extension-highlight" />
 import { BorderColor } from "@mui/icons-material";
-import { MenuButton, useRichTextEditorContext, type MenuButtonProps } from "..";
+import { useRichTextEditorContext } from "../context";
+import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
 export type MenuButtonHighlightToggleProps = Partial<MenuButtonProps>;
 

--- a/src/controls/MenuButtonTextColor.tsx
+++ b/src/controls/MenuButtonTextColor.tsx
@@ -1,6 +1,6 @@
 /// <reference types="@tiptap/extension-color" />
 import { FormatColorText } from "@mui/icons-material";
-import { useRichTextEditorContext } from "..";
+import { useRichTextEditorContext } from "../context";
 import {
   MenuButtonColorPicker,
   type MenuButtonColorPickerProps,


### PR DESCRIPTION
Despite things working well in an external environment dev server with Vite, running Vitest against it revealed this error:

```
TypeError: Cannot read properties of undefined (reading 'BUBBLE_MENU')
 ❯ node_modules/mui-tiptap/dist/esm/controls/MenuButtonColorPicker.js:44:49

 ❯ node_modules/mui-tiptap/dist/esm/controls/index.js:29:188
 ❯ node_modules/mui-tiptap/dist/esm/index.js:24:210
```

Seems due to the fact that these new component files were using import paths of `".."` and not more targeted file-specific import paths, and so perhaps can't be resolved properly in ESM contexts.