### PR TITLE
Update VSCode settings for eslint fix per new syntax

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,7 @@
   },
   "[typescript][typescriptreact][javascript][javascriptreact]": {
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+      "source.fixAll.eslint": "explicit"
     },
     "editor.tabSize": 2
   },


### PR DESCRIPTION
This changed was made automatically when opening VSCode.