### PR TITLE
Add prop to `RichTextContent` to disable its default built-in styles

### DIFF
--- a/src/controls/MenuSelectHeading.tsx
+++ b/src/controls/MenuSelectHeading.tsx
@@ -74,27 +74,27 @@ const useStyles = makeStyles({ name: { MenuSelectHeading } })((theme) => {
     },
 
     headingOption1: {
-      fontSize: editorStyles["& h1"].fontSize as string,
+      fontSize: editorStyles["& h1"].fontSize,
     },
 
     headingOption2: {
-      fontSize: editorStyles["& h2"].fontSize as string,
+      fontSize: editorStyles["& h2"].fontSize,
     },
 
     headingOption3: {
-      fontSize: editorStyles["& h3"].fontSize as string,
+      fontSize: editorStyles["& h3"].fontSize,
     },
 
     headingOption4: {
-      fontSize: editorStyles["& h4"].fontSize as string,
+      fontSize: editorStyles["& h4"].fontSize,
     },
 
     headingOption5: {
-      fontSize: editorStyles["& h5"].fontSize as string,
+      fontSize: editorStyles["& h5"].fontSize,
     },
 
     headingOption6: {
-      fontSize: editorStyles["& h6"].fontSize as string,
+      fontSize: editorStyles["& h6"].fontSize,
     },
   };
 });


### PR DESCRIPTION
Resolves https://github.com/sjdemartini/mui-tiptap/issues/221

Can be used via RichTextEditor and RichTextEditorReadonly as well, like:

```tsx
<RichTextEditor
  ref={rteRef}
  extensions={extensions}
  RichTextFieldProps={{
    RichTextContentProps: { disableDefaultStyles: true },
  }}
/>
```

```tsx
<RichTextReadOnly
  content={content}
  extensions={extensions}
  RichTextContentProps={{ disableDefaultStyles: true }}
/>
```

Example of what this looks like with the mui-tiptap demo:

<img width="1177" height="1038" alt="Screenshot 2025-07-18 220102" src="https://github.com/user-attachments/assets/712b792e-f7a2-49c2-baa7-ab32190cf992" />
