### PR TITLE
Improve "active text color" logic when multiple colors in selection

### DIFF
--- a/src/controls/MenuButtonTextColor.tsx
+++ b/src/controls/MenuButtonTextColor.tsx
@@ -1,6 +1,8 @@
 /// <reference types="@tiptap/extension-color" />
+import type { Editor } from "@tiptap/core";
 import { useRichTextEditorContext } from "../context";
 import { FormatColorTextNoBar } from "../icons";
+import { getAttributesForEachSelected } from "../utils";
 import {
   MenuButtonColorPicker,
   type MenuButtonColorPickerProps,
@@ -17,6 +19,14 @@ export interface MenuButtonTextColorProps
   defaultTextColor?: string;
 }
 
+// Tiptap will return any textStyle attributes when calling
+// `getAttributes("textStyle")`, but here we care about `color`, so add more
+// explicit typing for that. Based on
+// https://github.com/ueberdosis/tiptap/blob/6cbc2d423391c950558721510c1b4c8614feb534/packages/extension-color/src/color.ts#L37-L51
+interface TextStyleAttrs extends ReturnType<Editor["getAttributes"]> {
+  color?: string | null;
+}
+
 export default function MenuButtonTextColor({
   IconComponent = FormatColorTextNoBar,
   tooltipLabel = "Text color",
@@ -24,17 +34,47 @@ export default function MenuButtonTextColor({
   ...menuButtonProps
 }: MenuButtonTextColorProps) {
   const editor = useRichTextEditorContext();
-  const currentTextColor = editor?.getAttributes("textStyle").color as
-    | string
-    | null
-    | undefined;
+
+  // Determine if all of the selected content shares the same set color.
+  const allCurrentTextStyleAttrs: TextStyleAttrs[] = editor
+    ? getAttributesForEachSelected(editor.state, "textStyle")
+    : [];
+  const isTextStyleAppliedToEntireSelection = !!editor?.isActive("textStyle");
+  const currentColors: string[] = allCurrentTextStyleAttrs.map(
+    // Treat any null/missing color as the default color
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    (attrs) => attrs.color || defaultTextColor
+  );
+  if (!isTextStyleAppliedToEntireSelection) {
+    // If there is some selected content that does not have textStyle, we can
+    // treat it the same as a selected textStyle mark with color set to the
+    // default
+    currentColors.push(defaultTextColor);
+  }
+  const numUniqueCurrentColors = new Set(currentColors).size;
+
+  let currentColor;
+  if (numUniqueCurrentColors === 1) {
+    // There's exactly one color in the selected content, so show that
+    currentColor = currentColors[0];
+  } else if (numUniqueCurrentColors > 1) {
+    // There are multiple colors (either explicitly, or because some of the
+    // selection has a color set and some does not and is using the default
+    // color). Similar to other rich text editors like Google Docs, we'll treat
+    // this as "unset" and not show a color indicator in the button or a
+    // "current" color when interacting with the color picker.
+    currentColor = "";
+  } else {
+    // Since no color was set anywhere in the selected content, we should show
+    // the default color
+    currentColor = defaultTextColor;
+  }
+
   return (
     <MenuButtonColorPicker
       IconComponent={IconComponent}
       tooltipLabel={tooltipLabel}
-      // If the color is unset, we fall back to the default color
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      value={currentTextColor || defaultTextColor}
+      value={currentColor}
       onChange={(newColor) => {
         editor?.chain().focus().setColor(newColor).run();
       }}


### PR DESCRIPTION
We'll now show no color in the indicator if there are multiple colors within the current selection. This is more in line with how we handle font family and font size, and how other rich text editors behave. 

Follow up to @ericdwang's comment here https://github.com/sjdemartini/mui-tiptap/pull/139#issuecomment-1693790578

Demo:
![mui-tiptap_active_color_multiple](https://github.com/sjdemartini/mui-tiptap/assets/1647130/7d737882-a117-43d7-9a18-3fd77b12b013)

