### PR TITLE
Strike through menu button shortcut should use "S" instead of "X"

### DIFF
--- a/src/controls/MenuButtonStrikethrough.tsx
+++ b/src/controls/MenuButtonStrikethrough.tsx
@@ -12,7 +12,7 @@ export default function MenuButtonStrikethrough(
   return (
     <MenuButton
       tooltipLabel="Strikethrough"
-      tooltipShortcutKeys={["mod", "Shift", "X"]}
+      tooltipShortcutKeys={["mod", "Shift", "S"]}
       IconComponent={StrikethroughS}
       selected={editor?.isActive("strike") ?? false}
       disabled={!editor?.isEditable || !editor.can().toggleStrike()}


### PR DESCRIPTION
Hello, just noticed this small issue. Thought Id push a quick fix.

Thank you for this. You're a hero for building it.