### PR TITLE
Expose `sx` prop for `ControlledBubbleMenu` styles

### DIFF
--- a/src/ControlledBubbleMenu.tsx
+++ b/src/ControlledBubbleMenu.tsx
@@ -82,6 +82,8 @@ export type ControlledBubbleMenuProps = {
   className?: string;
   /** Override or extend existing styles. */
   classes?: Partial<ControlledBubbleMenuClasses>;
+  /** Styles applied to the root Popper element. */
+  sx?: PopperProps["sx"];
   /**
    * Override the default props for the Paper containing the bubble menu
    * content.
@@ -130,6 +132,7 @@ export default function ControlledBubbleMenu({
   open,
   className,
   classes: overrideClasses = {},
+  sx,
   children,
   anchorEl,
   container,
@@ -223,6 +226,7 @@ export default function ControlledBubbleMenu({
       ]}
       anchorEl={anchorEl ?? defaultAnchorEl}
       className={cx(controlledBubbleMenuClasses.root, classes.root, className)}
+      sx={sx}
       container={container}
       disablePortal={disablePortal}
       transition


### PR DESCRIPTION
This should make it easier to override styles like `zIndex` and more for the `ControlledBubbleMenu`, as well as the `LinkBubbleMenu` and `TableBubbleMenu` that utilize it under the hood. e.g.:

```tsx
<LinkBubbleMenu sx={{ "&&": { zIndex: 100 } }} />
```

Overriding the styles has been a common request, such as in https://github.com/sjdemartini/mui-tiptap/pull/291#issuecomment-2480911008, and in examples here https://github.com/sjdemartini/mui-tiptap/issues/206 (where folks were doing something similar specifically for `MenuButtonTextColor`'s `PopperProps`'s `sx` prop).