### PR TITLE
Allow hiding shortcuts for MenuSelectHeading

### DIFF
--- a/src/controls/MenuSelectHeading.tsx
+++ b/src/controls/MenuSelectHeading.tsx
@@ -42,7 +42,11 @@ export type MenuSelectHeadingProps = Except<
     /** @deprecated Use `labels.empty` instead. */
     emptyValue?: React.ReactNode;
   };
-  hideShortcuts?: boolean
+  /**
+   * Whether to hide the shortcut key tooltips for each heading option. By
+   * default false.
+   */
+  hideShortcuts?: boolean;
 };
 
 const useStyles = makeStyles({ name: { MenuSelectHeading } })((theme) => {
@@ -127,6 +131,7 @@ const LEVEL_TO_HEADING_OPTION_VALUE = {
 
 export default function MenuSelectHeading({
   labels,
+  hideShortcuts = false,
   ...menuSelectProps
 }: MenuSelectHeadingProps) {
   const { classes, cx } = useStyles();
@@ -267,7 +272,7 @@ export default function MenuSelectHeading({
       >
         <MenuButtonTooltip
           label=""
-          shortcutKeys={menuSelectProps.hideShortcuts ? undefined : ["mod", "alt", "0"]}
+          shortcutKeys={hideShortcuts ? undefined : ["mod", "alt", "0"]}
           placement="right"
           contentWrapperClassName={classes.menuOption}
         >
@@ -282,7 +287,7 @@ export default function MenuSelectHeading({
         >
           <MenuButtonTooltip
             label=""
-            shortcutKeys={menuSelectProps.hideShortcuts ? undefined : ["mod", "alt", "1"]}
+            shortcutKeys={hideShortcuts ? undefined : ["mod", "alt", "1"]}
             placement="right"
             contentWrapperClassName={cx(
               classes.menuOption,
@@ -302,7 +307,7 @@ export default function MenuSelectHeading({
         >
           <MenuButtonTooltip
             label=""
-            shortcutKeys={menuSelectProps.hideShortcuts ? undefined : ["mod", "alt", "2"]}
+            shortcutKeys={hideShortcuts ? undefined : ["mod", "alt", "2"]}
             placement="right"
             contentWrapperClassName={cx(
               classes.menuOption,
@@ -322,7 +327,7 @@ export default function MenuSelectHeading({
         >
           <MenuButtonTooltip
             label=""
-            shortcutKeys={menuSelectProps.hideShortcuts ? undefined : ["mod", "alt", "3"]}
+            shortcutKeys={hideShortcuts ? undefined : ["mod", "alt", "3"]}
             placement="right"
             contentWrapperClassName={cx(
               classes.menuOption,
@@ -342,7 +347,7 @@ export default function MenuSelectHeading({
         >
           <MenuButtonTooltip
             label=""
-            shortcutKeys={menuSelectProps.hideShortcuts ? undefined : ["mod", "alt", "4"]}
+            shortcutKeys={hideShortcuts ? undefined : ["mod", "alt", "4"]}
             placement="right"
             contentWrapperClassName={cx(
               classes.menuOption,
@@ -362,7 +367,7 @@ export default function MenuSelectHeading({
         >
           <MenuButtonTooltip
             label=""
-            shortcutKeys={menuSelectProps.hideShortcuts ? undefined : ["mod", "alt", "5"]}
+            shortcutKeys={hideShortcuts ? undefined : ["mod", "alt", "5"]}
             placement="right"
             contentWrapperClassName={cx(
               classes.menuOption,
@@ -382,7 +387,7 @@ export default function MenuSelectHeading({
         >
           <MenuButtonTooltip
             label=""
-            shortcutKeys={menuSelectProps.hideShortcuts ? undefined : ["mod", "alt", "6"]}
+            shortcutKeys={hideShortcuts ? undefined : ["mod", "alt", "6"]}
             placement="right"
             contentWrapperClassName={cx(
               classes.menuOption,

--- a/src/controls/MenuSelectHeading.tsx
+++ b/src/controls/MenuSelectHeading.tsx
@@ -42,6 +42,7 @@ export type MenuSelectHeadingProps = Except<
     /** @deprecated Use `labels.empty` instead. */
     emptyValue?: React.ReactNode;
   };
+  hideShortcuts?: boolean
 };
 
 const useStyles = makeStyles({ name: { MenuSelectHeading } })((theme) => {
@@ -266,7 +267,7 @@ export default function MenuSelectHeading({
       >
         <MenuButtonTooltip
           label=""
-          shortcutKeys={["mod", "alt", "0"]}
+          shortcutKeys={menuSelectProps.hideShortcuts ? undefined : ["mod", "alt", "0"]}
           placement="right"
           contentWrapperClassName={classes.menuOption}
         >
@@ -281,7 +282,7 @@ export default function MenuSelectHeading({
         >
           <MenuButtonTooltip
             label=""
-            shortcutKeys={["mod", "alt", "1"]}
+            shortcutKeys={menuSelectProps.hideShortcuts ? undefined : ["mod", "alt", "1"]}
             placement="right"
             contentWrapperClassName={cx(
               classes.menuOption,
@@ -301,7 +302,7 @@ export default function MenuSelectHeading({
         >
           <MenuButtonTooltip
             label=""
-            shortcutKeys={["mod", "alt", "2"]}
+            shortcutKeys={menuSelectProps.hideShortcuts ? undefined : ["mod", "alt", "2"]}
             placement="right"
             contentWrapperClassName={cx(
               classes.menuOption,
@@ -321,7 +322,7 @@ export default function MenuSelectHeading({
         >
           <MenuButtonTooltip
             label=""
-            shortcutKeys={["mod", "alt", "3"]}
+            shortcutKeys={menuSelectProps.hideShortcuts ? undefined : ["mod", "alt", "3"]}
             placement="right"
             contentWrapperClassName={cx(
               classes.menuOption,
@@ -341,7 +342,7 @@ export default function MenuSelectHeading({
         >
           <MenuButtonTooltip
             label=""
-            shortcutKeys={["mod", "alt", "4"]}
+            shortcutKeys={menuSelectProps.hideShortcuts ? undefined : ["mod", "alt", "4"]}
             placement="right"
             contentWrapperClassName={cx(
               classes.menuOption,
@@ -361,7 +362,7 @@ export default function MenuSelectHeading({
         >
           <MenuButtonTooltip
             label=""
-            shortcutKeys={["mod", "alt", "5"]}
+            shortcutKeys={menuSelectProps.hideShortcuts ? undefined : ["mod", "alt", "5"]}
             placement="right"
             contentWrapperClassName={cx(
               classes.menuOption,
@@ -381,7 +382,7 @@ export default function MenuSelectHeading({
         >
           <MenuButtonTooltip
             label=""
-            shortcutKeys={["mod", "alt", "6"]}
+            shortcutKeys={menuSelectProps.hideShortcuts ? undefined : ["mod", "alt", "6"]}
             placement="right"
             contentWrapperClassName={cx(
               classes.menuOption,


### PR DESCRIPTION
The shortcuts can be kind of too much for some users. There is no way to remove them from user space not even with CSS so it would make sense to add a prop that allows that customization