### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   # Re-run the usual tests and build steps to ensure things are stable for release
   build-test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-test.yml # use the callable built-test to run tests
 
   # Then release to npm


### PR DESCRIPTION
Potential fix for [https://github.com/sjdemartini/mui-tiptap/security/code-scanning/2](https://github.com/sjdemartini/mui-tiptap/security/code-scanning/2)

To fix the problem, we should set an explicit `permissions` block for the `build-test` job in `.github/workflows/release.yml`. The most restrictive permissions are recommended unless the job requires more. For typical test and build steps, only read access to repository contents is required, so we should set `permissions: contents: read` for the `build-test` job. This change should be added as a sibling of the `uses:` line (i.e., inside the `build-test` job definition). No additional imports or external definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
