### PR TITLE
Bump Vite to 4.5.2 to resolve security warning

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -63,6 +63,6 @@
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react-swc": "^3.4.0",
     "typescript": "^5.1.3",
-    "vite": "^4.5.1"
+    "vite": "^4.5.2"
   }
 }

--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -141,13 +141,13 @@ devDependencies:
     version: 18.0.11
   '@vitejs/plugin-react-swc':
     specifier: ^3.4.0
-    version: 3.4.0(vite@4.5.1)
+    version: 3.4.0(vite@4.5.2)
   typescript:
     specifier: ^5.1.3
     version: 5.1.3
   vite:
-    specifier: ^4.5.1
-    version: 4.5.1
+    specifier: ^4.5.2
+    version: 4.5.2
 
 dependenciesMeta:
   mui-tiptap:
@@ -1549,13 +1549,13 @@ packages:
     resolution: {integrity: sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ==}
     dev: false
 
-  /@vitejs/plugin-react-swc@3.4.0(vite@4.5.1):
+  /@vitejs/plugin-react-swc@3.4.0(vite@4.5.2):
     resolution: {integrity: sha512-m7UaA4Uvz82N/0EOVpZL4XsFIakRqrFKeSNxa1FBLSXGvWrWRBwmZb4qxk+ZIVAZcW3c3dn5YosomDgx62XWcQ==}
     peerDependencies:
       vite: ^4
     dependencies:
       '@swc/core': 1.3.92
-      vite: 4.5.1
+      vite: 4.5.2
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: true
@@ -2327,8 +2327,8 @@ packages:
       picocolors: 1.0.0
     dev: false
 
-  /vite@4.5.1:
-    resolution: {integrity: sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==}
+  /vite@4.5.2:
+    resolution: {integrity: sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "rimraf": "^5.0.0",
     "tippy.js": "^6.3.7",
     "typescript": "^5.1.6",
-    "vite": "^4.5.1",
+    "vite": "^4.5.2",
     "vitest": "^0.32.4",
     "y-prosemirror": "1.0.20",
     "y-protocols": "1.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,7 +269,7 @@ devDependencies:
     specifier: ^5.1.6
     version: 5.1.6
   vite:
-    specifier: ^4.5.1
+    specifier: ^4.5.2
     version: 4.5.2(@types/node@18.16.3)
   vitest:
     specifier: ^0.32.4


### PR DESCRIPTION
Resolves https://github.com/sjdemartini/mui-tiptap/security/dependabot/9 like https://github.com/sjdemartini/mui-tiptap/pull/190 did for the main pnpm-lock.