### PR TITLE
Allow relative and anchor links in link edit menu, and allow users to override link-formatting behavior

### DIFF
--- a/src/LinkBubbleMenu/EditLinkMenuContent.tsx
+++ b/src/LinkBubbleMenu/EditLinkMenuContent.tsx
@@ -98,26 +98,24 @@ export default function EditLinkMenuContent({
       return;
     }
 
-    // Parse what the user typed in, and add a protocol if they typed in a value
-    // but didn't include a protocol. (This also includes mailto and tel, since
-    // they are also valid for `href`
-    // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-href and
-    // Tiptap has builtin autolink support for email address conversion to
-    // mailto.) This is what Slack does, and seems like a reasonable behavior to
-    // ensure it's a valid URL (e.g. if someone types "example.com", we should
-    // accept it and treat it as "http://example.com", not a relative path on the
-    // current site). It also allows the value to pass browser-builtin
-    // `type="url"` validation.
+    // Parse what the user typed in. Unless the value is explicitly a relative
+    // URL (starting with "/" or "#"), add a protocol if they typed in a value
+    // that doesn't include a protocol. (This also includes mailto:, tel:, and
+    // sms: since they are also valid for `href`
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-href,
+    // and Tiptap has builtin autolink support for email address conversion to
+    // mailto.) This protocol-adding behavior is what Slack does, and seems
+    // reasonable to ensure it's more likely a valid/expected URL (e.g. if
+    // someone types "example.com", we should accept it and treat it as
+    // "http://example.com", not a relative path on the current site).
     let currentHrefValue = hrefRef.current.value.trim();
     if (
       currentHrefValue &&
-      !currentHrefValue.startsWith("http://") &&
-      !currentHrefValue.startsWith("https://") &&
-      !currentHrefValue.startsWith("mailto:") &&
-      !currentHrefValue.startsWith("tel:")
+      !/^(https?:\/\/|mailto:|tel:|sms:|\/|#)/.test(currentHrefValue)
     ) {
       currentHrefValue = `http://${currentHrefValue}`;
     }
+
     // URL-encode any characters that wouldn't be valid. We use `encodeurl`
     // instead of the builtin `encodeURI` so that if there are any
     // already-encoded sequences, they're not double-encoded and thus broken.
@@ -168,7 +166,7 @@ export default function EditLinkMenuContent({
         label={labels?.editLinkHrefInputLabel ?? "Link"}
         margin="dense"
         size="small"
-        type="url"
+        type="text" // "text" instead of "url" so that we can allow relative URLs
         onBlur={formatHref}
         onKeyDown={(event) => {
           // If the user is trying to submit the form directly from the href field, make

--- a/src/LinkBubbleMenu/index.tsx
+++ b/src/LinkBubbleMenu/index.tsx
@@ -26,6 +26,7 @@ export interface LinkBubbleMenuProps
    */
   labels?: ViewLinkMenuContentProps["labels"] &
     EditLinkMenuContentProps["labels"];
+  formatHref?: EditLinkMenuContentProps["formatHref"];
 }
 
 const useStyles = makeStyles({ name: { LinkBubbleMenu } })((theme) => ({
@@ -53,6 +54,7 @@ const useStyles = makeStyles({ name: { LinkBubbleMenu } })((theme) => ({
  */
 export default function LinkBubbleMenu({
   labels,
+  formatHref,
   ...controlledBubbleMenuProps
 }: LinkBubbleMenuProps) {
   const { classes } = useStyles();
@@ -135,6 +137,7 @@ export default function LinkBubbleMenu({
           editor.commands.closeLinkBubbleMenu();
         }}
         labels={labels}
+        formatHref={formatHref}
       />
     );
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,6 +5,7 @@ export { getAttributesForMarks } from "./getAttributesForMarks";
 export { getAttributesForNodes } from "./getAttributesForNodes";
 export * from "./images";
 export { default as keymapPluginFactory } from "./keymapPluginFactory";
+export * from "./links";
 export { getModShortcutKey, isMac, isTouchDevice } from "./platform";
 export { default as slugify } from "./slugify";
 export { default as truncateMiddle } from "./truncateMiddle";

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -1,0 +1,41 @@
+import encodeurl from "encodeurl";
+
+/**
+ * Format the `href` value for a link, when a user has finished typing.
+ *
+ * This function:
+ *  - trims leading/trailing whitespace
+ *  - ensures the value has a protocol (http://) if it doesn't already, unless
+ *    it's a relative URL (starting with "/") or anchor (starting with "#")
+ *  - URL-encodes the result
+ *
+ * @param value The value to format as an href (user-entered input value)
+ * @returns The formatted value
+ */
+
+export function formatHref(value: string): string {
+  // Unless the value is explicitly a relative URL (starting with "/" or "#"),
+  // add a protocol if they typed in a value that doesn't include a protocol.
+  // (This also includes mailto:, tel:, and sms: since they are also valid for
+  // `href`
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-href, and
+  // Tiptap has builtin autolink support for email address conversion to
+  // mailto.) This protocol-adding behavior is what Slack does, and seems
+  // reasonable to ensure it's more likely a valid/expected URL (e.g. if someone
+  // types "example.com", we should accept it and treat it as
+  // "http://example.com", not a relative path on the current site).
+  let currentHrefValue = value.trim();
+  if (
+    currentHrefValue &&
+    !/^(https?:\/\/|mailto:|tel:|sms:|\/|#)/.test(currentHrefValue)
+  ) {
+    currentHrefValue = `http://${currentHrefValue}`;
+  }
+
+  // URL-encode any characters that wouldn't be valid. We use `encodeurl`
+  // instead of the builtin `encodeURI` so that if there are any
+  // already-encoded sequences, they're not double-encoded and thus broken.
+  // (Useful for instance when a user pastes a URL into the form with complex
+  // and already-encoded parameters.)
+  return encodeurl(currentHrefValue);
+}


### PR DESCRIPTION
Resolves: https://github.com/sjdemartini/mui-tiptap/issues/182 and https://github.com/sjdemartini/mui-tiptap/issues/275

Changes:
- The default behavior of the LinkBubbleMenu editing is to do the following to the user-entered URL when they finish typing:
    - trim leading/trailing whitespace (unchanged)
    - ensure the value has a protocol (http://) if it doesn't already and isn't a relative (starting with "/") or anchor (starting with "#") URL **(_change in behavior_)**
        - Change: We now accept relative URLs starting with "/" and anchor links starting with "#"  (resolves #275)
        - Change: We now also accept `sms:` as a valid protocol, like we did for `mailto:` and `tel:` before
    - URL-encode the result (unchanged)
- `LinkBubbleMenu` now has a `formatHref` prop which can be used to override the above link-formatting behavior and provide custom functionality (resolves #182)

The input field is now of type `text` instead of `url` to support relative URLs.