### PR TITLE
Create esm dir package.json file to fix importing mui-tiptap in node.js contexts

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,7 @@
     "node": true
   },
   "parser": "@typescript-eslint/parser",
+  "ignorePatterns": ["create-esm-package-json.js"], // Not in the TS project
   "parserOptions": {
     "ecmaFeatures": {
       "jsx": true

--- a/create-esm-package-json.js
+++ b/create-esm-package-json.js
@@ -1,0 +1,19 @@
+// Create a `package.json` file in the `dist/esm` build output directory with
+// {"type: "module"}, which should ensure that mui-tiptap can be imported
+// properly as ESM in a node.js context (fixing
+// https://github.com/sjdemartini/mui-tiptap/issues/256).
+// See:
+// - https://github.com/microsoft/TypeScript/issues/18442#issuecomment-1377529164
+// - https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html
+// - https://github.com/nodejs/node/issues/34515
+const fs = require("fs");
+const path = require("path");
+
+const dir = path.join(__dirname, "dist", "esm");
+const filePath = path.join(dir, "package.json");
+const content = JSON.stringify({ type: "module" }, null, 2);
+
+fs.writeFileSync(filePath, content, "utf8");
+
+// Print the path relative to __dirname:
+console.log(`Created ${path.relative(__dirname, filePath)}`);

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "pnpm clean && tsc --project tsconfig.build.json && tsc --project tsconfig.build-esm.json",
+    "build": "pnpm clean && tsc --project tsconfig.build.json && tsc --project tsconfig.build-esm.json && node create-esm-package-json.js",
     "clean": "rimraf dist coverage",
     "example": "pnpm build && rimraf ./example/node_modules && pnpm --dir ./example install && pnpm --dir ./example run dev",
     "dev": "vite",


### PR DESCRIPTION
Should resolve https://github.com/sjdemartini/mui-tiptap/issues/256

Planning to test this before publishing to confirm that this does the trick.