### PR TITLE
Fall back to default mark color if highlight is active but has "" color

### DIFF
--- a/src/controls/MenuButtonHighlightColor.tsx
+++ b/src/controls/MenuButtonHighlightColor.tsx
@@ -42,7 +42,8 @@ export default function MenuButtonHighlightColor({
       // highlight keyboard shortcut, toggleHighlight/setHighlight when no
       // explicit color is provided, and the "==thing==" syntax), fall back to
       // the provided defaultMarkColor
-      (editor.getAttributes("highlight").color as string | null | undefined) ??
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      (editor.getAttributes("highlight").color as string | null | undefined) ||
       defaultMarkColor
     : "";
   return (


### PR DESCRIPTION
If highlighting is active but the Tiptap state has color is empty, we should fall back to showing the "active color" in button and color-picker as the defaultMarkColor. We were already doing this if the color was `null`, but this fixes it so it behaves that way if the `color` attribute is an empty string too.