### PR TITLE
Add utility classes to ColorPicker component

### DIFF
--- a/src/controls/ColorPicker.tsx
+++ b/src/controls/ColorPicker.tsx
@@ -101,19 +101,20 @@ export type ColorPickerProps = {
      */
     textFieldPlaceholder?: string;
   };
-  /** Override or extend existing styles. These classes are merged with the
-   * default utility classes. For instance, to hide the swatch container,
-   * you could do:
+  /**
+   * Override or extend existing styles. These classes are merged with the
+   * default utility classes. For instance, if you need to conditionally hide
+   * the swatch container, you could do:
    *
    *   ColorPickerProps={{
    *     classes: {
-   *       swatchContainer: "hide-swatch"
+   *       swatchContainer: shouldHide ? "hide" : undefined
    *     }
    *   }}
    *
    * And in your CSS:
    *
-   *   .MuiTiptap-ColorPicker-swatchContainer.hide-swatch {
+   *   .MuiTiptap-ColorPicker-swatchContainer.hide {
    *     display: none;
    *   }
    */

--- a/src/controls/ColorPicker.tsx
+++ b/src/controls/ColorPicker.tsx
@@ -2,8 +2,11 @@ import { TextField } from "@mui/material";
 import { useEffect, useRef } from "react";
 import { HexAlphaColorPicker, HexColorPicker } from "react-colorful";
 import { makeStyles } from "tss-react/mui";
+import { getUtilityClasses } from "../styles";
 import { colorToHex as colorToHexDefault } from "../utils/color";
 import { ColorSwatchButton } from "./ColorSwatchButton";
+
+export type ColorPickerClasses = ReturnType<typeof useStyles>["classes"];
 
 export type ColorChangeSource = "gradient" | "text" | "swatch";
 
@@ -98,7 +101,29 @@ export type ColorPickerProps = {
      */
     textFieldPlaceholder?: string;
   };
+  /** Override or extend existing styles. These classes are merged with the
+   * default utility classes. For instance, to hide the swatch container,
+   * you could do:
+   *
+   *   ColorPickerProps={{
+   *     classes: {
+   *       swatchContainer: "hide-swatch"
+   *     }
+   *   }}
+   *
+   * And in your CSS:
+   *
+   *   .MuiTiptap-ColorPicker-swatchContainer.hide-swatch {
+   *     display: none;
+   *   }
+   */
+  classes?: Partial<ColorPickerClasses>;
 };
+
+const colorPickerUtilityClasses: ColorPickerClasses = getUtilityClasses(
+  "ColorPicker",
+  ["gradientPicker", "colorTextInput", "swatchContainer"]
+);
 
 const useStyles = makeStyles({ name: { ColorPicker } })((theme) => ({
   gradientPicker: {
@@ -131,8 +156,11 @@ export function ColorPicker({
   colorToHex = colorToHexDefault,
   disableAlpha = false,
   labels = {},
+  classes: overrideClasses = {},
 }: ColorPickerProps) {
-  const { classes } = useStyles();
+  const { classes, cx } = useStyles(undefined, {
+    props: { classes: overrideClasses },
+  });
   const { textFieldPlaceholder = 'Ex: "#7cb5ec"' } = labels;
 
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -161,18 +189,24 @@ export function ColorPicker({
       {disableAlpha ? (
         <HexColorPicker
           color={colorValueAsHex ?? "#000000"}
+          className={cx(
+            colorPickerUtilityClasses.gradientPicker,
+            classes.gradientPicker
+          )}
           onChange={(color) => {
             onChange(color, "gradient");
           }}
-          className={classes.gradientPicker}
         />
       ) : (
         <HexAlphaColorPicker
           color={colorValueAsHex ?? "#000000"}
+          className={cx(
+            colorPickerUtilityClasses.gradientPicker,
+            classes.gradientPicker
+          )}
           onChange={(color) => {
             onChange(color, "gradient");
           }}
-          className={classes.gradientPicker}
         />
       )}
 
@@ -183,7 +217,10 @@ export function ColorPicker({
         defaultValue={value || ""}
         inputRef={inputRef}
         spellCheck={false}
-        className={classes.colorTextInput}
+        className={cx(
+          colorPickerUtilityClasses.colorTextInput,
+          classes.colorTextInput
+        )}
         onChange={(event) => {
           const newColor = event.target.value;
           const newHexColor = colorToHex(newColor);
@@ -195,7 +232,12 @@ export function ColorPicker({
       />
 
       {swatchColorObjects.length > 0 && (
-        <div className={classes.swatchContainer}>
+        <div
+          className={cx(
+            colorPickerUtilityClasses.swatchContainer,
+            classes.swatchContainer
+          )}
+        >
           {swatchColorObjects.map((swatchColor) => (
             <ColorSwatchButton
               key={swatchColor.value}


### PR DESCRIPTION
In relation to #320, adds utility classes to `ColorPicker` so users can override/extend the default styles of the gradient picker, text input, and swatch container. This provides extensive customisability to any components making use of the ColorPicker. It introduces a `classes` prop to control the styling by merging custom class names with the default generated utility classes.

## Changes
- Added a `colorPickerUtilityClasses` constant generated by the `getUtilityClasses` helper.
- Exposed `gradientPicker`, `colorTextInput`, and `swatchContainer` for ColorPicker.
- Introduced a `classes` prop on `ColorPickerProps`.
- Applied utility classes to the `<HexColorPicker>`/`<HexAlphaColorPicker>`, `<TextField>`, and swatch container `<div>`.

## Example
Apply the desired CSS class to the `ColorPickerProps`:
```js
<MenuButtonTextColor
  defaultTextColor={theme.palette.text.primary}
  swatchColors={[
      { value: "#000000", label: "Black" },
      { value: "#ffffff", label: "White" },
      { value: "#ff0000", label: "Red" },
      { value: "#0000ff", label: "Blue" },
  ]}
  ColorPickerProps={{
    classes: {
      gradientPicker: "hide",
      colorTextInput: "hide",
    },
  }}
/>
```
Apply the wanted styles, for example to hide certain parts of the color picker:
```css
}.MuiTiptap-ColorPicker-gradientPicker.hide {
  display: none;
}
}.MuiTiptap-ColorPicker-colorTextInput.hide {
  display: none;
}
```