### PR TITLE
Close MenuSelect tooltip when opening dropdown options

### DIFF
--- a/src/controls/MenuSelect.tsx
+++ b/src/controls/MenuSelect.tsx
@@ -96,6 +96,13 @@ export default function MenuSelect<T>({
         setTooltipOpen(false);
         selectProps.onClick?.(...args);
       }}
+      onOpen={(...args) => {
+        // Close the tooltip when the dropdown is opened. This can ensure the
+        // tooltip doesn't block menu items, etc. (see
+        // https://github.com/sjdemartini/mui-tiptap/issues/308).
+        setTooltipOpen(false);
+        selectProps.onOpen?.(...args);
+      }}
       inputProps={{
         ...selectProps.inputProps,
         className: cx(classes.input, selectProps.inputProps?.className),


### PR DESCRIPTION
This ensures menu items aren't blocked, etc., and the tooltip need not continue to be displayed if you've already clicked the select, like:

<img width="193" alt="Screenshot 2024-12-22 at 3 16 07 PM" src="https://github.com/user-attachments/assets/670abbd7-1a23-486b-ae9d-29e074026472" />


Resolves https://github.com/sjdemartini/mui-tiptap/issues/308