### PR TITLE
Fix the same file image upload issue

### DIFF
--- a/src/controls/MenuButtonImageUpload.tsx
+++ b/src/controls/MenuButtonImageUpload.tsx
@@ -85,6 +85,8 @@ export default function MenuButtonImageUpload({
           if (event.target.files) {
             await handleAndInsertNewFiles(event.target.files);
           }
+
+          event.target.value = ""; // Clear the input so the same file can be re-uploaded
         }}
         style={{ display: "none" }} // Hide this input
         {...inputProps}


### PR DESCRIPTION
Fixed same image file upload issue for MenuButtonImageUpload.tsx.


For example, after uploading 1.jpg, uploading same file 1.jpg again did not trigger onChange trigger.

I added clear input value logic.

