### PR TITLE
Fix issue where other heading levels are disabled when Heading 1 is selected

### DIFF
--- a/src/controls/MenuSelectHeading.tsx
+++ b/src/controls/MenuSelectHeading.tsx
@@ -187,6 +187,9 @@ export default function MenuSelectHeading({
   const isCurrentlyParagraphOrHeading = selectedValue !== "";
   const canSetParagraph = editor?.can().setParagraph();
   // We have to pass a level when running `can`, so this is just an arbitrary one
+  // And, we have to check `currentLevel` to prevent all other heading levels from
+  // being disabled when Heading 1 is selected.
+  // See https://github.com/sjdemartini/mui-tiptap/issues/197
   const canSetHeading =
     currentLevel === 1 || editor?.can().setHeading({ level: 1 });
 

--- a/src/controls/MenuSelectHeading.tsx
+++ b/src/controls/MenuSelectHeading.tsx
@@ -156,6 +156,7 @@ export default function MenuSelectHeading({
   );
 
   let selectedValue: HeadingOptionValue | "" = "";
+  let currentLevel: number | undefined;
   if (editor?.isActive("paragraph")) {
     selectedValue = HEADING_OPTION_VALUES.Paragraph;
   } else if (editor?.isActive("heading")) {
@@ -173,11 +174,12 @@ export default function MenuSelectHeading({
     // show the first of the selected nodes' levels and not allow changing all
     // selected to that heading level. See
     // https://github.com/ueberdosis/tiptap/issues/3481.)
-    const level = numCurrentNodeLevels === 1 ? currentNodeLevels[0] : undefined;
-    if (level && level in LEVEL_TO_HEADING_OPTION_VALUE) {
+    currentLevel =
+      numCurrentNodeLevels === 1 ? currentNodeLevels[0] : undefined;
+    if (currentLevel && currentLevel in LEVEL_TO_HEADING_OPTION_VALUE) {
       selectedValue =
         LEVEL_TO_HEADING_OPTION_VALUE[
-          level as keyof typeof LEVEL_TO_HEADING_OPTION_VALUE
+          currentLevel as keyof typeof LEVEL_TO_HEADING_OPTION_VALUE
         ];
     }
   }
@@ -185,7 +187,8 @@ export default function MenuSelectHeading({
   const isCurrentlyParagraphOrHeading = selectedValue !== "";
   const canSetParagraph = editor?.can().setParagraph();
   // We have to pass a level when running `can`, so this is just an arbitrary one
-  const canSetHeading = editor?.can().setHeading({ level: 1 });
+  const canSetHeading =
+    currentLevel === 1 || editor?.can().setHeading({ level: 1 });
 
   // Figure out which settings the user has enabled with the heading extension
   const enabledHeadingLevels: Set<Level> = useMemo(() => {

--- a/src/controls/MenuSelectHeading.tsx
+++ b/src/controls/MenuSelectHeading.tsx
@@ -185,13 +185,13 @@ export default function MenuSelectHeading({
   }
 
   const isCurrentlyParagraphOrHeading = selectedValue !== "";
-  const canSetParagraph = editor?.can().setParagraph();
-  // We have to pass a level when running `can`, so this is just an arbitrary one
-  // And, we have to check `currentLevel` to prevent all other heading levels from
-  // being disabled when Heading 1 is selected.
-  // See https://github.com/sjdemartini/mui-tiptap/issues/197
+  const canSetParagraph = !!editor?.can().setParagraph();
+  // We have to pass a level when running `can`, so this is just an arbitrary
+  // one. And we have to check `currentLevel` to prevent all other heading
+  // levels from being disabled when Heading 1 is selected (see
+  // https://github.com/sjdemartini/mui-tiptap/issues/197).
   const canSetHeading =
-    currentLevel === 1 || editor?.can().setHeading({ level: 1 });
+    currentLevel === 1 || !!editor?.can().setHeading({ level: 1 });
 
   // Figure out which settings the user has enabled with the heading extension
   const enabledHeadingLevels: Set<Level> = useMemo(() => {


### PR DESCRIPTION
Fix issue #197 

I have modified the code by moving the variable` level `outside the scope of the if statement and renamed it to `currentLevel `for greater specificity. Additionally, I have included `currentLevel `in the conditions for `canSetHeading`.

Please excuse any oversights as I am new to contributing and still familiarizing myself with the process.