### PR TITLE
Fix bug with resizable image resizer on Tiptap 2.11+

### DIFF
--- a/src/extensions/ResizableImageResizer.tsx
+++ b/src/extensions/ResizableImageResizer.tsx
@@ -66,7 +66,10 @@ export function ResizableImageResizer({
   }, [setMouseDown]);
 
   const handleMouseDown = useCallback(
-    (_event: React.MouseEvent) => {
+    (event: React.MouseEvent) => {
+      // Ensure this click event doesn't trigger dragging of the image itself
+      event.preventDefault();
+      event.stopPropagation();
       setMouseDown(true);
     },
     [setMouseDown],


### PR DESCRIPTION
Without this fix, clicking and trying to drag the resizer would instead end up dragging the whole image, for versions of Tiptap 2.11 onward.