### PR TITLE
fix: change remaining mui-icons to path imports

### DIFF
--- a/src/controls/ColorSwatchButton.tsx
+++ b/src/controls/ColorSwatchButton.tsx
@@ -1,4 +1,4 @@
-import { Check } from "@mui/icons-material";
+import Check from "@mui/icons-material/Check";
 import {
   forwardRef,
   type ComponentPropsWithoutRef,

--- a/src/controls/MenuButtonAddImage.tsx
+++ b/src/controls/MenuButtonAddImage.tsx
@@ -1,4 +1,4 @@
-import { AddPhotoAlternate } from "@mui/icons-material";
+import AddPhotoAlternate from "@mui/icons-material/AddPhotoAlternate";
 import type { SetRequired } from "type-fest";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";

--- a/src/controls/MenuButtonBlockquote.tsx
+++ b/src/controls/MenuButtonBlockquote.tsx
@@ -1,5 +1,5 @@
 /// <reference types="@tiptap/extension-blockquote" />
-import { FormatQuote } from "@mui/icons-material";
+import FormatQuote from "@mui/icons-material/FormatQuote";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 

--- a/src/controls/MenuButtonBold.tsx
+++ b/src/controls/MenuButtonBold.tsx
@@ -1,5 +1,5 @@
 /// <reference types="@tiptap/extension-bold" />
-import { FormatBold } from "@mui/icons-material";
+import FormatBold from "@mui/icons-material/FormatBold";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 

--- a/src/controls/MenuButtonBulletedList.tsx
+++ b/src/controls/MenuButtonBulletedList.tsx
@@ -1,5 +1,5 @@
 /// <reference types="@tiptap/extension-bullet-list" />
-import { FormatListBulleted } from "@mui/icons-material";
+import FormatListBulleted from "@mui/icons-material/FormatListBulleted";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 

--- a/src/controls/MenuButtonCode.tsx
+++ b/src/controls/MenuButtonCode.tsx
@@ -1,5 +1,5 @@
 /// <reference types="@tiptap/extension-code" />
-import { Code } from "@mui/icons-material";
+import Code from "@mui/icons-material/Code";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 

--- a/src/controls/MenuButtonEditLink.tsx
+++ b/src/controls/MenuButtonEditLink.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@mui/icons-material";
+import Link from "@mui/icons-material/Link";
 import { useRef } from "react";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";

--- a/src/controls/MenuButtonIndent.tsx
+++ b/src/controls/MenuButtonIndent.tsx
@@ -1,4 +1,4 @@
-import { FormatIndentIncrease } from "@mui/icons-material";
+import FormatIndentIncrease from "@mui/icons-material/FormatIndentIncrease";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 

--- a/src/controls/MenuButtonItalic.tsx
+++ b/src/controls/MenuButtonItalic.tsx
@@ -1,5 +1,5 @@
 /// <reference types="@tiptap/extension-italic" />
-import { FormatItalic } from "@mui/icons-material";
+import FormatItalic from "@mui/icons-material/FormatItalic";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 

--- a/src/controls/MenuButtonOrderedList.tsx
+++ b/src/controls/MenuButtonOrderedList.tsx
@@ -1,5 +1,5 @@
 /// <reference types="@tiptap/extension-ordered-list" />
-import { FormatListNumbered } from "@mui/icons-material";
+import FormatListNumbered from "@mui/icons-material/FormatListNumbered";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 

--- a/src/controls/MenuButtonRemoveFormatting.tsx
+++ b/src/controls/MenuButtonRemoveFormatting.tsx
@@ -1,4 +1,4 @@
-import { FormatClear } from "@mui/icons-material";
+import FormatClear from "@mui/icons-material/FormatClear";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 

--- a/src/controls/MenuButtonStrikethrough.tsx
+++ b/src/controls/MenuButtonStrikethrough.tsx
@@ -1,5 +1,5 @@
 /// <reference types="@tiptap/extension-strike" />
-import { StrikethroughS } from "@mui/icons-material";
+import StrikethroughS from "@mui/icons-material/StrikethroughS";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 

--- a/src/controls/MenuButtonSubscript.tsx
+++ b/src/controls/MenuButtonSubscript.tsx
@@ -1,5 +1,5 @@
 /// <reference types="@tiptap/extension-subscript" />
-import { Subscript } from "@mui/icons-material";
+import Subscript from "@mui/icons-material/Subscript";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 

--- a/src/controls/MenuButtonSuperscript.tsx
+++ b/src/controls/MenuButtonSuperscript.tsx
@@ -1,5 +1,5 @@
 /// <reference types="@tiptap/extension-superscript" />
-import { Superscript } from "@mui/icons-material";
+import Superscript from "@mui/icons-material/Superscript";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 

--- a/src/controls/MenuButtonTaskList.tsx
+++ b/src/controls/MenuButtonTaskList.tsx
@@ -1,5 +1,5 @@
 /// <reference types="@tiptap/extension-task-list" />
-import { Checklist } from "@mui/icons-material";
+import Checklist from "@mui/icons-material/Checklist";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 

--- a/src/controls/MenuButtonUnindent.tsx
+++ b/src/controls/MenuButtonUnindent.tsx
@@ -1,4 +1,4 @@
-import { FormatIndentDecrease } from "@mui/icons-material";
+import FormatIndentDecrease from "@mui/icons-material/FormatIndentIncrease";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 

--- a/src/controls/MenuSelectFontSize.tsx
+++ b/src/controls/MenuSelectFontSize.tsx
@@ -1,4 +1,4 @@
-import { FormatSize } from "@mui/icons-material";
+import FormatSize from "@mui/icons-material/FormatSize";
 import { MenuItem } from "@mui/material";
 import type { Editor } from "@tiptap/core";
 import type { ReactNode } from "react";

--- a/src/controls/TableMenuControls.tsx
+++ b/src/controls/TableMenuControls.tsx
@@ -1,4 +1,5 @@
-import { FormatColorFill, GridOff } from "@mui/icons-material";
+import FormatColorFill from "@mui/icons-material/FormatColorFill";
+import GridOff from "@mui/icons-material/GridOff";
 import MenuDivider from "../MenuDivider";
 import { useRichTextEditorContext } from "../context";
 import {

--- a/src/demo/Editor.tsx
+++ b/src/demo/Editor.tsx
@@ -1,4 +1,6 @@
-import { Lock, LockOpen, TextFields } from "@mui/icons-material";
+import Lock from "@mui/icons-material/Lock";
+import LockOpen from "@mui/icons-material/LockOpen";
+import TextFields from "@mui/icons-material/TextFields";
 import { Box, Button, Stack, Typography } from "@mui/material";
 import type { EditorOptions } from "@tiptap/core";
 import { useCallback, useRef, useState } from "react";

--- a/src/extensions/HeadingWithAnchorComponent.tsx
+++ b/src/extensions/HeadingWithAnchorComponent.tsx
@@ -1,4 +1,4 @@
-import { Link as LinkIcon } from "@mui/icons-material";
+import LinkIcon from "@mui/icons-material/Link";
 import {
   getText,
   getTextSerializersFromSchema,


### PR DESCRIPTION
Changed the import paths to ensure all mui/icons-material follow a direct import path.

Related is an issue which I just opened https://github.com/sjdemartini/mui-tiptap/issues/154  .

This should solve the issue. I verified that the affected controls still work as intended. 

Please let me know of any changes required. Thanks for your patience as this is my first open source PR. I did my best to follow the contribution guidelines and ran all checks.