### PR TITLE
Bump Vite to newer patch version to silence Dependabot alerts

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -63,6 +63,6 @@
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react-swc": "^3.4.0",
     "typescript": "^5.1.3",
-    "vite": "^4.5.2"
+    "vite": "^4.5.3"
   }
 }

--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -141,13 +141,13 @@ devDependencies:
     version: 18.0.11
   '@vitejs/plugin-react-swc':
     specifier: ^3.4.0
-    version: 3.4.0(vite@4.5.2)
+    version: 3.4.0(vite@4.5.3)
   typescript:
     specifier: ^5.1.3
     version: 5.1.3
   vite:
-    specifier: ^4.5.2
-    version: 4.5.2
+    specifier: ^4.5.3
+    version: 4.5.3
 
 dependenciesMeta:
   mui-tiptap:
@@ -1549,13 +1549,13 @@ packages:
     resolution: {integrity: sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ==}
     dev: false
 
-  /@vitejs/plugin-react-swc@3.4.0(vite@4.5.2):
+  /@vitejs/plugin-react-swc@3.4.0(vite@4.5.3):
     resolution: {integrity: sha512-m7UaA4Uvz82N/0EOVpZL4XsFIakRqrFKeSNxa1FBLSXGvWrWRBwmZb4qxk+ZIVAZcW3c3dn5YosomDgx62XWcQ==}
     peerDependencies:
       vite: ^4
     dependencies:
       '@swc/core': 1.3.92
-      vite: 4.5.2
+      vite: 4.5.3
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: true
@@ -2327,8 +2327,8 @@ packages:
       picocolors: 1.0.0
     dev: false
 
-  /vite@4.5.2:
-    resolution: {integrity: sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==}
+  /vite@4.5.3:
+    resolution: {integrity: sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "rimraf": "^5.0.0",
     "tippy.js": "^6.3.7",
     "typescript": "^5.1.6",
-    "vite": "^4.5.2",
+    "vite": "^4.5.3",
     "vitest": "^0.32.4",
     "y-prosemirror": "1.0.20",
     "y-protocols": "1.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,7 +269,7 @@ devDependencies:
     specifier: ^5.1.6
     version: 5.1.6
   vite:
-    specifier: ^4.5.2
+    specifier: ^4.5.3
     version: 4.5.3(@types/node@18.16.3)
   vitest:
     specifier: ^0.32.4


### PR DESCRIPTION
> Vite dev server option server.fs.deny did not deny requests for patterns with directories. An example of such a pattern is /foo/**/*.

Fixed in 4.5.3.

Doesn't affect us, and only a dev dep, but bumping to remove the alerts.