### PR TITLE
Ignore major version bumps of type-fest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,11 @@ updates:
 
       - dependency-name: "prosemirror-*"
 
+      # Newer versions of type-fest would require a newer TS version than MUI's
+      # minimum TS version.
+      - dependency-name: "type-fest"
+        update-types: ["version-update:semver-major"]
+
       - dependency-name: "y-*"
 
       - dependency-name: "yjs"


### PR DESCRIPTION
Codifying in the config what was done here
https://github.com/sjdemartini/mui-tiptap/pull/367#issuecomment-3024440495