### PR TITLE
Add simple npm package script for bundle size visualizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "test:watch": "vitest watch",
     "test:coverage": "vitest run --coverage",
     "spell:check": "cspell \"{README.md,CODE_OF_CONDUCT.md,CONTRIBUTING.md,.github/*.md}\"",
+    "visualize": "npx vite-bundle-visualizer@0.10.0",
     "prepare": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
Run `pnpm visualize` kick of the bundle size analysis/visualization:

<img width="1725" alt="image" src="https://github.com/sjdemartini/mui-tiptap/assets/1647130/5a9122aa-e4dd-4320-b027-b08a916127b5">
