### PR TITLE
Update iconbuddy link to resolve 404

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ To instead test a "built" version of this package which is installed into an "ex
 
 When the `@mui/icons-material` icon set is insufficient, it can be helpful to browse a larger set of free open-source icons and add what’s needed directly to `mui-tiptap`. This also avoids any additional third-party JS dependencies.
 
-1. Download an icon (e.g. from https://iconbuddy.app/svg-icons, which aggregates and organizes thousands of free icons from many separate icon libraries and sources)
+1. Download an icon (e.g. from https://iconbuddy.app, which aggregates and organizes thousands of free icons from many separate icon libraries and sources)
 2. Create a new tsx file in `src/icons/`
 3. If icon edits or customizations are needed, https://yqnn.github.io/svg-path-editor/ and https://boxy-svg.com/app are handy free web-based tools. Typically you will want to work with and export in a "0 0 24 24" viewBox, since that is what MUI icons use by default.
 4. Copy the `<path>` from the downloaded SVG, and in the new TSX file, pass that as the argument to the `createSvgIcon` helper from `@mui/material`. (If there are multiple `<path>`s, put them within a React Fragment.)

--- a/src/icons/FormatInkHighlighter.tsx
+++ b/src/icons/FormatInkHighlighter.tsx
@@ -2,8 +2,8 @@ import { createSvgIcon } from "@mui/material";
 
 const FormatInkHighlighter = createSvgIcon(
   // Part of Material Symbols (and so unfortunately not in @mui/icons-material),
-  // this SVG was downloaded from https://iconbuddy.app/svg-icons, and a similar
-  // source version can be found here
+  // this SVG was downloaded from https://iconbuddy.app, and a similar source
+  // version can be found here
   // https://fonts.google.com/icons?icon.query=highlight&icon.set=Material+Symbols.
   <path d="M2 24v-4h20v4H2Zm8.6-16l5.4 5.425l-4 4q-.6.6-1.413.6t-1.412-.6L8.5 18h-5l3.15-3.125q-.6-.6-.625-1.438T6.6 12l4-4ZM12 6.575L16 2.6q.6-.6 1.413-.6t1.412.6l2.6 2.575q.6.6.6 1.413T21.425 8l-4 4L12 6.575Z" />,
   "FormatInkHighlighter"


### PR DESCRIPTION
As seen here
https://github.com/sjdemartini/mui-tiptap/actions/runs/6148807694/job/16683337943?pr=149#step:12:24

Seems they removed/changed that route.