### PR TITLE
Update RichTextReadOnly types to support Tiptap 2.5+ options

### DIFF
--- a/src/RichTextEditor.tsx
+++ b/src/RichTextEditor.tsx
@@ -15,7 +15,7 @@ import RichTextField, { type RichTextFieldProps } from "./RichTextField";
 // (https://github.com/ueberdosis/tiptap/commit/df5609cdff27f97e11860579a7af852cf3e50ce5#diff-13acb5e551812e195c1140c10ba5ac298a0005996d07756cfd77c2d4194cb350R16),
 // as well as Tiptap <2.5 where `useEditor` used the `EditorOptions` type and
 // `UseEditorOptions` didn't yet exist.
-type UseEditorOptions = NonNullable<Parameters<typeof useEditor>[0]>;
+export type UseEditorOptions = NonNullable<Parameters<typeof useEditor>[0]>;
 
 export interface RichTextEditorProps
   extends SetRequired<Partial<UseEditorOptions>, "extensions"> {

--- a/src/RichTextReadOnly.tsx
+++ b/src/RichTextReadOnly.tsx
@@ -1,11 +1,12 @@
-import { useEditor, type EditorOptions } from "@tiptap/react";
+import { useEditor } from "@tiptap/react";
 import { useEffect, useRef } from "react";
 import type { Except, SetRequired } from "type-fest";
 import RichTextContent from "./RichTextContent";
+import type { UseEditorOptions } from "./RichTextEditor";
 import RichTextEditorProvider from "./RichTextEditorProvider";
 
 export type RichTextReadOnlyProps = SetRequired<
-  Partial<Except<EditorOptions, "editable">>,
+  Partial<Except<UseEditorOptions, "editable">>,
   "extensions"
 >;
 


### PR DESCRIPTION
We should support the new Tiptap 2.5+ props for `RichTextReadOnly` like 9e98e24 did for `RichTextEditor`, as pointed out in https://github.com/sjdemartini/mui-tiptap/issues/249#issuecomment-2249020284. e.g.

```tsx
<RichTextReadOnly
  content={content}
  extensions={extensions}
  immediatelyRender
/>
```