### PR TITLE
Remove only-allow pre-install due to issue installing with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "lint": "eslint --ext .js,.jsx,.ts,.tsx src --fix",
     "lint:check": "eslint --ext .js,.jsx,.ts,.tsx src",
     "md-link:check": "markdown-link-check -v -p *.md -c .markdown-link-check-config.json",
-    "preinstall": "npx only-allow pnpm",
     "test": "vitest run",
     "test:watch": "vitest watch",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
Fixes https://github.com/sjdemartini/mui-tiptap/issues/152 and https://github.com/sjdemartini/mui-tiptap/issues/151. This seems to be due to a bug in only-allow that specifically affects `npm`, where the `only-allow` goes into effect even when installing the package as a dependency: https://github.com/pnpm/only-allow/issues/13