### PR TITLE
feat: Using the tooltip zIndex based on the Mui Theme

### DIFF
--- a/src/ControlledBubbleMenu.tsx
+++ b/src/ControlledBubbleMenu.tsx
@@ -9,7 +9,7 @@ import {
 import { isNodeSelection, posToDOMRect, type Editor } from "@tiptap/core";
 import { useCallback } from "react";
 import { makeStyles } from "tss-react/mui";
-import { Z_INDEXES, getUtilityClasses } from "./styles";
+import { getUtilityClasses } from "./styles";
 
 export type ControlledBubbleMenuClasses = ReturnType<
   typeof useStyles
@@ -94,7 +94,7 @@ const controlledBubbleMenuClasses: ControlledBubbleMenuClasses =
 
 const useStyles = makeStyles({ name: { ControlledBubbleMenu } })((theme) => ({
   root: {
-    zIndex: Z_INDEXES.BUBBLE_MENU,
+    zIndex: theme.zIndex.tooltip,
   },
 
   paper: {

--- a/src/controls/ColorPickerPopper.tsx
+++ b/src/controls/ColorPickerPopper.tsx
@@ -10,7 +10,6 @@ import {
 } from "@mui/material";
 import { useEffect, useState } from "react";
 import { makeStyles } from "tss-react/mui";
-import { Z_INDEXES } from "../styles";
 import { ColorPicker } from "./ColorPicker";
 import type { MenuButtonColorPickerProps } from "./MenuButtonColorPicker";
 
@@ -106,14 +105,14 @@ export function ColorPickerPopperBody({
   );
 }
 
-const useStyles = makeStyles({ name: { ColorPickerPopper } })({
+const useStyles = makeStyles({ name: { ColorPickerPopper } })((theme) => ({
   root: {
-    zIndex: Z_INDEXES.BUBBLE_MENU,
+    zIndex: theme.zIndex.tooltip,
     // This width seems to work well to allow exactly 8 swatches, as well as the
     // default button content
     width: 235,
   },
-});
+}));
 
 /**
  * Renders the ColorPicker inside of a Popper interface, for use with the

--- a/src/demo/App.tsx
+++ b/src/demo/App.tsx
@@ -3,7 +3,9 @@ import Brightness7Icon from "@mui/icons-material/Brightness7";
 import {
   AppBar,
   Box,
+  Button,
   CssBaseline,
+  Dialog,
   IconButton,
   ThemeProvider,
   Toolbar,
@@ -22,6 +24,7 @@ export default function App() {
   const [paletteMode, setPaletteMode] = useState<PaletteMode>(
     systemSettingsPrefersDarkMode ? "dark" : "light"
   );
+  const [openDialog, setOpenDialog] = useState(false);
   const togglePaletteMode = useCallback(
     () =>
       setPaletteMode((prevMode) => (prevMode === "light" ? "dark" : "light")),
@@ -49,7 +52,7 @@ export default function App() {
           <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
             mui-tiptap
           </Typography>
-
+          <Button onClick={() => setOpenDialog(true)}>View in a Dialog</Button>
           <IconButton onClick={togglePaletteMode} color="inherit">
             {theme.palette.mode === "dark" ? (
               <Brightness7Icon />
@@ -63,6 +66,13 @@ export default function App() {
       <Box sx={{ p: 3, maxWidth: 1207, margin: "0 auto" }}>
         <Editor />
       </Box>
+      <Dialog
+        open={openDialog}
+        onClose={() => setOpenDialog(false)}
+        maxWidth="lg"
+      >
+        <Editor />
+      </Dialog>
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
Simple fix.
This will use the theme based zIndex in the Popover and other tooltip components to avoid the tooltip stay behind the mui-tiptap once it is placed on a Dialog/Modal.

https://mui.com/material-ui/customization/default-theme/?expend-path=$.zIndex

I also added a button to open a Dialon with the mui-tiptap inside in the main example.

