### PR TITLE
Rename `insertImages` position option for brevity

### DIFF
--- a/src/demo/Editor.tsx
+++ b/src/demo/Editor.tsx
@@ -57,7 +57,7 @@ export default function Editor() {
       insertImages({
         images: attributesForImageFiles,
         editor: rteRef.current.editor,
-        insertPosition,
+        position: insertPosition,
       });
     },
     []

--- a/src/utils/images.ts
+++ b/src/utils/images.ts
@@ -20,17 +20,17 @@ export type ImageNodeAttributes = {
  *
  * @param options.images The attributes of each image to insert
  * @param options.editor The Tiptap editor in which to insert
- * @param options.insertPosition The position at which to insert into the editor
+ * @param options.position The position at which to insert into the editor
  * content. If not given, uses the current editor caret/selection position.
  */
 export function insertImages({
   images,
   editor,
-  insertPosition,
+  position,
 }: {
   images: ImageNodeAttributes[];
   editor: Editor | null;
-  insertPosition?: number;
+  position?: number;
 }): void {
   if (!editor || editor.isDestroyed || images.length === 0) {
     return;
@@ -46,12 +46,12 @@ export function insertImages({
   editor
     .chain()
     .command(({ commands }) => {
-      if (insertPosition == null) {
+      if (position == null) {
         // We'll insert at and replace the user's current selection if there
         // wasn't a specific insert position given
         return commands.insertContent(imageContentToInsert);
       } else {
-        return commands.insertContentAt(insertPosition, imageContentToInsert);
+        return commands.insertContentAt(position, imageContentToInsert);
       }
     })
     .focus()


### PR DESCRIPTION
This is more consistent with Tiptap's util parameter naming, and "insertPosition" was redundant given the function name. Technically a "breaking" API change, but was just released, wasn't documented explicitly, and is a straightforward update.