### PR TITLE
Support inline and non-inline configuration styling for ResizableImage/Image

### DIFF
--- a/src/extensions/ResizableImageComponent.tsx
+++ b/src/extensions/ResizableImageComponent.tsx
@@ -36,9 +36,8 @@ const IMAGE_MINIMUM_WIDTH_PIXELS = 15;
 const useStyles = makeStyles({ name: { ResizableImageComponent } })(
   (theme) => ({
     imageContainer: {
-      // Use inline-block so that the container is only as big as the inner
-      // img
-      display: "inline-block",
+      // Use inline-flex so that the container is only as big as the inner img
+      display: "inline-flex",
       // Use relative position so that the resizer is positioned relative to
       // the img dimensions (via their common container)
       position: "relative",
@@ -150,6 +149,10 @@ function ResizableImageComponent(props: Props) {
         textAlign: attrs.textAlign,
         width: "100%",
       }}
+      // Change the outer component's component to a "span" if the `inline`
+      // extension option is enabled, to ensure it can appear alongside other
+      // inline elements like text.
+      as={extension.options.inline ? "span" : "div"}
     >
       {/* We need a separate inner image container here in order to (1) have the
       node view wrapper take up the full width of its parent div created by

--- a/src/extensions/ResizableImageResizer.tsx
+++ b/src/extensions/ResizableImageResizer.tsx
@@ -36,17 +36,18 @@ export function ResizableImageResizer({
   const { classes, cx } = useStyles();
 
   useEffect(() => {
+    if (!mouseDown) {
+      return;
+    }
+
+    // If the user is currently holding down the resize handle, we'll have mouse
+    // movements fire the onResize callback (since the user would be "dragging"
+    // the handle).
     const handleMouseMove = (event: MouseEvent) => {
       onResize(event);
     };
 
-    if (mouseDown) {
-      // If the user is currently holding down the resize handle, we'll have mouse
-      // movements fire the onResize callback (since the user would be "dragging" the
-      // handle)
-      window.addEventListener("mousemove", handleMouseMove);
-    }
-
+    window.addEventListener("mousemove", handleMouseMove);
     return () => {
       window.removeEventListener("mousemove", handleMouseMove);
     };

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -265,7 +265,12 @@ export function getEditorStyles(theme: Theme): StyleRules {
       // and add a scrollbar
       maxWidth: "100%",
       height: "auto",
-      display: "block",
+      // Using inline-flex allows the image to be correctly positioned, whether
+      // the Image/ResizableImage extension is configured with `inline` as false
+      // or true. In the former case (the default), it should have other
+      // block-level elements on either side of it, allowing it to flow
+      // correctly as a block.
+      display: "inline-flex",
       ...getImageBackgroundColorStyles(theme),
 
       // Behavior when an image (node) is selected, at which point it can be deleted,


### PR DESCRIPTION
Before this change, even if `inline: true` was set for `Image` or `ResizableImage`, the image would still appear as a block element (thanks to mui-tiptap's styles and the NodeView element type of `div`) and so would not be truly "inline", largely defeating the purpose of `inline: true`. Corrected here.

Here are screenshots with `ResizableImage.configure({ inline: true })`. Before, it would show up as non-inline due to the styles/elements being used.

| before | after |
|--------|--------|
| <img width="848" alt="Screenshot 2024-06-23 at 10 47 49 PM" src="https://github.com/sjdemartini/mui-tiptap/assets/1647130/1df56260-3f5e-4a4e-b0cb-f05f1ec1a02e"> | <img width="1053" alt="Screenshot 2024-06-23 at 10 47 36 PM" src="https://github.com/sjdemartini/mui-tiptap/assets/1647130/38c9fa0e-b012-48fc-9af9-9d141b436bda"> | 