### PR TITLE
Force node to use CJS to get around dependency import errors, and validate package types in CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -66,3 +66,6 @@ jobs:
         # Run the tests and print out the coverage information. In the future,
         # we could integrate with Codecov or something.
         run: pnpm run test:coverage
+
+      - name: Validate the build's packaging CJS and ESM compatibility
+        run: npx @arethetypeswrong/cli@0.15.4 --pack

--- a/example/pnpm-lock.yaml
+++ b/example/pnpm-lock.yaml
@@ -2559,7 +2559,7 @@ packages:
     resolution: {directory: .., type: directory}
     id: file:..
     name: mui-tiptap
-    version: 1.9.1
+    version: 1.9.5
     engines: {pnpm: '>=8'}
     requiresBuild: true
     peerDependencies:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "files": [
     "dist"
   ],
+  "type": "commonjs",
   "types": "./dist/index.d.ts",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -22,25 +22,25 @@
     "dist"
   ],
   "type": "commonjs",
-  "types": "./dist/index.d.ts",
-  "main": "dist/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "require": "./dist/index.js",
-      "import": "./dist/esm/index.js"
+      "types": "./dist/cjs/index.d.ts",
+      "module": "./dist/esm/index.js",
+      "default": "./dist/cjs/index.js"
     },
     "./icons": {
-      "types": "./dist/icons/index.d.ts",
-      "require": "./dist/icons/index.js",
-      "import": "./dist/esm/icons/index.js"
+      "types": "./dist/cjs/icons/index.d.ts",
+      "module": "./dist/esm/icons/index.js",
+      "default": "./dist/cjs/icons/index.js"
     }
   },
   "typesVersions": {
     "*": {
       "icons": [
-        "./dist/icons/index.d.ts"
+        "./dist/cjs/icons/index.d.ts"
       ],
       "*": [
         "*"

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "include": ["./src"],
-  "exclude": ["./src/demo", "./src/**/__tests__"]
+  "exclude": ["./src/demo", "./src/**/__tests__"],
+  "compilerOptions": {
+    "outDir": "./dist/cjs"
+  }
 }


### PR DESCRIPTION
_Third_ attempt to resolve https://github.com/sjdemartini/mui-tiptap/issues/256 😅   (should supersede https://github.com/sjdemartini/mui-tiptap/pull/258 and https://github.com/sjdemartini/mui-tiptap/pull/257, see the former for more details/discussion)

Should resolve https://github.com/sjdemartini/mui-tiptap/issues/256

Both `@mui/icons-material` (https://github.com/mui/material-ui/issues/35233) and `lodash` (https://github.com/lodash/lodash/issues/5107) have problems being imported in a consuming package when using ESM. The workarounds attempted in https://github.com/sjdemartini/mui-tiptap/pull/258 almost seemed to work (didn't break a downstream bundled package using Vite), but still caused problems for the original example node application https://codesandbox.io/p/devbox/pensive-volhard-hyhtls, with errors like:

```
Error: Cannot find module '/path/to/mui-tiptap-in-node/node_modules/@mui/icons-material/esm/FormatColorFill
```

This approach is inspired by [what tss-react does](https://github.com/garronej/tss-react/blob/f5351e42e33f35f18415cfc1ffc6b08eb8ce4d25/package.json) (e.g. see here https://github.com/garronej/tss-react/commit/46997026db70ec9bc326a1405d1ab7ea99a8d111 and https://github.com/garronej/tss-react/issues/164).

With this change, this code now works in the node context (though slightly odd):

```ts
import pkg from "mui-tiptap";
const { FontSize, HeadingWithAnchor, ResizableImage, TableImproved } = pkg;
```

and is considered valid by `arethetypeswrong`:

```
❯ npx @arethetypeswrong/cli@0.15.4 --pack

mui-tiptap v1.9.5

Build tools:
- typescript@^5.1.6
- vite@^5.3.1

 No problems found 🌟


┌───────────────────┬──────────────┬────────────────────┐
│                   │ "mui-tiptap" │ "mui-tiptap/icons" │
├───────────────────┼──────────────┼────────────────────┤
│ node10            │ 🟢           │ 🟢                 │
├───────────────────┼──────────────┼────────────────────┤
│ node16 (from CJS) │ 🟢 (CJS)     │ 🟢 (CJS)           │
├───────────────────┼──────────────┼────────────────────┤
│ node16 (from ESM) │ 🟢 (CJS)     │ 🟢 (CJS)           │
├───────────────────┼──────────────┼────────────────────┤
│ bundler           │ 🟢           │ 🟢                 │
└───────────────────┴──────────────┴────────────────────┘
```

CJS vs ESM package resolution is an absolute mess—sad there's so much fragmentation and trouble getting things to play nicely with third party packages and different environments 😞 

