### PR TITLE
Add eslint rule to enforce MUI icon default import paths

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -102,11 +102,20 @@
             "name": "lodash",
             "message": "Please use specific module imports like \"lodash/foo\" instead of \"lodash\".",
             "allowTypeImports": true
+          },
+          {
+            "name": "@mui/icons-material",
+            "message": "Please use second-level default path imports rather than top-level named imports. See https://github.com/sjdemartini/mui-tiptap/issues/154"
           }
         ],
         // Disallow imports of third-level MUI "private" paths per
         // https://mui.com/material-ui/guides/minimizing-bundle-size/#option-one-use-path-imports
-        "patterns": ["@mui/*/*/*"]
+        "patterns": [
+          {
+            "group": ["@mui/*/*/*"],
+            "message": "Imports of third-level MUI \"private\" paths are not allowed per https://mui.com/material-ui/guides/minimizing-bundle-size/#option-one-use-path-imports"
+          }
+        ]
       }
     ],
     "react/function-component-definition": "warn",


### PR DESCRIPTION
To avoid regressions after fixing https://github.com/sjdemartini/mui-tiptap/issues/154.


![Screenshot 2023-09-15 at 9 26 38 AM](https://github.com/sjdemartini/mui-tiptap/assets/1647130/33494c7c-b304-4844-a3df-a8bd3ba670d8)
