### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,5 +1,8 @@
 name: build-test
 
+permissions:
+  contents: read
+
 # Run this for pushes to the main branch and for pull requests, and allow this
 # to be called from other workflows
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/sjdemartini/mui-tiptap/security/code-scanning/1](https://github.com/sjdemartini/mui-tiptap/security/code-scanning/1)

To fix the error, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions needed for the workflow to operate. Based on the provided workflow, the `contents: read` permission should suffice because there is no indication of actions requiring write access (e.g., modifying pull requests or repository contents).

- The `permissions` block will be added at the root level (after the `name` field) to apply to all jobs in the workflow.
- The block will specify `contents: read` to explicitly limit the `GITHUB_TOKEN`'s permissions to read-only access to repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
