### PR TITLE
Add typesVersions to package.json to support usage with `"node"` resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,16 @@
       "import": "./dist/esm/icons/index.js"
     }
   },
+  "typesVersions": {
+    "*": {
+      "icons": [
+        "./dist/icons/index.d.ts"
+      ],
+      "*": [
+        "*"
+      ]
+    }
+  },
   "license": "MIT",
   "engines": {
     "pnpm": ">=8"


### PR DESCRIPTION
In order to separately export from two different modules, `"mui-tiptap"` and `"mui-tiptap/icons"`, typically our existing `"exports"` configuration in package.json would be sufficient. However, it turns out that this only supports importing the non-root module in a TS application if the consuming package that installs mui-tiptap uses `moduleResolution` of `Node16`, `NodeNext`, `bundler`, etc. but *not* `node` (the default, and the option suggested by TS in their official docs here
https://www.typescriptlang.org/docs/handbook/module-resolution.html#module-resolution-strategies).

As a (semi-hacky) workaround, we define `typesVersions` so that we can be compatible with `node`/`node10` resolution in consuming packages for our separate `"mui-tiptap/icons"` module.

Some resources related to this:
- https://antfu.me/posts/types-for-sub-modules
- https://stackoverflow.com/questions/72193784/why-doesnt-the-exports-field-of-npm-work-in-typescript
- https://stackoverflow.com/questions/70296652/how-can-i-use-exports-in-package-json-for-nested-submodules-and-typescript
- https://www.typescriptlang.org/tsconfig#moduleResolution
- https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#version-selection-with-typesversions
- https://www.typescriptlang.org/docs/handbook/module-resolution.html#tracing-module-resolution