### PR TITLE
Use MUI theme tooltip zIndex for popper menus to appear above modals

### DIFF
--- a/src/ControlledBubbleMenu.tsx
+++ b/src/ControlledBubbleMenu.tsx
@@ -9,7 +9,7 @@ import {
 import { isNodeSelection, posToDOMRect, type Editor } from "@tiptap/core";
 import { useCallback } from "react";
 import { makeStyles } from "tss-react/mui";
-import { Z_INDEXES, getUtilityClasses } from "./styles";
+import { getUtilityClasses } from "./styles";
 
 export type ControlledBubbleMenuClasses = ReturnType<
   typeof useStyles
@@ -94,7 +94,11 @@ const controlledBubbleMenuClasses: ControlledBubbleMenuClasses =
 
 const useStyles = makeStyles({ name: { ControlledBubbleMenu } })((theme) => ({
   root: {
-    zIndex: Z_INDEXES.BUBBLE_MENU,
+    // Ensure the bubble menu is above modals, in case the editor is rendered in
+    // a modal, consistent with recommendations here
+    // https://github.com/mui/material-ui/issues/14216. See
+    // https://github.com/sjdemartini/mui-tiptap/issues/265.
+    zIndex: theme.zIndex.tooltip,
   },
 
   paper: {

--- a/src/controls/ColorPickerPopper.tsx
+++ b/src/controls/ColorPickerPopper.tsx
@@ -10,7 +10,6 @@ import {
 } from "@mui/material";
 import { useEffect, useState } from "react";
 import { makeStyles } from "tss-react/mui";
-import { Z_INDEXES } from "../styles";
 import { ColorPicker } from "./ColorPicker";
 import type { MenuButtonColorPickerProps } from "./MenuButtonColorPicker";
 
@@ -106,14 +105,18 @@ export function ColorPickerPopperBody({
   );
 }
 
-const useStyles = makeStyles({ name: { ColorPickerPopper } })({
+const useStyles = makeStyles({ name: { ColorPickerPopper } })((theme) => ({
   root: {
-    zIndex: Z_INDEXES.BUBBLE_MENU,
+    // Ensure the popper is above modals, in case the editor is rendered in a
+    // modal, consistent with recommendations here
+    // https://github.com/mui/material-ui/issues/14216. See
+    // https://github.com/sjdemartini/mui-tiptap/issues/206.
+    zIndex: theme.zIndex.tooltip,
     // This width seems to work well to allow exactly 8 swatches, as well as the
     // default button content
     width: 235,
   },
-});
+}));
 
 /**
  * Renders the ColorPicker inside of a Popper interface, for use with the

--- a/src/demo/App.tsx
+++ b/src/demo/App.tsx
@@ -1,9 +1,14 @@
 import Brightness4Icon from "@mui/icons-material/Brightness4";
 import Brightness7Icon from "@mui/icons-material/Brightness7";
+import CloseIcon from "@mui/icons-material/Close";
 import {
   AppBar,
   Box,
+  Button,
   CssBaseline,
+  Dialog,
+  DialogContent,
+  DialogTitle,
   IconButton,
   ThemeProvider,
   Toolbar,
@@ -22,6 +27,7 @@ export default function App() {
   const [paletteMode, setPaletteMode] = useState<PaletteMode>(
     systemSettingsPrefersDarkMode ? "dark" : "light"
   );
+  const [dialogOpen, setDialogOpen] = useState(false);
   const togglePaletteMode = useCallback(
     () =>
       setPaletteMode((prevMode) => (prevMode === "light" ? "dark" : "light")),
@@ -49,7 +55,7 @@ export default function App() {
           <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
             mui-tiptap
           </Typography>
-
+          <Button onClick={() => setDialogOpen(true)}>View in a dialog</Button>
           <IconButton onClick={togglePaletteMode} color="inherit">
             {theme.palette.mode === "dark" ? (
               <Brightness7Icon />
@@ -63,6 +69,31 @@ export default function App() {
       <Box sx={{ p: 3, maxWidth: 1207, margin: "0 auto" }}>
         <Editor />
       </Box>
+
+      <Dialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        maxWidth="xl"
+        PaperProps={{ sx: { overflowY: "auto", maxHeight: "70vh" } }}
+        aria-labelledby="editor-dialog-title"
+      >
+        <DialogTitle id="editor-dialog-title">Editor in a dialog</DialogTitle>
+        <IconButton
+          onClick={() => setDialogOpen(false)}
+          aria-label="close"
+          sx={{
+            position: "absolute",
+            right: 8,
+            top: 8,
+          }}
+        >
+          <CloseIcon />
+        </IconButton>
+
+        <DialogContent>
+          <Editor disableStickyMenuBar />
+        </DialogContent>
+      </Dialog>
     </ThemeProvider>
   );
 }

--- a/src/demo/Editor.tsx
+++ b/src/demo/Editor.tsx
@@ -29,7 +29,11 @@ function fileListToImageFiles(fileList: FileList): File[] {
   });
 }
 
-export default function Editor() {
+type Props = {
+  disableStickyMenuBar?: boolean;
+};
+
+export default function Editor({ disableStickyMenuBar }: Props) {
   const extensions = useExtensions({
     placeholder: "Add your own content here...",
   });
@@ -155,6 +159,7 @@ export default function Editor() {
             variant: "outlined",
             MenuBarProps: {
               hide: !showMenuBar,
+              disableSticky: disableStickyMenuBar,
             },
             // Below is an example of adding a toggle within the outlined field
             // for showing/hiding the editor menu bar, and a "submit" button for

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -18,8 +18,6 @@ export const Z_INDEXES = {
   // The notched outline of the "outlined" field variant should be at the same z-index
   // as the menu-bar, so that it can contain/enclose it
   NOTCHED_OUTLINE: 2,
-  // The bubble menus should appear on top of the menu bar
-  BUBBLE_MENU: 3,
 } as const;
 
 export function getEditorStyles(theme: Theme): StyleRules {


### PR DESCRIPTION
Bringing back the functionality of https://github.com/sjdemartini/mui-tiptap/pull/225.

Overwhelming consensus and convention is to have poppers use the `tooltip` zIndex to always appear above modals, which affects 

Two "breaking" changes as a result:
1. The z-index for the bubble menus (`ControlledBubbleMenu`, `LinkBubbleMenu`, `TableBubbleMenu`) and poppers (`ColorPickerPopper` via `MenuButtonHighlightColor` and `MenuButtonTextColor`) will now be `theme.zIndex.tooltip`
2. The `Z_INDEXES` object (exported from `mui-tiptap`) removes the `BUBBLE_MENU` value. You should instead reference `theme.zIndex.tooltip` to get the z-index used for the bubble menus, as mui-tiptap does not define the value internally.

Relates to and resolves these issues/PRs:
- https://github.com/sjdemartini/mui-tiptap/issues/194
- https://github.com/sjdemartini/mui-tiptap/issues/206
- https://github.com/sjdemartini/mui-tiptap/issues/265
- https://github.com/sjdemartini/mui-tiptap/pull/209
- https://github.com/sjdemartini/mui-tiptap/issues/289
