### PR TITLE
Rename `MentionList` -> `SuggestionList` in demo example for clarity

### DIFF
--- a/src/demo/SuggestionList.tsx
+++ b/src/demo/SuggestionList.tsx
@@ -3,8 +3,8 @@ import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
 import type { MentionSuggestion } from "./mentionSuggestionOptions";
 
-export type MentionListRef = {
-  // For convenience using this MentionList from within the
+export type SuggestionListRef = {
+  // For convenience using this SuggestionList from within the
   // mentionSuggestionOptions, we'll match the signature of SuggestionOptions's
   // `onKeyDown` returned in its `render` function
   onKeyDown: NonNullable<
@@ -23,9 +23,9 @@ interface MentionNodeAttrs {
   label?: string | null;
 }
 
-export type MentionListProps = SuggestionProps<MentionSuggestion>;
+export type SuggestionListProps = SuggestionProps<MentionSuggestion>;
 
-const MentionList = forwardRef<MentionListRef, MentionListProps>(
+const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>(
   (props, ref) => {
     const [selectedIndex, setSelectedIndex] = useState(0);
 
@@ -123,6 +123,6 @@ const MentionList = forwardRef<MentionListRef, MentionListProps>(
   }
 );
 
-MentionList.displayName = "MentionList";
+SuggestionList.displayName = "SuggestionList";
 
-export default MentionList;
+export default SuggestionList;

--- a/src/demo/mentionSuggestionOptions.ts
+++ b/src/demo/mentionSuggestionOptions.ts
@@ -1,7 +1,7 @@
 import type { MentionOptions } from "@tiptap/extension-mention";
 import { ReactRenderer } from "@tiptap/react";
 import tippy, { type Instance as TippyInstance } from "tippy.js";
-import MentionList, { type MentionListRef } from "./MentionList";
+import SuggestionList, { type SuggestionListRef } from "./SuggestionList";
 
 export type MentionSuggestion = {
   id: string;
@@ -80,12 +80,12 @@ export const mentionSuggestionOptions: MentionOptions["suggestion"] = {
     ),
 
   render: () => {
-    let component: ReactRenderer<MentionListRef> | undefined;
+    let component: ReactRenderer<SuggestionListRef> | undefined;
     let popup: TippyInstance | undefined;
 
     return {
       onStart: (props) => {
-        component = new ReactRenderer(MentionList, {
+        component = new ReactRenderer(SuggestionList, {
           props,
           editor: props.editor,
         });


### PR DESCRIPTION
It's actually a list of suggestions (for use with the Mention extension), rather than being a list of "mentions". This deviates from Tiptap's example, but I feel is a clearer naming convention.