### PR TITLE
Ignore tiptap packages for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "@tiptap/*"


### PR DESCRIPTION
This are relatively frequent, we intentionally support old versions, etc., so don't want the dependabot spam of bumping all of these continuously for the local dev deps.