### PR TITLE
add option to add a child component to images

### DIFF
--- a/src/extensions/ResizableImage.ts
+++ b/src/extensions/ResizableImage.ts
@@ -6,7 +6,6 @@ import {
 } from "@tiptap/core";
 import { Image, type ImageOptions } from "@tiptap/extension-image";
 import { ReactNodeViewRenderer } from "@tiptap/react";
-import type { FC } from "react";
 import ResizableImageComponent from "./ResizableImageComponent";
 
 export type ResizableImageOptions = ImageOptions & {
@@ -22,9 +21,11 @@ export type ResizableImageOptions = ImageOptions & {
   isAllowedImgSrc(src: string | null): boolean;
 
   /**
-   * Optional React component to pass in as a child component to ResizableImage.
+   * Optional React component to pass in as a child component to ResizableImage,
+   * as a sibling placed after the img element.
+   * This component will be rendered with the NodeViewProps passed from TipTap.
    */
-  childComponent?: FC<NodeViewProps>;
+  ChildComponent?: React.ElementType<NodeViewProps>;
 };
 
 /**

--- a/src/extensions/ResizableImage.ts
+++ b/src/extensions/ResizableImage.ts
@@ -2,9 +2,11 @@ import {
   InputRule,
   mergeAttributes,
   type ExtendedRegExpMatchArray,
+  type NodeViewProps,
 } from "@tiptap/core";
 import { Image, type ImageOptions } from "@tiptap/extension-image";
 import { ReactNodeViewRenderer } from "@tiptap/react";
+import type { FC } from "react";
 import ResizableImageComponent from "./ResizableImageComponent";
 
 export type ResizableImageOptions = ImageOptions & {
@@ -18,6 +20,11 @@ export type ResizableImageOptions = ImageOptions & {
    * hostnames are allowed.
    */
   isAllowedImgSrc(src: string | null): boolean;
+
+  /**
+   * Optional React component to pass in as a child component to ResizableImage.
+   */
+  childComponent?: FC<NodeViewProps>;
 };
 
 /**

--- a/src/extensions/ResizableImageComponent.tsx
+++ b/src/extensions/ResizableImageComponent.tsx
@@ -4,6 +4,7 @@ import { NodeViewWrapper } from "@tiptap/react";
 import throttle from "lodash/throttle";
 import { useMemo, useRef } from "react";
 import { makeStyles } from "tss-react/mui";
+import type ResizableImage from "./ResizableImage";
 import { ResizableImageResizer } from "./ResizableImageResizer";
 
 // Based on
@@ -27,6 +28,7 @@ interface ResizableImageNode extends ProseMirrorNode {
 
 interface Props extends NodeViewProps {
   node: ResizableImageNode;
+  extension: typeof ResizableImage;
 }
 
 const IMAGE_MINIMUM_WIDTH_PIXELS = 15;
@@ -71,7 +73,8 @@ const useStyles = makeStyles({ name: { ResizableImageComponent } })(
   })
 );
 
-function ResizableImageComponent({ node, selected, updateAttributes }: Props) {
+function ResizableImageComponent(props: Props) {
+  const { node, selected, updateAttributes, extension } = props;
   const { classes, cx } = useStyles();
   const { attrs } = node;
 
@@ -200,6 +203,10 @@ function ResizableImageComponent({ node, selected, updateAttributes }: Props) {
             onResize={handleResize}
             className={classes.resizer}
           />
+        )}
+
+        {extension.options.childComponent && (
+          <extension.options.childComponent {...props} />
         )}
       </div>
     </NodeViewWrapper>

--- a/src/extensions/ResizableImageComponent.tsx
+++ b/src/extensions/ResizableImageComponent.tsx
@@ -128,6 +128,7 @@ function ResizableImageComponent(props: Props) {
     [updateAttributes]
   );
 
+  const ChildComponent = extension.options.ChildComponent;
   return (
     <NodeViewWrapper
       style={{
@@ -205,9 +206,7 @@ function ResizableImageComponent(props: Props) {
           />
         )}
 
-        {extension.options.childComponent && (
-          <extension.options.childComponent {...props} />
-        )}
+        {ChildComponent && <ChildComponent {...props} />}
       </div>
     </NodeViewWrapper>
   );


### PR DESCRIPTION
This will allow users of ResizableImage to inject their own custom child component. My use case is to add a custom button overlaid over the image.