### PR TITLE
Add ColorPicker bubble menu

### DIFF
--- a/src/ColorPickerBubbleMenu/index.tsx
+++ b/src/ColorPickerBubbleMenu/index.tsx
@@ -1,0 +1,169 @@
+/// <reference types="@tiptap/extension-color" />
+import { useState } from "react";
+import { makeStyles } from "tss-react/mui";
+import type { Except } from "type-fest";
+import ControlledBubbleMenu, {
+  type ControlledBubbleMenuProps,
+} from "../ControlledBubbleMenu";
+import { useRichTextEditorContext } from "../context";
+import { ColorPickerPopperBody } from "../controls/ColorPickerPopper";
+import { ColorPickerBubbleMenuHandlerStorage } from "../extensions/ColorPickerBubbleMenuHandler";
+// import {
+//   LinkMenuState,
+//   type LinkBubbleMenuHandlerStorage,
+// } from "../extensions/LinkBubbleMenuHandler";
+// import EditLinkMenuContent, {
+//   type EditLinkMenuContentProps,
+// } from "./EditLinkMenuContent";
+// import ViewLinkMenuContent, {
+//   type ViewLinkMenuContentProps,
+// } from "./ViewLinkMenuContent";
+
+export interface ColorPickerBubbleMenuProps
+  extends Partial<
+    Except<ControlledBubbleMenuProps, "open" | "editor" | "children">
+  > {
+  /**
+   * Override the default text content/labels in this interface. For any value
+   * that is omitted in this object, it falls back to the default content.
+   */
+  // labels?: ViewLinkMenuContentProps["labels"] &
+  //   EditLinkMenuContentProps["labels"];
+  whatever?: string;
+}
+
+const useStyles = makeStyles({ name: { ColorPickerBubbleMenu } })((theme) => ({
+  content: {
+    padding: theme.spacing(1.5, 2, 0.5),
+  },
+}));
+
+/**
+ * A component that renders a bubble menu when viewing, creating, or editing a
+ * link. Requires the mui-tiptap LinkBubbleMenuHandler extension and Tiptap's
+ * Link extension (@tiptap/extension-link, https://tiptap.dev/api/marks/link) to
+ * both be included in your editor `extensions` array.
+ *
+ * Pairs well with the `<MenuButtonEditLink />` component.
+ *
+ * If you're using `RichTextEditor`, include this component via
+ * `RichTextEditor`’s `children` render-prop. Otherwise, include the
+ * `LinkBubbleMenu` as a child of the component where you call `useEditor` and
+ * render your `RichTextField` or `RichTextContent`. (The bubble menu itself
+ * will be positioned appropriately no matter where you put it in your React
+ * tree, as long as it is re-rendered whenever the Tiptap `editor` forces an
+ * update, which will happen if it's a child of the component using
+ * `useEditor`).
+ */
+export default function ColorPickerBubbleMenu({
+  ...controlledBubbleMenuProps
+}: ColorPickerBubbleMenuProps) {
+  const { classes } = useStyles();
+  const editor = useRichTextEditorContext();
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const handleClose = () => setAnchorEl(null);
+
+  if (!editor?.isEditable) {
+    return null;
+  }
+
+  if (!("linkBubbleMenuHandler" in editor.storage)) {
+    throw new Error(
+      "You must add the LinkBubbleMenuHandler extension to the useEditor `extensions` array in order to use this component!"
+    );
+  }
+  const handlerStorage = editor.storage
+    .colorPickerBubbleMenuHandler as ColorPickerBubbleMenuHandlerStorage;
+
+  // Update the menu step if the bubble menu state has changed
+  const menuState = handlerStorage.state;
+
+  // let linkMenuContent = null;
+  // if (menuState === LinkMenuState.VIEW_LINK_DETAILS) {
+  //   linkMenuContent = (
+  //     <ViewLinkMenuContent
+  //       editor={editor}
+  //       onCancel={editor.commands.closeLinkBubbleMenu}
+  //       onEdit={editor.commands.editLinkInBubbleMenu}
+  //       onRemove={() => {
+  //         // Remove the link and place the cursor at the end of the link (which
+  //         // requires "focus" to take effect)
+  //         editor
+  //           .chain()
+  //           .unsetLink()
+  //           .setTextSelection(editor.state.selection.to)
+  //           .focus()
+  //           .run();
+  //       }}
+  //       labels={labels}
+  //     />
+  //   );
+  // } else if (menuState === LinkMenuState.EDIT_LINK) {
+  //   linkMenuContent = (
+  //     <EditLinkMenuContent
+  //       editor={editor}
+  //       onCancel={editor.commands.closeLinkBubbleMenu}
+  //       onSave={({ text, link }) => {
+  //         editor
+  //           .chain()
+  //           // Make sure if we're updating a link, we update the link for the
+  //           // full link "mark"
+  //           .extendMarkRange("link")
+  //           // Update the link href and its text content
+  //           .insertContent({
+  //             type: "text",
+  //             marks: [
+  //               {
+  //                 type: "link",
+  //                 attrs: {
+  //                   href: link,
+  //                 },
+  //               },
+  //             ],
+  //             text: text,
+  //           })
+  //           // Note that as of "@tiptap/extension-link" 2.0.0-beta.37 when
+  //           // `autolink` is on (which we want), adding the link mark directly
+  //           // via `insertContent` above wasn't sufficient for the link mark to
+  //           // be applied (though specifying it above is still necessary), so we
+  //           // insert the content there and call `setLink` separately here.
+  //           // Unclear why this separate command is necessary, but it does the
+  //           // trick.
+  //           .setLink({
+  //             href: link,
+  //           })
+  //           // Place the cursor at the end of the link (which requires "focus"
+  //           // to take effect)
+  //           .focus()
+  //           .run();
+
+  //         editor.commands.closeLinkBubbleMenu();
+  //       }}
+  //       labels={labels}
+  //     />
+  //   );
+  // }
+
+  return (
+    <ControlledBubbleMenu
+      editor={editor}
+      open={menuState}
+      {...handlerStorage.bubbleMenuOptions}
+      {...controlledBubbleMenuProps}
+    >
+      <ColorPickerPopperBody
+        value={""}
+        onSave={(newColor: string) => {
+          console.log("[ColorPickerBubbleMenu] Save");
+        }}
+        onCancel={editor.commands.closeColorPickerBubbleMenu}
+        // value={value || ""}
+        // onSave={onSave}
+        // onCancel={onCancel}
+        // swatchColors={swatchColors}
+        // ColorPickerProps={ColorPickerProps}
+        // labels={labels}
+      />
+    </ControlledBubbleMenu>
+  );
+}

--- a/src/ColorPickerBubbleMenu/index.tsx
+++ b/src/ColorPickerBubbleMenu/index.tsx
@@ -125,7 +125,7 @@ export default function ColorPickerBubbleMenu({
       <ColorPickerPopperBody
         value={currentColor}
         onSave={(newColor: string) => {
-          if (handlerStorage.bubbleMenuOptions.mode === ColorPickerMode.Text) {
+          if (handlerStorage.bubbleMenuOptions?.mode === ColorPickerMode.Text) {
             editor.chain().focus().setColor(newColor).run();
           } else {
             // Highlight

--- a/src/ColorPickerBubbleMenu/index.tsx
+++ b/src/ColorPickerBubbleMenu/index.tsx
@@ -10,9 +10,9 @@ import type {
   SwatchColorOption,
 } from "../controls/ColorPicker";
 import { ColorPickerPopperBody } from "../controls/ColorPickerPopper";
-import { ColorPickerMode } from "../controls/MenuButtonColorPicker";
 import type { ColorPickerBubbleMenuHandlerStorage } from "../extensions/ColorPickerBubbleMenuHandler";
 import { getAttributesForEachSelected } from "../utils";
+import { ColorPickerMode } from "../utils/types";
 
 export interface ColorPickerBubbleMenuProps
   extends Partial<
@@ -81,9 +81,8 @@ export default function ColorPickerBubbleMenu({
   const menuState = handlerStorage.state;
 
   // Determine if all of the selected content shares the same set color.
-  const allCurrentTextStyleAttrs: TextStyleAttrs[] = editor
-    ? getAttributesForEachSelected(editor.state, "textStyle")
-    : [];
+  const allCurrentTextStyleAttrs: TextStyleAttrs[] =
+    getAttributesForEachSelected(editor.state, "textStyle");
   const isTextStyleAppliedToEntireSelection = !!editor.isActive("textStyle");
   const currentColors: string[] = allCurrentTextStyleAttrs.map(
     // Treat any null/missing color as the default color

--- a/src/controls/MenuButtonColorPicker.tsx
+++ b/src/controls/MenuButtonColorPicker.tsx
@@ -2,6 +2,7 @@ import type { PopperProps } from "@mui/material";
 import { useState, type ReactNode } from "react";
 import { makeStyles } from "tss-react/mui";
 import type { Except } from "type-fest";
+import { useRichTextEditorContext } from "../context";
 import { FormatColorBar } from "../icons";
 import type { ColorPickerProps, SwatchColorOption } from "./ColorPicker";
 import { ColorPickerPopper } from "./ColorPickerPopper";
@@ -99,16 +100,24 @@ export function MenuButtonColorPicker({
 }: MenuButtonColorPickerProps) {
   const { classes, cx } = useStyles();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const editor = useRichTextEditorContext();
 
   const handleClose = () => setAnchorEl(null);
 
   const { IconComponent, children, ...otherMenuButtonProps } = menuButtonProps;
+  console.log({ commands: editor?.commands });
 
   return (
     <>
       <MenuButton
-        onClick={(e) =>
-          anchorEl ? handleClose() : setAnchorEl(e.currentTarget)
+        onClick={
+          (e) => {
+            editor?.commands.openColorPickerBubbleMenu({
+              anchorEl,
+              placement: "bottom",
+            });
+          }
+          // anchorEl ? handleClose() : setAnchorEl(e.currentTarget)
         }
         aria-describedby={popperId}
         {...otherMenuButtonProps}

--- a/src/controls/MenuButtonColorPicker.tsx
+++ b/src/controls/MenuButtonColorPicker.tsx
@@ -4,17 +4,13 @@ import { makeStyles } from "tss-react/mui";
 import type { Except } from "type-fest";
 import { useRichTextEditorContext } from "../context";
 import { FormatColorBar } from "../icons";
+import type { ColorPickerMode } from "../utils/types";
 import type { ColorPickerProps, SwatchColorOption } from "./ColorPicker";
 import { ColorPickerPopper } from "./ColorPickerPopper";
 import MenuButton, {
   MENU_BUTTON_FONT_SIZE_DEFAULT,
   type MenuButtonProps,
 } from "./MenuButton";
-
-export enum ColorPickerMode {
-  Text,
-  Highlight,
-}
 
 export interface MenuButtonColorPickerProps
   // Omit the default `color`, `value`, and `onChange` toggle button props so

--- a/src/controls/MenuButtonColorPicker.tsx
+++ b/src/controls/MenuButtonColorPicker.tsx
@@ -11,6 +11,11 @@ import MenuButton, {
   type MenuButtonProps,
 } from "./MenuButton";
 
+export enum ColorPickerMode {
+  Text,
+  Highlight,
+}
+
 export interface MenuButtonColorPickerProps
   // Omit the default `color`, `value`, and `onChange` toggle button props so
   // that "color" can't be confused for the `value` prop, and so that we can use
@@ -71,6 +76,20 @@ export interface MenuButtonColorPickerProps
      */
     textFieldPlaceholder?: string;
   };
+
+  /**
+   * Used internally to set the intention of the color picker to either text coloring or highlight.
+   */
+  mode?: ColorPickerMode;
+
+  /**
+   * The `<MenuButtonTextColor />`, `<MenuButtonHighlightColor />` components can also
+   * be used with bubble menu, like the link. In case you need more control regarding
+   * where the color picker is rendered. For example, if you're using it inside a modal
+   * and the color picker renders in a layer below it, you can use `<ColorPickerBubbleMenu />`
+   * and pass the `container` prop to change the rendering parent.
+   */
+  useWithBubbleMenu?: boolean;
 }
 
 const useStyles = makeStyles({ name: { MenuButtonColorPicker } })((theme) => ({
@@ -96,6 +115,8 @@ export function MenuButtonColorPicker({
   popperId,
   PopperProps,
   ColorPickerProps,
+  mode,
+  useWithBubbleMenu,
   ...menuButtonProps
 }: MenuButtonColorPickerProps) {
   const { classes, cx } = useStyles();
@@ -105,20 +126,21 @@ export function MenuButtonColorPicker({
   const handleClose = () => setAnchorEl(null);
 
   const { IconComponent, children, ...otherMenuButtonProps } = menuButtonProps;
-  console.log({ commands: editor?.commands });
 
   return (
     <>
       <MenuButton
-        onClick={
-          (e) => {
+        onClick={(e) => {
+          if (useWithBubbleMenu) {
             editor?.commands.openColorPickerBubbleMenu({
               anchorEl,
               placement: "bottom",
+              mode,
             });
+          } else {
+            anchorEl ? handleClose() : setAnchorEl(e.currentTarget);
           }
-          // anchorEl ? handleClose() : setAnchorEl(e.currentTarget)
-        }
+        }}
         aria-describedby={popperId}
         {...otherMenuButtonProps}
       >

--- a/src/controls/MenuButtonHighlightColor.tsx
+++ b/src/controls/MenuButtonHighlightColor.tsx
@@ -1,8 +1,8 @@
 /// <reference types="@tiptap/extension-highlight" />
 import { useRichTextEditorContext } from "../context";
 import { FormatInkHighlighterNoBar } from "../icons";
+import { ColorPickerMode } from "../utils/types";
 import {
-  ColorPickerMode,
   MenuButtonColorPicker,
   type MenuButtonColorPickerProps,
 } from "./MenuButtonColorPicker";

--- a/src/controls/MenuButtonHighlightColor.tsx
+++ b/src/controls/MenuButtonHighlightColor.tsx
@@ -2,6 +2,7 @@
 import { useRichTextEditorContext } from "../context";
 import { FormatInkHighlighterNoBar } from "../icons";
 import {
+  ColorPickerMode,
   MenuButtonColorPicker,
   type MenuButtonColorPickerProps,
 } from "./MenuButtonColorPicker";
@@ -66,6 +67,7 @@ export default function MenuButtonHighlightColor({
         removeColorButtonTooltipTitle: "Remove highlighting from this text",
         ...menuButtonProps.labels,
       }}
+      mode={ColorPickerMode.Highlight}
     />
   );
 }

--- a/src/controls/MenuButtonTextColor.tsx
+++ b/src/controls/MenuButtonTextColor.tsx
@@ -3,8 +3,8 @@ import type { Editor } from "@tiptap/core";
 import { useRichTextEditorContext } from "../context";
 import { FormatColorTextNoBar } from "../icons";
 import { getAttributesForEachSelected } from "../utils";
+import { ColorPickerMode } from "../utils/types";
 import {
-  ColorPickerMode,
   MenuButtonColorPicker,
   type MenuButtonColorPickerProps,
 } from "./MenuButtonColorPicker";

--- a/src/controls/MenuButtonTextColor.tsx
+++ b/src/controls/MenuButtonTextColor.tsx
@@ -4,6 +4,7 @@ import { useRichTextEditorContext } from "../context";
 import { FormatColorTextNoBar } from "../icons";
 import { getAttributesForEachSelected } from "../utils";
 import {
+  ColorPickerMode,
   MenuButtonColorPicker,
   type MenuButtonColorPickerProps,
 } from "./MenuButtonColorPicker";
@@ -81,6 +82,7 @@ export default function MenuButtonTextColor({
       disabled={!editor?.isEditable || !editor.can().setColor("#000")}
       {...menuButtonProps}
       labels={{ removeColorButton: "Reset", ...menuButtonProps.labels }}
+      mode={ColorPickerMode.Text}
     />
   );
 }

--- a/src/demo/Editor.tsx
+++ b/src/demo/Editor.tsx
@@ -13,6 +13,7 @@ import {
   insertImages,
   type RichTextEditorRef,
 } from "../";
+import ColorPickerBubbleMenu from "../ColorPickerBubbleMenu";
 import EditorMenuControls from "./EditorMenuControls";
 import useExtensions from "./useExtensions";
 
@@ -215,6 +216,7 @@ export default function Editor() {
           {() => (
             <>
               <LinkBubbleMenu />
+              <ColorPickerBubbleMenu />
               <TableBubbleMenu />
             </>
           )}

--- a/src/demo/EditorMenuControls.tsx
+++ b/src/demo/EditorMenuControls.tsx
@@ -71,6 +71,7 @@ export default function EditorMenuControls() {
 
       <MenuButtonTextColor
         defaultTextColor={theme.palette.text.primary}
+        useWithBubbleMenu={true}
         swatchColors={[
           { value: "#000000", label: "Black" },
           { value: "#ffffff", label: "White" },
@@ -84,6 +85,7 @@ export default function EditorMenuControls() {
       />
 
       <MenuButtonHighlightColor
+        useWithBubbleMenu={true}
         swatchColors={[
           { value: "#595959", label: "Dark grey" },
           { value: "#dddddd", label: "Light grey" },

--- a/src/demo/useExtensions.ts
+++ b/src/demo/useExtensions.ts
@@ -40,6 +40,7 @@ import {
   ResizableImage,
   TableImproved,
 } from "../";
+import ColorPickerBubbleMenuHandler from "../extensions/ColorPickerBubbleMenuHandler";
 import { mentionSuggestionOptions } from "./mentionSuggestionOptions";
 
 export type UseExtensionsOptions = {
@@ -148,6 +149,7 @@ export default function useExtensions({
         openOnClick: false,
       }),
       LinkBubbleMenuHandler,
+      ColorPickerBubbleMenuHandler,
 
       // Extensions
       Gapcursor,

--- a/src/extensions/ColorPickerBubbleMenuHandler.ts
+++ b/src/extensions/ColorPickerBubbleMenuHandler.ts
@@ -1,5 +1,4 @@
 import { Extension } from "@tiptap/core";
-import { Plugin, PluginKey } from "@tiptap/pm/state";
 import type { ColorPickerBubbleMenuProps } from "../ColorPickerBubbleMenu";
 
 declare module "@tiptap/core" {
@@ -46,34 +45,9 @@ const ColorPickerBubbleMenuHandler = Extension.create<
           return true;
         },
 
-      // editLinkInBubbleMenu:
-      //   () =>
-      //   ({ dispatch }) => {
-      //     const currentMenuState = this.storage.state;
-      //     const newMenuState = LinkMenuState.EDIT_LINK;
-      //     if (currentMenuState === newMenuState) {
-      //       return false;
-      //     }
-
-      //     if (dispatch) {
-      //       // Only change the state if this is not a dry-run
-      //       // https://tiptap.dev/api/commands#dry-run-for-commands.
-      //       this.storage.state = newMenuState;
-      //     }
-
-      //     return true;
-      //   },
-
       closeColorPickerBubbleMenu:
         () =>
         ({ commands, dispatch }) => {
-          // const currentMenuState = this.storage.state;
-          // if (currentMenuState === LinkMenuState.HIDDEN) {
-          //   return false;
-          // }
-
-          // Re-focus on the editor (e.g. for re-selection) since the user was
-          // previously editing and has now canceled
           commands.focus();
 
           if (dispatch) {
@@ -87,71 +61,6 @@ const ColorPickerBubbleMenuHandler = Extension.create<
           return true;
         },
     };
-  },
-
-  onSelectionUpdate() {
-    console.log("onSelectionUpdate");
-    // To ensure we maintain the proper bubble menu state, if someone is
-    // viewing/editing a link but moves off of it (e.g. with their keyboard
-    // arrow keys, or by clicking out, or by typing over the currently selected
-    // link), we'll close the bubble menu. Note that when in "view" mode (and
-    // not "edit") for an existing link, we only close if the state shows the
-    // user is not on an active link anymore, since the selection can be updated
-    // via `openLinkBubbleMenu` (and we don't want to immediately close it upon
-    // initial opening of the bubble menu). By contrast in "edit" mode, the
-    // user's focus should be in the edit form and selection shouldn't
-    // automatically update during opening or otherwise, so clicking out (i.e.
-    // changing selection) definitively indicates cancellation.
-    // onSelectionUpdate runs before handleClick, so we need to promptly close
-    // in that scenario.
-    // if (this.storage.state === LinkMenuState.EDIT_LINK) {
-    //   this.editor.commands.closeLinkBubbleMenu();
-    // } else if (
-    //   this.storage.state === LinkMenuState.VIEW_LINK_DETAILS &&
-    //   !this.editor.isActive("link")
-    // ) {
-    //   this.editor.commands.closeLinkBubbleMenu();
-    // }
-  },
-
-  addKeyboardShortcuts() {
-    return {
-      "Mod-Shift-u": () => {
-        this.editor.commands.openLinkBubbleMenu();
-        return true;
-      },
-    };
-  },
-
-  addProseMirrorPlugins() {
-    return [
-      new Plugin({
-        key: new PluginKey("handleClickLinkForMenu"),
-        props: {
-          handleClick: (view, pos, event) => {
-            console.log("addProseMirrorPlugins clickHandler");
-            // const attrs = getAttributes(view.state, "link");
-            // const link = (event.target as HTMLElement).closest("a");
-            // If the user has clicked on a link and the menu isn't already
-            // open, we'll open it. Otherwise we close it. (Closing the menu if
-            // it's already open allows a user to put their cursor at a specific
-            // point within the link text and implicitly close the bubble menu,
-            // like the Slack UI does, if they don't want to use the bubble menu
-            // but instead want to use regular cursor/keyboard interaction with
-            // the link text.)
-            if (this.storage.state) {
-              this.editor.commands.openColorPickerBubbleMenu();
-            } else {
-              this.editor.commands.closeColorPickerBubbleMenu();
-            }
-            // Return false so that the click still propagates to any other
-            // handlers, without `preventDefault` (see note on boolean return
-            // values here https://prosemirror.net/docs/ref/#view.EditorProps)
-            return false;
-          },
-        },
-      }),
-    ];
   },
 });
 

--- a/src/extensions/ColorPickerBubbleMenuHandler.ts
+++ b/src/extensions/ColorPickerBubbleMenuHandler.ts
@@ -39,43 +39,7 @@ const ColorPickerBubbleMenuHandler = Extension.create<
     return {
       openColorPickerBubbleMenu:
         (bubbleMenuOptions = {}) =>
-        ({ editor, chain, dispatch }) => {
-          // let newMenuState: LinkMenuState;
-          // if (editor.isActive("link")) {
-          //   // If their cursor is currently on a link, we'll open the link menu to
-          //   // view the details.
-          //   if (currentMenuState !== LinkMenuState.VIEW_LINK_DETAILS) {
-          //     // If the user isn't already in the "View Link Details" menu, we'll first
-          //     // change the selection to encompass the entire link to make it obvious which
-          //     // link is being edited and what text it includes. We also focus in case the
-          //     // user clicked the Link menu button (so we re-focus on the editor).
-
-          //     // NOTE: there is a bug in Tiptap where `extendMarkRange` will not
-          //     // work despite `isActive("link")` having returning true if the
-          //     // click/cursor is at the end of a link
-          //     // https://github.com/ueberdosis/tiptap/issues/2535. This leads to
-          //     // confusing behavior and should probably be handled with a workaround
-          //     // (like checking whether `extendMarkRange` had any effect) so that we
-          //     // don't open the link menu unless we know we've selected the entire
-          //     // link.
-          //     chain().extendMarkRange("link").focus().run();
-          //   }
-
-          //   newMenuState = LinkMenuState.VIEW_LINK_DETAILS;
-          // } else {
-          //   // Otherwise open the edit link menu for the user to add a new link
-          //   newMenuState = LinkMenuState.EDIT_LINK;
-          // }
-
-          // if (dispatch) {
-          //   // Only change the state if this is not a dry-run
-          //   // https://tiptap.dev/api/commands#dry-run-for-commands. Note that
-          //   // this happens automatically for the Tiptap built-in commands
-          //   // called with `chain()` above.
-          //   this.storage.state = newMenuState;
-          //   this.storage.bubbleMenuOptions = bubbleMenuOptions;
-          // }
-
+        () => {
           this.storage.state = true;
           this.storage.bubbleMenuOptions = bubbleMenuOptions;
 

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -1,4 +1,8 @@
 export {
+  default as ColorPickerBubbleMenuHandler,
+  type ColorPickerBubbleMenuHandlerStorage,
+} from "./ColorPickerBubbleMenuHandler";
+export {
   default as FontSize,
   type FontSizeAttrs,
   type FontSizeOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
 export {
+  default as ColorPickerBubbleMenu,
+  type ColorPickerBubbleMenuProps,
+} from "./ColorPickerBubbleMenu";
+export {
   default as ControlledBubbleMenu,
   type ControlledBubbleMenuProps,
 } from "./ControlledBubbleMenu";

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,4 @@
+export enum ColorPickerMode {
+  Text,
+  Highlight,
+}


### PR DESCRIPTION
Added `ColorPickerBubbleMenu` component based on the `LinkBubbleMenu`  in order to enable passing a container reference so that the color picker can be displayed in a modal or any kind of component that renders above the main application container.

**NOTE**: This should affect both text color and text highlight.

### TODO
- [x] Cleanup code from comments and refactor what is needed
- [x] Reconnect the coloring functionality and test if everything is working properly