### PR TITLE
Remove type: "commonjs" to fix importing in NextJS

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -68,4 +68,11 @@ jobs:
         run: pnpm run test:coverage
 
       - name: Validate the build's packaging CJS and ESM compatibility
-        run: npx @arethetypeswrong/cli@0.16.2 --pack
+        # For now, we ignore the named-exports rule, as this gets triggered for
+        # the `node16 (from ESM)` context, and appears hard to resolve while
+        # still avoiding these issues:
+        # - https://github.com/sjdemartini/mui-tiptap/issues/256
+        # - https://github.com/sjdemartini/mui-tiptap/issues/264
+        # Ideally we can fix this in the future without breaking Node and NextJS
+        # contexts.
+        run: npx @arethetypeswrong/cli@0.16.2 --pack --ignore-rules named-exports

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -68,4 +68,4 @@ jobs:
         run: pnpm run test:coverage
 
       - name: Validate the build's packaging CJS and ESM compatibility
-        run: npx @arethetypeswrong/cli@0.15.4 --pack
+        run: npx @arethetypeswrong/cli@0.16.2 --pack

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "files": [
     "dist"
   ],
-  "type": "commonjs",
   "types": "./dist/cjs/index.d.ts",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
When `"type": "commonjs"` is specified in our package.json, it apparently causes the following problem in NextJS:

```
Module parse failed: 'import' and 'export' may appear only with 'sourceType: module' (1:0)
> export { default as ControlledBubbleMenu, } from "./ControlledBubbleMenu";
| export { default as LinkBubbleMenu, } from "./LinkBubbleMenu";
| export { default as MenuBar } from "./MenuBar";
```

This is odd, since we indeed *are* using "commonjs" type, as that's the default (https://nodejs.org/api/packages.html#type), but it seems that fortunately merely omitting this resolves import errors in NextJS, and still supports NodeJS, based on my testing.

Should resolve https://github.com/sjdemartini/mui-tiptap/issues/264, removing one of the changes from https://github.com/sjdemartini/mui-tiptap/pull/259, while still hopefully keeping https://github.com/sjdemartini/mui-tiptap/issues/256 fixed.

---

Note that I did try other approaches in attempting to fix NextJS and still support Node:
1. Using tsup/rollup again like #258, with `@mui/icons-material` bumped to v6 for supposed "proper" ESM support https://github.com/sjdemartini/mui-tiptap/issues/264#issuecomment-2346621784, but that still caused problems in the Node context. It seems icons-material still doesn't use `.js` extensions, so is still not correct.
2. Switch to `"type": "module"`, using `.js` extensions for all relative imports in the project (enforced/automated with the eslint plugin `eslint-plugin-require-extensions`). This seemed like an improvement, but still seems it would require some workarounds for lodash and/or mui/icons-material like in #258 in the Node context, as those imports of the third party dependencies failed when importing mui-tiptap.