### PR TITLE
Prevent static class names from getting mangled in build

### DIFF
--- a/src/ControlledBubbleMenu.tsx
+++ b/src/ControlledBubbleMenu.tsx
@@ -90,7 +90,7 @@ export type ControlledBubbleMenuProps = {
 };
 
 const controlledBubbleMenuClasses: ControlledBubbleMenuClasses =
-  getUtilityClasses(ControlledBubbleMenu.name, ["root", "paper"]);
+  getUtilityClasses("ControlledBubbleMenu", ["root", "paper"]);
 
 const useStyles = makeStyles({ name: { ControlledBubbleMenu } })((theme) => ({
   root: {

--- a/src/FieldContainer.tsx
+++ b/src/FieldContainer.tsx
@@ -22,7 +22,7 @@ export type FieldContainerProps = {
 };
 
 const fieldContainerClasses: FieldContainerClasses = getUtilityClasses(
-  FieldContainer.name,
+  "FieldContainer",
   ["root", "outlined", "standard", "focused", "disabled", "notchedOutline"]
 );
 

--- a/src/MenuBar.tsx
+++ b/src/MenuBar.tsx
@@ -30,7 +30,7 @@ export type MenuBarProps = {
   classes?: Partial<MenuBarClasses>;
 };
 
-const menuBarClasses: MenuBarClasses = getUtilityClasses(MenuBar.name, [
+const menuBarClasses: MenuBarClasses = getUtilityClasses("MenuBar", [
   "root",
   "sticky",
   "nonSticky",

--- a/src/RichTextContent.tsx
+++ b/src/RichTextContent.tsx
@@ -16,7 +16,7 @@ export type RichTextContentProps = {
 };
 
 const richTextContentClasses: RichTextContentClasses = getUtilityClasses(
-  RichTextContent.name,
+  "RichTextContent",
   ["root", "readonly", "editable"]
 );
 

--- a/src/RichTextField.tsx
+++ b/src/RichTextField.tsx
@@ -60,7 +60,7 @@ export type RichTextFieldProps = {
 };
 
 const richTextFieldClasses: RichTextFieldClasses = getUtilityClasses(
-  RichTextField.name,
+  "RichTextField",
   ["root", "standard", "outlined", "menuBar", "menuBarContent", "content"]
 );
 

--- a/src/extensions/HeadingWithAnchorComponent.tsx
+++ b/src/extensions/HeadingWithAnchorComponent.tsx
@@ -91,7 +91,7 @@ export type HeadingWithAnchorComponentClasses = ReturnType<
 >["classes"];
 
 const headingWithAnchorComponentClasses: HeadingWithAnchorComponentClasses =
-  getUtilityClasses(HeadingWithAnchorComponent.name, [
+  getUtilityClasses("HeadingWithAnchorComponent", [
     "root",
     "container",
     "link",


### PR DESCRIPTION
Fixes https://github.com/sjdemartini/mui-tiptap/issues/178

In certain build setups, we can't use `function.name`, since the function will be mangled/minified, and so to ensure the MuiTiptap classes (like `MuiTiptap-RichTextField-content`) are static and consistent, we have to hard-code the component names as strings.