### PR TITLE
Use MUI `styled` instead of `tss-react`, and support style overrides customization

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -16,6 +16,7 @@
     "preminor",
     "prepatch",
     "prosemirror",
+    "resizer",
     "selectednode",
     "strikethrough",
     "tinycolor",

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
     - [`TableImproved`](#tableimproved)
   - [Components](#components)
     - [Controls components](#controls-components)
+- [Style customization](#style-customization)
 - [Localization](#localization)
 - [Tips and suggestions](#tips-and-suggestions)
   - [Choosing your editor `extensions`](#choosing-your-editor-extensions)
@@ -326,6 +327,51 @@ Typically you will define your controls (for `RichTextEditor`’s `renderControl
   {/* Add more controls of your choosing here */}
 </MenuControlsContainer>
 ```
+
+## Style customization
+
+You can override styles in several different ways, following standard [MUI conventions](https://mui.com/material-ui/customization/how-to-customize/). Most notably:
+
+1. Use the `sx` prop with any mui-tiptap component. Example:
+
+   ```tsx
+   <RichTextEditor {...otherProps} sx={{ backgroundColor: "#222" }} />
+   ```
+
+2. Use theme overrides (https://mui.com/material-ui/customization/theme-components/). Example:
+
+   ```ts
+   const theme = createTheme({
+     components: {
+       // Override the behavior for the mui-tiptap `FieldContainer`
+       "MuiTiptap-FieldContainer": {
+         defaultProps: {
+           // If no `variant` value is set, use "standard"
+           variant: "standard",
+         },
+         styleOverrides: {
+           // Apply this background color to the `root` slot
+           root: { backgroundColor: "#222" },
+           // Apply this border style to the `notchedOutline` slot
+           notchedOutline: { borderStyle: "dashed" },
+         },
+         variants: [
+           // When the `disabled` prop is `true`, show a red outline
+           {
+             props: { disabled: true },
+             style: { outline: "1px solid red" },
+           },
+         ],
+       },
+     },
+   });
+   ```
+
+3. Apply styles based on utility class names of mui-tiptap components. These are useful for applying CSS externally, or for nested component styling when using `sx` or `styleOverrides`.
+
+   For instance, for the `RichTextField` component, the `"MuiTiptap-RichTextField-root"` class name is applied to its root element, a separate class will be included on that element based on the current variant (like `"MuiTiptap-RichTextField-outlined"`), and its inner content element gets the `"MuiTiptap-RichTextField-content"` class.
+
+   You can import helper objects from mui-tiptap to avoid hard-coding these, like `import { richTextFieldClasses } from "mui-tiptap";`, and access them like `richTextFieldClasses.content` for the `"MuiTiptap-RichTextField-content"` value.
 
 ## Localization
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -188,6 +188,10 @@ export default tseslint.config(
         },
       ],
 
+      // Not necessary due to TS validation, and noisy when using
+      // `useThemeProps` before destructuring:
+      "react/prop-types": "off",
+
       "react-refresh/only-export-components": [
         "warn",
         {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -150,6 +150,13 @@ export default tseslint.config(
 
       "no-restricted-imports": "off",
 
+      "@typescript-eslint/no-empty-object-type": [
+        "error",
+        {
+          allowInterfaces: "with-single-extends",
+        },
+      ],
+
       "@typescript-eslint/no-restricted-imports": [
         "error",
         {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,6 @@ import jsxA11y from "eslint-plugin-jsx-a11y";
 import reactPlugin from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
-import tssUnusedClasses from "eslint-plugin-tss-unused-classes";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 
@@ -32,7 +31,6 @@ export default tseslint.config(
     plugins: {
       "react-hooks": reactHooks,
       "react-refresh": reactRefresh,
-      "tss-unused-classes": tssUnusedClasses,
     },
 
     linterOptions: {
@@ -205,8 +203,6 @@ export default tseslint.config(
           allowConstantExport: true,
         },
       ],
-
-      "tss-unused-classes/unused-classes": "warn",
 
       // Conditionally relax rules when testing against Tiptap v2 in CI
       ...(process.env.TIPTAP_MAJOR === "2"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "encodeurl": "^2.0.0",
     "lodash": "^4.17.21",
     "react-colorful": "^5.6.1",
-    "tss-react": "^4.8.3",
     "type-fest": "^3.12.0"
   },
   "peerDependencies": {
@@ -164,7 +163,6 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
-    "eslint-plugin-tss-unused-classes": "^1.0.3",
     "globals": "^16.2.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.2",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "clsx": "^2.1.1",
     "encodeurl": "^2.0.0",
     "lodash": "^4.17.21",
     "react-colorful": "^5.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       encodeurl:
         specifier: ^2.0.0
         version: 2.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       react-colorful:
         specifier: ^5.6.1
         version: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      tss-react:
-        specifier: ^4.8.3
-        version: 4.9.18(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
       type-fest:
         specifier: ^3.12.0
         version: 3.12.0
@@ -231,9 +228,6 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.4.20
         version: 0.4.20(eslint@9.32.0)
-      eslint-plugin-tss-unused-classes:
-        specifier: ^1.0.3
-        version: 1.0.3(eslint@9.32.0)
       globals:
         specifier: ^16.2.0
         version: 16.3.0
@@ -2293,11 +2287,6 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
-  eslint-plugin-tss-unused-classes@1.0.3:
-    resolution: {integrity: sha512-FtfNwEsUfEN7y+6+C9j4INh3LTL1lyujmtj8MiorPVbEDYwt9NcjuOpsjvEkSzsD0oyLZB1kBFrW59JTtepRnA==}
-    peerDependencies:
-      eslint: ^7.14.0 || ^8.0.0 || ^9.0.0
-
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3584,20 +3573,6 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
-  tss-react@4.9.18:
-    resolution: {integrity: sha512-Uc+VvP4RXVzfEacw735xRvne1lwt5HNhvIFptpvmK+G6F/hRA5TeEr3SEzxrqTb6ixA4vANB0iXjBB6LdexxJA==}
-    peerDependencies:
-      '@emotion/react': ^11.4.1
-      '@emotion/server': ^11.4.0
-      '@mui/material': ^5.0.0 || ^6.0.0 || ^7.0.0
-      '@types/react': ^16.8.0 || ^17.0.2 || ^18.0.0 || ^19.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/server':
-        optional: true
-      '@mui/material':
-        optional: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -5980,10 +5955,6 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-tss-unused-classes@1.0.3(eslint@9.32.0):
-    dependencies:
-      eslint: 9.32.0
-
   eslint-scope@8.4.0:
     dependencies:
       esrecurse: 4.3.0
@@ -7443,17 +7414,6 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
-
-  tss-react@4.9.18(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react@18.3.1):
-    dependencies:
-      '@emotion/cache': 11.14.0
-      '@emotion/react': 11.14.0(@types/react@18.3.23)(react@18.3.1)
-      '@emotion/serialize': 1.3.3
-      '@emotion/utils': 1.4.2
-      '@types/react': 18.3.23
-      react: 18.3.1
-    optionalDependencies:
-      '@mui/material': 7.2.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   type-check@0.4.0:
     dependencies:

--- a/src/ControlledBubbleMenu.classes.ts
+++ b/src/ControlledBubbleMenu.classes.ts
@@ -9,10 +9,8 @@ export interface ControlledBubbleMenuClasses {
 
 export type ControlledBubbleMenuClassKey = keyof ControlledBubbleMenuClasses;
 
-const controlledBubbleMenuClassKeys = [
-  "root",
-  "paper",
-] as const satisfies ReadonlyArray<ControlledBubbleMenuClassKey>;
-
 export const controlledBubbleMenuClasses: ControlledBubbleMenuClasses =
-  getUtilityClasses("ControlledBubbleMenu", controlledBubbleMenuClassKeys);
+  getUtilityClasses("ControlledBubbleMenu", [
+    "root",
+    "paper",
+  ] satisfies ControlledBubbleMenuClassKey[]);

--- a/src/ControlledBubbleMenu.classes.ts
+++ b/src/ControlledBubbleMenu.classes.ts
@@ -1,0 +1,18 @@
+import { getUtilityClasses } from "./styles";
+
+export interface ControlledBubbleMenuClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the Paper element. */
+  paper: string;
+}
+
+export type ControlledBubbleMenuClassKey = keyof ControlledBubbleMenuClasses;
+
+const controlledBubbleMenuClassKeys = [
+  "root",
+  "paper",
+] as const satisfies ReadonlyArray<ControlledBubbleMenuClassKey>;
+
+export const controlledBubbleMenuClasses: ControlledBubbleMenuClasses =
+  getUtilityClasses("ControlledBubbleMenu", controlledBubbleMenuClassKeys);

--- a/src/ControlledBubbleMenu.tsx
+++ b/src/ControlledBubbleMenu.tsx
@@ -17,7 +17,7 @@ import {
   type ControlledBubbleMenuClassKey,
   type ControlledBubbleMenuClasses,
 } from "./ControlledBubbleMenu.classes";
-import { getComponentName } from "./styles";
+import { getUtilityComponentName } from "./styles";
 
 export type ControlledBubbleMenuProps = Omit<
   PopperProps,
@@ -109,7 +109,7 @@ export type ControlledBubbleMenuProps = Omit<
   PaperProps?: Partial<PaperProps>;
 };
 
-const componentName = getComponentName("ControlledBubbleMenu");
+const componentName = getUtilityComponentName("ControlledBubbleMenu");
 
 const ControlledBubbleMenuRoot = styled(Popper, {
   name: componentName,

--- a/src/ControlledBubbleMenu.tsx
+++ b/src/ControlledBubbleMenu.tsx
@@ -11,7 +11,7 @@ import {
 } from "@mui/material";
 import { isNodeSelection, posToDOMRect, type Editor } from "@tiptap/core";
 import { clsx } from "clsx";
-import { useCallback, useMemo, type ReactNode } from "react";
+import { useCallback, type ReactNode } from "react";
 import {
   controlledBubbleMenuClasses,
   type ControlledBubbleMenuClasses,
@@ -113,7 +113,7 @@ const componentName = getComponentName("ControlledBubbleMenu");
 const ControlledBubbleMenuRoot = styled(Popper, {
   name: componentName,
   slot: "root",
-  overridesResolver: (props, styles) => [styles.root],
+  overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => ({
   // Ensure the bubble menu is above modals, in case the editor is rendered in
   // a modal, consistent with recommendations here
@@ -125,7 +125,7 @@ const ControlledBubbleMenuRoot = styled(Popper, {
 const ControlledBubbleMenuPaper = styled(Paper, {
   name: componentName,
   slot: "paper",
-  overridesResolver: (props, styles) => [styles.paper],
+  overridesResolver: (props, styles) => styles.paper,
 })(({ theme }) => ({
   backgroundColor: theme.palette.background.default,
 }));
@@ -201,21 +201,6 @@ export default function ControlledBubbleMenu(
     };
   }, [editor]);
 
-  const rootClasses = useMemo(
-    () => clsx([controlledBubbleMenuClasses.root, className, classes.root]),
-    [className, classes.root],
-  );
-
-  const paperClasses = useMemo(
-    () =>
-      clsx([
-        controlledBubbleMenuClasses.paper,
-        classes.paper,
-        PaperProps?.className,
-      ]),
-    [classes.paper, PaperProps?.className],
-  );
-
   return (
     <ControlledBubbleMenuRoot
       open={open}
@@ -265,7 +250,11 @@ export default function ControlledBubbleMenu(
         // which is probably not worth it
       ]}
       anchorEl={anchorEl ?? defaultAnchorEl}
-      className={rootClasses}
+      className={clsx([
+        controlledBubbleMenuClasses.root,
+        className,
+        classes.root,
+      ])}
       sx={sx}
       container={container}
       disablePortal={disablePortal}
@@ -287,7 +276,11 @@ export default function ControlledBubbleMenu(
           <ControlledBubbleMenuPaper
             elevation={7}
             {...PaperProps}
-            className={paperClasses}
+            className={clsx([
+              controlledBubbleMenuClasses.paper,
+              classes.paper,
+              PaperProps?.className,
+            ])}
           >
             {children}
           </ControlledBubbleMenuPaper>

--- a/src/ControlledBubbleMenu.tsx
+++ b/src/ControlledBubbleMenu.tsx
@@ -108,18 +108,13 @@ export type ControlledBubbleMenuProps = Omit<
   PaperProps?: Partial<PaperProps>;
 };
 
-interface ControlledBubbleMenuOwnerState {}
-
 const componentName = getComponentName("ControlledBubbleMenu");
 
 const ControlledBubbleMenuRoot = styled(Popper, {
   name: componentName,
   slot: "root",
-  overridesResolver: (
-    props: { ownerState?: ControlledBubbleMenuOwnerState },
-    styles,
-  ) => [styles.root],
-})<{ ownerState: ControlledBubbleMenuOwnerState }>(({ theme }) => ({
+  overridesResolver: (props, styles) => [styles.root],
+})(({ theme }) => ({
   // Ensure the bubble menu is above modals, in case the editor is rendered in
   // a modal, consistent with recommendations here
   // https://github.com/mui/material-ui/issues/14216. See
@@ -130,11 +125,8 @@ const ControlledBubbleMenuRoot = styled(Popper, {
 const ControlledBubbleMenuPaper = styled(Paper, {
   name: componentName,
   slot: "paper",
-  overridesResolver: (
-    props: { ownerState?: ControlledBubbleMenuOwnerState },
-    styles,
-  ) => [styles.paper],
-})<{ ownerState: ControlledBubbleMenuOwnerState }>(({ theme }) => ({
+  overridesResolver: (props, styles) => [styles.paper],
+})(({ theme }) => ({
   backgroundColor: theme.palette.background.default,
 }));
 
@@ -186,8 +178,6 @@ export default function ControlledBubbleMenu(
   } = props;
 
   const theme = useTheme();
-
-  const ownerState = useMemo(() => ({}), []);
 
   const defaultAnchorEl = useCallback(() => {
     // The logic here is taken from the positioning implementation in Tiptap's BubbleMenuPlugin
@@ -280,7 +270,6 @@ export default function ControlledBubbleMenu(
       container={container}
       disablePortal={disablePortal}
       transition
-      ownerState={ownerState}
       {...popperProps}
     >
       {({ TransitionProps }) => (
@@ -299,7 +288,6 @@ export default function ControlledBubbleMenu(
             elevation={7}
             {...PaperProps}
             className={paperClasses}
-            ownerState={ownerState}
           >
             {children}
           </ControlledBubbleMenuPaper>

--- a/src/ControlledBubbleMenu.tsx
+++ b/src/ControlledBubbleMenu.tsx
@@ -14,6 +14,7 @@ import { clsx } from "clsx";
 import { useCallback, type ReactNode } from "react";
 import {
   controlledBubbleMenuClasses,
+  type ControlledBubbleMenuClassKey,
   type ControlledBubbleMenuClasses,
 } from "./ControlledBubbleMenu.classes";
 import { getComponentName } from "./styles";
@@ -112,7 +113,7 @@ const componentName = getComponentName("ControlledBubbleMenu");
 
 const ControlledBubbleMenuRoot = styled(Popper, {
   name: componentName,
-  slot: "root",
+  slot: "root" satisfies ControlledBubbleMenuClassKey,
   overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => ({
   // Ensure the bubble menu is above modals, in case the editor is rendered in
@@ -124,7 +125,7 @@ const ControlledBubbleMenuRoot = styled(Popper, {
 
 const ControlledBubbleMenuPaper = styled(Paper, {
   name: componentName,
-  slot: "paper",
+  slot: "paper" satisfies ControlledBubbleMenuClassKey,
   overridesResolver: (props, styles) => styles.paper,
 })(({ theme }) => ({
   backgroundColor: theme.palette.background.default,

--- a/src/FieldContainer.classes.ts
+++ b/src/FieldContainer.classes.ts
@@ -17,16 +17,14 @@ export interface FieldContainerClasses {
 
 export type FieldContainerClassKey = keyof FieldContainerClasses;
 
-const fieldContainerClassKeys = [
-  "root",
-  "outlined",
-  "standard",
-  "focused",
-  "disabled",
-  "notchedOutline",
-] as const satisfies ReadonlyArray<FieldContainerClassKey>;
-
 export const fieldContainerClasses: FieldContainerClasses = getUtilityClasses(
   "FieldContainer",
-  fieldContainerClassKeys,
+  [
+    "root",
+    "outlined",
+    "standard",
+    "focused",
+    "disabled",
+    "notchedOutline",
+  ] satisfies FieldContainerClassKey[],
 );

--- a/src/FieldContainer.classes.ts
+++ b/src/FieldContainer.classes.ts
@@ -1,0 +1,32 @@
+import { getUtilityClasses } from "./styles";
+
+export interface FieldContainerClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the root element if variant="outlined". */
+  outlined: string;
+  /** Styles applied to the root element if variant="standard". */
+  standard: string;
+  /** Styles applied to the root element if focused=true. */
+  focused: string;
+  /** Styles applied to the root element if disabled=true. */
+  disabled: string;
+  /** Styles applied to the notched outline element. */
+  notchedOutline: string;
+}
+
+export type FieldContainerClassKey = keyof FieldContainerClasses;
+
+const fieldContainerClassKeys = [
+  "root",
+  "outlined",
+  "standard",
+  "focused",
+  "disabled",
+  "notchedOutline",
+] as const satisfies ReadonlyArray<FieldContainerClassKey>;
+
+export const fieldContainerClasses: FieldContainerClasses = getUtilityClasses(
+  "FieldContainer",
+  fieldContainerClassKeys,
+);

--- a/src/FieldContainer.tsx
+++ b/src/FieldContainer.tsx
@@ -9,6 +9,7 @@ import { clsx } from "clsx";
 import type { ReactNode } from "react";
 import {
   fieldContainerClasses,
+  type FieldContainerClassKey,
   type FieldContainerClasses,
 } from "./FieldContainer.classes";
 import { Z_INDEXES, getComponentName } from "./styles";
@@ -42,7 +43,7 @@ const componentName = getComponentName("FieldContainer");
 
 const FieldContainerRoot = styled(Box, {
   name: componentName,
-  slot: "root",
+  slot: "root" satisfies FieldContainerClassKey,
   overridesResolver: (
     props: { ownerState: FieldContainerOwnerState },
     styles,
@@ -80,9 +81,9 @@ const FieldContainerRoot = styled(Box, {
   }),
 }));
 
-const FieldContainerNotchedOutline = styled("div", {
+const FieldContainerNotchedOutline = styled("fieldset", {
   name: componentName,
-  slot: "notchedOutline",
+  slot: "notchedOutline" satisfies FieldContainerClassKey,
   overridesResolver: (props, styles) => styles.notchedOutline,
 })<{ ownerState: FieldContainerOwnerState }>(({ theme }) => ({
   position: "absolute",

--- a/src/FieldContainer.tsx
+++ b/src/FieldContainer.tsx
@@ -64,20 +64,12 @@ const FieldContainerRoot = styled(Box, {
     padding: 1,
     position: "relative",
 
-    [`&:hover .${fieldContainerClasses.notchedOutline}`]: {
-      borderColor: theme.palette.text.primary,
-    },
-
-    [`&.${fieldContainerClasses.focused} .${fieldContainerClasses.notchedOutline}`]:
-      {
-        borderColor: theme.palette.primary.main,
-        borderWidth: 2,
-      },
-
-    [`&.${fieldContainerClasses.disabled} .${fieldContainerClasses.notchedOutline}`]:
-      {
-        borderColor: theme.palette.action.disabled,
-      },
+    ...(!ownerState.focused &&
+      !ownerState.disabled && {
+        [`&:hover .${fieldContainerClasses.notchedOutline}`]: {
+          borderColor: theme.palette.text.primary,
+        },
+      }),
   }),
 }));
 
@@ -85,7 +77,7 @@ const FieldContainerNotchedOutline = styled("fieldset", {
   name: componentName,
   slot: "notchedOutline" satisfies FieldContainerClassKey,
   overridesResolver: (props, styles) => styles.notchedOutline,
-})<{ ownerState: FieldContainerOwnerState }>(({ theme }) => ({
+})<{ ownerState: FieldContainerOwnerState }>(({ theme, ownerState }) => ({
   position: "absolute",
   inset: 0,
   borderRadius: "inherit",
@@ -98,6 +90,15 @@ const FieldContainerNotchedOutline = styled("fieldset", {
   pointerEvents: "none",
   overflow: "hidden",
   zIndex: Z_INDEXES.NOTCHED_OUTLINE,
+
+  ...(ownerState.focused && {
+    borderColor: theme.palette.primary.main,
+    borderWidth: 2,
+  }),
+
+  ...(ownerState.disabled && {
+    borderColor: theme.palette.action.disabled,
+  }),
 }));
 
 /**

--- a/src/FieldContainer.tsx
+++ b/src/FieldContainer.tsx
@@ -12,7 +12,7 @@ import {
   type FieldContainerClassKey,
   type FieldContainerClasses,
 } from "./FieldContainer.classes";
-import { Z_INDEXES, getComponentName } from "./styles";
+import { Z_INDEXES, getUtilityComponentName } from "./styles";
 
 export type FieldContainerProps = Omit<
   BoxProps,
@@ -39,7 +39,7 @@ export type FieldContainerProps = Omit<
 interface FieldContainerOwnerState
   extends Pick<FieldContainerProps, "variant" | "focused" | "disabled"> {}
 
-const componentName = getComponentName("FieldContainer");
+const componentName = getUtilityComponentName("FieldContainer");
 
 const FieldContainerRoot = styled(Box, {
   name: componentName,

--- a/src/FieldContainer.tsx
+++ b/src/FieldContainer.tsx
@@ -6,7 +6,7 @@ import {
   type SxProps,
 } from "@mui/material";
 import { clsx } from "clsx";
-import { useMemo, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import {
   fieldContainerClasses,
   type FieldContainerClasses,
@@ -35,11 +35,8 @@ export type FieldContainerProps = Omit<
   sx?: SxProps;
 };
 
-interface FieldContainerOwnerState {
-  variant: "outlined" | "standard";
-  focused: boolean;
-  disabled: boolean;
-}
+interface FieldContainerOwnerState
+  extends Pick<FieldContainerProps, "variant" | "focused" | "disabled"> {}
 
 const componentName = getComponentName("FieldContainer");
 
@@ -47,25 +44,24 @@ const FieldContainerRoot = styled(Box, {
   name: componentName,
   slot: "root",
   overridesResolver: (
-    props: { ownerState?: FieldContainerOwnerState },
+    props: { ownerState: FieldContainerOwnerState },
     styles,
   ) => [
     styles.root,
-    props.ownerState?.variant === "outlined" && styles.outlined,
-    props.ownerState?.variant === "standard" && styles.standard,
-    props.ownerState?.focused && styles.focused,
-    props.ownerState?.disabled && styles.disabled,
+    props.ownerState.variant === "outlined" && styles.outlined,
+    props.ownerState.variant === "standard" && styles.standard,
+    props.ownerState.focused && styles.focused,
+    props.ownerState.disabled && styles.disabled,
   ],
 })<{ ownerState: FieldContainerOwnerState }>(({ theme, ownerState }) => ({
   // Based on the concept behind and styles of OutlinedInput and NotchedOutline
   // styles here, to imitate outlined input appearance in material-ui
   // https://github.com/mui-org/material-ui/blob/a4972c5931e637611f6421ed2a5cc3f78207cbb2/packages/material-ui/src/OutlinedInput/OutlinedInput.js#L9-L37
   // https://github.com/mui/material-ui/blob/a4972c5931e637611f6421ed2a5cc3f78207cbb2/packages/material-ui/src/OutlinedInput/NotchedOutline.js
-
   ...(ownerState.variant === "outlined" && {
     borderRadius: theme.shape.borderRadius,
     padding: 1,
-    position: "relative" as const,
+    position: "relative",
 
     [`&:hover .${fieldContainerClasses.notchedOutline}`]: {
       borderColor: theme.palette.text.primary,
@@ -87,10 +83,7 @@ const FieldContainerRoot = styled(Box, {
 const FieldContainerNotchedOutline = styled("div", {
   name: componentName,
   slot: "notchedOutline",
-  overridesResolver: (
-    props: { ownerState?: FieldContainerOwnerState },
-    styles,
-  ) => [styles.notchedOutline],
+  overridesResolver: (props, styles) => styles.notchedOutline,
 })<{ ownerState: FieldContainerOwnerState }>(({ theme }) => ({
   position: "absolute",
   inset: 0,
@@ -116,22 +109,20 @@ export default function FieldContainer(inProps: FieldContainerProps) {
   const {
     variant = "outlined",
     children,
-    focused = false,
-    disabled = false,
+    focused,
+    disabled,
     classes = {},
     className,
     sx,
     ...boxProps
   } = props;
 
-  const ownerState = useMemo(
-    () => ({ variant, focused, disabled }),
-    [variant, focused, disabled],
-  );
+  const ownerState: FieldContainerOwnerState = { variant, focused, disabled };
 
-  const rootClasses = useMemo(
-    () =>
-      clsx([
+  return (
+    <FieldContainerRoot
+      {...boxProps}
+      className={clsx([
         fieldContainerClasses.root,
         className,
         classes.root,
@@ -143,29 +134,7 @@ export default function FieldContainer(inProps: FieldContainerProps) {
         // in this order
         focused && [fieldContainerClasses.focused, classes.focused],
         disabled && [fieldContainerClasses.disabled, classes.disabled],
-      ]),
-    [
-      className,
-      classes.root,
-      classes.outlined,
-      classes.standard,
-      classes.focused,
-      classes.disabled,
-      variant,
-      focused,
-      disabled,
-    ],
-  );
-
-  const notchedOutlineClasses = useMemo(
-    () => clsx([fieldContainerClasses.notchedOutline, classes.notchedOutline]),
-    [classes.notchedOutline],
-  );
-
-  return (
-    <FieldContainerRoot
-      {...(boxProps as any)}
-      className={rootClasses}
+      ])}
       sx={sx}
       ownerState={ownerState}
     >
@@ -174,7 +143,10 @@ export default function FieldContainer(inProps: FieldContainerProps) {
       {variant === "outlined" && (
         <FieldContainerNotchedOutline
           ownerState={ownerState}
-          className={notchedOutlineClasses}
+          className={clsx([
+            fieldContainerClasses.notchedOutline,
+            classes.notchedOutline,
+          ])}
           aria-hidden
         />
       )}

--- a/src/LinkBubbleMenu/LinkBubbleMenu.classes.ts
+++ b/src/LinkBubbleMenu/LinkBubbleMenu.classes.ts
@@ -11,13 +11,7 @@ export interface LinkBubbleMenuClasses {
 
 export type LinkBubbleMenuClassKey = keyof LinkBubbleMenuClasses;
 
-const linkBubbleMenuClassKeys = [
-  "root",
-  "paper",
-  "content",
-] as const satisfies ReadonlyArray<LinkBubbleMenuClassKey>;
-
 export const linkBubbleMenuClasses: LinkBubbleMenuClasses = getUtilityClasses(
   "LinkBubbleMenu",
-  linkBubbleMenuClassKeys,
+  ["root", "paper", "content"] satisfies LinkBubbleMenuClassKey[],
 );

--- a/src/LinkBubbleMenu/LinkBubbleMenu.classes.ts
+++ b/src/LinkBubbleMenu/LinkBubbleMenu.classes.ts
@@ -1,0 +1,23 @@
+import { getUtilityClasses } from "../styles";
+
+export interface LinkBubbleMenuClasses {
+  /** Styles applied to the root element (ControlledBubbleMenu root). */
+  root: string;
+  /** Styles applied to the Paper element (ControlledBubbleMenu paper). */
+  paper: string;
+  /** Styles applied to the content within the bubble menu. */
+  content: string;
+}
+
+export type LinkBubbleMenuClassKey = keyof LinkBubbleMenuClasses;
+
+const linkBubbleMenuClassKeys = [
+  "root",
+  "paper",
+  "content",
+] as const satisfies ReadonlyArray<LinkBubbleMenuClassKey>;
+
+export const linkBubbleMenuClasses: LinkBubbleMenuClasses = getUtilityClasses(
+  "LinkBubbleMenu",
+  linkBubbleMenuClassKeys,
+);

--- a/src/LinkBubbleMenu/ViewLinkMenuContent.classes.ts
+++ b/src/LinkBubbleMenu/ViewLinkMenuContent.classes.ts
@@ -1,0 +1,18 @@
+import { getUtilityClasses } from "../styles";
+
+export interface ViewLinkMenuContentClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the link preview text elements. */
+  linkPreviewText: string;
+}
+
+export type ViewLinkMenuContentClassKey = keyof ViewLinkMenuContentClasses;
+
+const viewLinkMenuContentClassKeys = [
+  "root",
+  "linkPreviewText",
+] as const satisfies ReadonlyArray<ViewLinkMenuContentClassKey>;
+
+export const viewLinkMenuContentClasses: ViewLinkMenuContentClasses =
+  getUtilityClasses("ViewLinkMenuContent", viewLinkMenuContentClassKeys);

--- a/src/LinkBubbleMenu/ViewLinkMenuContent.classes.ts
+++ b/src/LinkBubbleMenu/ViewLinkMenuContent.classes.ts
@@ -9,10 +9,8 @@ export interface ViewLinkMenuContentClasses {
 
 export type ViewLinkMenuContentClassKey = keyof ViewLinkMenuContentClasses;
 
-const viewLinkMenuContentClassKeys = [
-  "root",
-  "linkPreviewText",
-] as const satisfies ReadonlyArray<ViewLinkMenuContentClassKey>;
-
 export const viewLinkMenuContentClasses: ViewLinkMenuContentClasses =
-  getUtilityClasses("ViewLinkMenuContent", viewLinkMenuContentClassKeys);
+  getUtilityClasses("ViewLinkMenuContent", [
+    "root",
+    "linkPreviewText",
+  ] satisfies ViewLinkMenuContentClassKey[]);

--- a/src/LinkBubbleMenu/ViewLinkMenuContent.tsx
+++ b/src/LinkBubbleMenu/ViewLinkMenuContent.tsx
@@ -1,10 +1,23 @@
-import { Button, DialogActions, Link } from "@mui/material";
+import {
+  Button,
+  DialogActions,
+  Link,
+  styled,
+  useThemeProps,
+  type SxProps,
+} from "@mui/material";
 import { getMarkRange, getMarkType, type Editor } from "@tiptap/core";
+import { clsx } from "clsx";
 import truncate from "lodash/truncate";
 import type { ReactNode } from "react";
-import { makeStyles } from "tss-react/mui";
 import useKeyDown from "../hooks/useKeyDown";
+import { getComponentName } from "../styles";
 import truncateMiddle from "../utils/truncateMiddle";
+import {
+  viewLinkMenuContentClasses,
+  type ViewLinkMenuContentClassKey,
+  type ViewLinkMenuContentClasses,
+} from "./ViewLinkMenuContent.classes";
 
 export type ViewLinkMenuContentProps = {
   editor: Editor;
@@ -18,23 +31,41 @@ export type ViewLinkMenuContentProps = {
     /** Content shown in the button used to remove the link. */
     viewLinkRemoveButtonLabel?: ReactNode;
   };
+  /** Override or extend existing styles. */
+  classes?: Partial<ViewLinkMenuContentClasses>;
+  /** Provide custom styles. */
+  sx?: SxProps;
 };
 
-const useStyles = makeStyles({ name: { ViewLinkMenuContent } })({
-  linkPreviewText: {
-    overflowWrap: "anywhere",
-  },
+const componentName = getComponentName("ViewLinkMenuContent");
+
+const ViewLinkMenuContentRoot = styled("div", {
+  name: componentName,
+  slot: "root" satisfies ViewLinkMenuContentClassKey,
+  overridesResolver: (props, styles) => styles.root,
+})({});
+
+const ViewLinkMenuContentLinkPreviewText = styled("div", {
+  name: componentName,
+  slot: "linkPreviewText" satisfies ViewLinkMenuContentClassKey,
+  overridesResolver: (props, styles) => styles.linkPreviewText,
+})({
+  overflowWrap: "anywhere",
 });
 
 /** Shown when a user is viewing the details of an existing Link for Tiptap. */
-export default function ViewLinkMenuContent({
-  editor,
-  onCancel,
-  onEdit,
-  onRemove,
-  labels,
-}: ViewLinkMenuContentProps) {
-  const { classes } = useStyles();
+export default function ViewLinkMenuContent(inProps: ViewLinkMenuContentProps) {
+  const props = useThemeProps({ props: inProps, name: componentName });
+  const {
+    editor,
+    onCancel,
+    onEdit,
+    onRemove,
+    labels,
+    classes = {},
+    sx,
+  } = props;
+
   const linkRange = getMarkRange(
     editor.state.selection.$to,
     getMarkType("link", editor.schema),
@@ -50,21 +81,34 @@ export default function ViewLinkMenuContent({
   useKeyDown("Escape", onCancel);
 
   return (
-    <>
-      <div className={classes.linkPreviewText}>
+    <ViewLinkMenuContentRoot
+      className={clsx([viewLinkMenuContentClasses.root, classes.root])}
+      sx={sx}
+    >
+      <ViewLinkMenuContentLinkPreviewText
+        className={clsx([
+          viewLinkMenuContentClasses.linkPreviewText,
+          classes.linkPreviewText,
+        ])}
+      >
         {truncate(linkText, {
           length: 50,
           omission: "…",
         })}
-      </div>
+      </ViewLinkMenuContentLinkPreviewText>
 
-      <div className={classes.linkPreviewText}>
+      <ViewLinkMenuContentLinkPreviewText
+        className={clsx([
+          viewLinkMenuContentClasses.linkPreviewText,
+          classes.linkPreviewText,
+        ])}
+      >
         <Link href={currentHref} target="_blank" rel="noopener">
           {/* We truncate in the middle, since the beginning and end of a URL are often the most
             important parts */}
           {truncateMiddle(currentHref, 50)}
         </Link>
-      </div>
+      </ViewLinkMenuContentLinkPreviewText>
 
       <DialogActions sx={{ px: 0 }}>
         <Button
@@ -84,6 +128,6 @@ export default function ViewLinkMenuContent({
           {labels?.viewLinkRemoveButtonLabel ?? "Remove"}
         </Button>
       </DialogActions>
-    </>
+    </ViewLinkMenuContentRoot>
   );
 }

--- a/src/LinkBubbleMenu/ViewLinkMenuContent.tsx
+++ b/src/LinkBubbleMenu/ViewLinkMenuContent.tsx
@@ -11,7 +11,7 @@ import { clsx } from "clsx";
 import truncate from "lodash/truncate";
 import type { ReactNode } from "react";
 import useKeyDown from "../hooks/useKeyDown";
-import { getComponentName } from "../styles";
+import { getUtilityComponentName } from "../styles";
 import truncateMiddle from "../utils/truncateMiddle";
 import {
   viewLinkMenuContentClasses,
@@ -37,7 +37,7 @@ export type ViewLinkMenuContentProps = {
   sx?: SxProps;
 };
 
-const componentName = getComponentName("ViewLinkMenuContent");
+const componentName = getUtilityComponentName("ViewLinkMenuContent");
 
 const ViewLinkMenuContentRoot = styled("div", {
   name: componentName,

--- a/src/LinkBubbleMenu/index.tsx
+++ b/src/LinkBubbleMenu/index.tsx
@@ -9,7 +9,7 @@ import {
   LinkMenuState,
   type LinkBubbleMenuHandlerStorage,
 } from "../extensions/LinkBubbleMenuHandler";
-import { getComponentName } from "../styles";
+import { getUtilityComponentName } from "../styles";
 import EditLinkMenuContent, {
   type EditLinkMenuContentProps,
 } from "./EditLinkMenuContent";
@@ -39,7 +39,7 @@ export interface LinkBubbleMenuProps
   sx?: SxProps;
 }
 
-const componentName = getComponentName("LinkBubbleMenu");
+const componentName = getUtilityComponentName("LinkBubbleMenu");
 
 const LinkBubbleMenuContent = styled("div", {
   name: componentName,

--- a/src/MenuBar.classes.ts
+++ b/src/MenuBar.classes.ts
@@ -13,14 +13,9 @@ export interface MenuBarClasses {
 
 export type MenuBarClassKey = keyof MenuBarClasses;
 
-const menuBarClassKeys = [
+export const menuBarClasses: MenuBarClasses = getUtilityClasses("MenuBar", [
   "root",
   "sticky",
   "nonSticky",
   "content",
-] as const satisfies ReadonlyArray<MenuBarClassKey>;
-
-export const menuBarClasses: MenuBarClasses = getUtilityClasses(
-  "MenuBar",
-  menuBarClassKeys,
-);
+] satisfies MenuBarClassKey[]);

--- a/src/MenuBar.classes.ts
+++ b/src/MenuBar.classes.ts
@@ -1,0 +1,26 @@
+import { getUtilityClasses } from "./styles";
+
+export interface MenuBarClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the root element when sticky=true. */
+  sticky: string;
+  /** Styles applied to the root element when sticky=false. */
+  nonSticky: string;
+  /** Styles applied to the content element. */
+  content: string;
+}
+
+export type MenuBarClassKey = keyof MenuBarClasses;
+
+const menuBarClassKeys = [
+  "root",
+  "sticky",
+  "nonSticky",
+  "content",
+] as const satisfies ReadonlyArray<MenuBarClassKey>;
+
+export const menuBarClasses: MenuBarClasses = getUtilityClasses(
+  "MenuBar",
+  menuBarClassKeys,
+);

--- a/src/MenuBar.tsx
+++ b/src/MenuBar.tsx
@@ -12,7 +12,7 @@ import {
   type MenuBarClassKey,
   type MenuBarClasses,
 } from "./MenuBar.classes";
-import { Z_INDEXES, getComponentName } from "./styles";
+import { Z_INDEXES, getUtilityComponentName } from "./styles";
 
 export type MenuBarProps = Omit<
   CollapseProps,
@@ -59,7 +59,7 @@ interface MenuBarOwnerState
   stickyOffset: NonNullable<MenuBarProps["stickyOffset"]>;
 }
 
-const componentName = getComponentName("MenuBar");
+const componentName = getUtilityComponentName("MenuBar");
 
 const MenuBarRoot = styled(Collapse, {
   name: componentName,

--- a/src/MenuBar.tsx
+++ b/src/MenuBar.tsx
@@ -70,7 +70,7 @@ const MenuBarRoot = styled(Collapse, {
     ? {}
     : {
         position: "sticky" as const,
-        top: ownerState.stickyOffset ?? 0,
+        top: ownerState.stickyOffset,
         zIndex: Z_INDEXES.MENU_BAR,
         background: theme.palette.background.default,
       }),

--- a/src/MenuBar.tsx
+++ b/src/MenuBar.tsx
@@ -7,7 +7,11 @@ import {
 } from "@mui/material";
 import { clsx } from "clsx";
 import type { ReactNode } from "react";
-import { menuBarClasses, type MenuBarClasses } from "./MenuBar.classes";
+import {
+  menuBarClasses,
+  type MenuBarClassKey,
+  type MenuBarClasses,
+} from "./MenuBar.classes";
 import { Z_INDEXES, getComponentName } from "./styles";
 
 export type MenuBarProps = Omit<
@@ -59,7 +63,7 @@ const componentName = getComponentName("MenuBar");
 
 const MenuBarRoot = styled(Collapse, {
   name: componentName,
-  slot: "root",
+  slot: "root" satisfies MenuBarClassKey,
   overridesResolver: (props: { ownerState: MenuBarOwnerState }, styles) => [
     styles.root,
     props.ownerState.disableSticky ? styles.nonSticky : styles.sticky,
@@ -81,7 +85,7 @@ const MenuBarRoot = styled(Collapse, {
 
 const MenuBarContent = styled("div", {
   name: componentName,
-  slot: "content",
+  slot: "content" satisfies MenuBarClassKey,
   overridesResolver: (props, styles) => styles.content,
 })<{ ownerState: MenuBarOwnerState }>({});
 

--- a/src/MenuDivider.classes.ts
+++ b/src/MenuDivider.classes.ts
@@ -1,0 +1,17 @@
+import { getUtilityClasses } from "./styles";
+
+export interface MenuDividerClasses {
+  /** Styles applied to the root element. */
+  root: string;
+}
+
+export type MenuDividerClassKey = keyof MenuDividerClasses;
+
+const menuDividerClassKeys = [
+  "root",
+] as const satisfies ReadonlyArray<MenuDividerClassKey>;
+
+export const menuDividerClasses: MenuDividerClasses = getUtilityClasses(
+  "MenuDivider",
+  menuDividerClassKeys,
+);

--- a/src/MenuDivider.classes.ts
+++ b/src/MenuDivider.classes.ts
@@ -7,11 +7,7 @@ export interface MenuDividerClasses {
 
 export type MenuDividerClassKey = keyof MenuDividerClasses;
 
-const menuDividerClassKeys = [
-  "root",
-] as const satisfies ReadonlyArray<MenuDividerClassKey>;
-
 export const menuDividerClasses: MenuDividerClasses = getUtilityClasses(
   "MenuDivider",
-  menuDividerClassKeys,
+  ["root"] satisfies MenuDividerClassKey[],
 );

--- a/src/MenuDivider.tsx
+++ b/src/MenuDivider.tsx
@@ -8,6 +8,7 @@ import {
 import { clsx } from "clsx";
 import {
   menuDividerClasses,
+  type MenuDividerClassKey,
   type MenuDividerClasses,
 } from "./MenuDivider.classes";
 import { getComponentName } from "./styles";
@@ -29,7 +30,7 @@ const componentName = getComponentName("MenuDivider");
 
 const MenuDividerRoot = styled(Divider, {
   name: componentName,
-  slot: "root",
+  slot: "root" satisfies MenuDividerClassKey,
   overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => ({
   height: 18,

--- a/src/MenuDivider.tsx
+++ b/src/MenuDivider.tsx
@@ -11,7 +11,7 @@ import {
   type MenuDividerClassKey,
   type MenuDividerClasses,
 } from "./MenuDivider.classes";
-import { getComponentName } from "./styles";
+import { getUtilityComponentName } from "./styles";
 
 // The orientation of our menu dividers will always be vertical
 export type MenuDividerProps = Omit<
@@ -26,7 +26,7 @@ export type MenuDividerProps = Omit<
   sx?: SxProps;
 };
 
-const componentName = getComponentName("MenuDivider");
+const componentName = getUtilityComponentName("MenuDivider");
 
 const MenuDividerRoot = styled(Divider, {
   name: componentName,

--- a/src/MenuDivider.tsx
+++ b/src/MenuDivider.tsx
@@ -6,7 +6,6 @@ import {
   type SxProps,
 } from "@mui/material";
 import { clsx } from "clsx";
-import { useMemo } from "react";
 import {
   menuDividerClasses,
   type MenuDividerClasses,
@@ -31,7 +30,7 @@ const componentName = getComponentName("MenuDivider");
 const MenuDividerRoot = styled(Divider, {
   name: componentName,
   slot: "root",
-  overridesResolver: (props, styles) => [styles.root],
+  overridesResolver: (props, styles) => styles.root,
 })(({ theme }) => ({
   height: 18,
   margin: theme.spacing(0, 0.5),
@@ -41,16 +40,11 @@ export default function MenuDivider(inProps: MenuDividerProps) {
   const props = useThemeProps({ props: inProps, name: componentName });
   const { className, classes = {}, sx, ...dividerProps } = props;
 
-  const rootClasses = useMemo(
-    () => clsx([menuDividerClasses.root, className, classes.root]),
-    [className, classes.root],
-  );
-
   return (
     <MenuDividerRoot
       orientation="vertical"
       {...dividerProps}
-      className={rootClasses}
+      className={clsx([menuDividerClasses.root, className, classes.root])}
       sx={sx}
     />
   );

--- a/src/MenuDivider.tsx
+++ b/src/MenuDivider.tsx
@@ -26,18 +26,13 @@ export type MenuDividerProps = Omit<
   sx?: SxProps;
 };
 
-type MenuDividerOwnerState = object;
-
 const componentName = getComponentName("MenuDivider");
 
 const MenuDividerRoot = styled(Divider, {
   name: componentName,
   slot: "root",
-  overridesResolver: (
-    props: { ownerState?: MenuDividerOwnerState },
-    styles,
-  ) => [styles.root],
-})<{ ownerState: MenuDividerOwnerState }>(({ theme }) => ({
+  overridesResolver: (props, styles) => [styles.root],
+})(({ theme }) => ({
   height: 18,
   margin: theme.spacing(0, 0.5),
 }));
@@ -45,8 +40,6 @@ const MenuDividerRoot = styled(Divider, {
 export default function MenuDivider(inProps: MenuDividerProps) {
   const props = useThemeProps({ props: inProps, name: componentName });
   const { className, classes = {}, sx, ...dividerProps } = props;
-
-  const ownerState = useMemo(() => ({}), []);
 
   const rootClasses = useMemo(
     () => clsx([menuDividerClasses.root, className, classes.root]),
@@ -57,7 +50,6 @@ export default function MenuDivider(inProps: MenuDividerProps) {
     <MenuDividerRoot
       orientation="vertical"
       {...dividerProps}
-      ownerState={ownerState}
       className={rootClasses}
       sx={sx}
     />

--- a/src/MenuDivider.tsx
+++ b/src/MenuDivider.tsx
@@ -1,23 +1,65 @@
-import { Divider, type DividerProps } from "@mui/material";
-import { makeStyles } from "tss-react/mui";
+import {
+  Divider,
+  styled,
+  useThemeProps,
+  type DividerProps,
+  type SxProps,
+} from "@mui/material";
+import { clsx } from "clsx";
+import { useMemo } from "react";
+import {
+  menuDividerClasses,
+  type MenuDividerClasses,
+} from "./MenuDivider.classes";
+import { getComponentName } from "./styles";
 
 // The orientation of our menu dividers will always be vertical
-export type MenuDividerProps = Omit<DividerProps, "orientation">;
+export type MenuDividerProps = Omit<
+  DividerProps,
+  "orientation" | "className" | "classes"
+> & {
+  /** Optional additional className to provide to the root element. */
+  className?: string;
+  /** Override or extend existing styles. */
+  classes?: Partial<MenuDividerClasses>;
+  /** Provide custom styles. */
+  sx?: SxProps;
+};
 
-const useStyles = makeStyles({ name: { MenuDivider } })((theme) => ({
-  root: {
-    height: 18,
-    margin: theme.spacing(0, 0.5),
-  },
+type MenuDividerOwnerState = object;
+
+const componentName = getComponentName("MenuDivider");
+
+const MenuDividerRoot = styled(Divider, {
+  name: componentName,
+  slot: "root",
+  overridesResolver: (
+    props: { ownerState?: MenuDividerOwnerState },
+    styles,
+  ) => [styles.root],
+})<{ ownerState: MenuDividerOwnerState }>(({ theme }) => ({
+  height: 18,
+  margin: theme.spacing(0, 0.5),
 }));
 
-export default function MenuDivider(props: MenuDividerProps) {
-  const { classes, cx } = useStyles();
+export default function MenuDivider(inProps: MenuDividerProps) {
+  const props = useThemeProps({ props: inProps, name: componentName });
+  const { className, classes = {}, sx, ...dividerProps } = props;
+
+  const ownerState = useMemo(() => ({}), []);
+
+  const rootClasses = useMemo(
+    () => clsx([menuDividerClasses.root, className, classes.root]),
+    [className, classes.root],
+  );
+
   return (
-    <Divider
+    <MenuDividerRoot
       orientation="vertical"
-      {...props}
-      className={cx(classes.root, props.className)}
+      {...dividerProps}
+      ownerState={ownerState}
+      className={rootClasses}
+      sx={sx}
     />
   );
 }

--- a/src/RichTextContent.classes.ts
+++ b/src/RichTextContent.classes.ts
@@ -11,13 +11,7 @@ export interface RichTextContentClasses {
 
 export type RichTextContentClassKey = keyof RichTextContentClasses;
 
-const richTextContentClassKeys = [
-  "root",
-  "readonly",
-  "editable",
-] as const satisfies ReadonlyArray<RichTextContentClassKey>;
-
 export const richTextContentClasses: RichTextContentClasses = getUtilityClasses(
   "RichTextContent",
-  richTextContentClassKeys,
+  ["root", "readonly", "editable"] satisfies RichTextContentClassKey[],
 );

--- a/src/RichTextContent.classes.ts
+++ b/src/RichTextContent.classes.ts
@@ -1,0 +1,23 @@
+import { getUtilityClasses } from "./styles";
+
+export interface RichTextContentClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied when the editor is in read-only mode (editable=false). */
+  readonly: string;
+  /** Styles applied when the editor is editable (editable=true). */
+  editable: string;
+}
+
+export type RichTextContentClassKey = keyof RichTextContentClasses;
+
+const richTextContentClassKeys = [
+  "root",
+  "readonly",
+  "editable",
+] as const satisfies ReadonlyArray<RichTextContentClassKey>;
+
+export const richTextContentClasses: RichTextContentClasses = getUtilityClasses(
+  "RichTextContent",
+  richTextContentClassKeys,
+);

--- a/src/RichTextContent.tsx
+++ b/src/RichTextContent.tsx
@@ -1,22 +1,17 @@
-import { Box, type BoxProps } from "@mui/material";
-import { EditorContent } from "@tiptap/react";
+import { styled, useThemeProps, type SxProps } from "@mui/material/styles";
+import { EditorContent, type EditorContentProps } from "@tiptap/react";
+import { clsx } from "clsx";
 import { useMemo } from "react";
-import type { CSSObject } from "tss-react";
-import { makeStyles } from "tss-react/mui";
-import type { Except } from "type-fest";
+import {
+  richTextContentClasses,
+  type RichTextContentClasses,
+} from "./RichTextContent.classes";
 import { useRichTextEditorContext } from "./context";
-import { getEditorStyles, getUtilityClasses } from "./styles";
+import { getComponentName, getEditorStyles } from "./styles";
 
-export type RichTextContentClasses = ReturnType<typeof useStyles>["classes"];
-
-export type RichTextContentProps = Except<
-  BoxProps,
-  "children" | "component"
-> & {
-  /** Optional additional className to provide to the root element. */
-  className?: string;
-  /** Override or extend existing styles. */
-  classes?: Partial<RichTextContentClasses>;
+export type RichTextContentProps = {
+  /** Optional ref to provide to the EditorContent DOM element. */
+  innerRef?: EditorContentProps["innerRef"];
   /**
    * Whether to disable all default styles applied to the rich text content.
    *
@@ -31,37 +26,38 @@ export type RichTextContentProps = Except<
    * extensions you use.
    */
   disableDefaultStyles?: boolean;
+  /** Optional additional className to provide to the root element. */
+  className?: string;
+  /** Override or extend existing styles. */
+  classes?: Partial<RichTextContentClasses>;
+  /** Provide custom styles. */
+  sx?: SxProps;
 };
 
-const richTextContentClasses: RichTextContentClasses = getUtilityClasses(
-  "RichTextContent",
-  ["root", "readonly", "editable"],
+interface RichTextContentOwnerState {
+  editable: boolean;
+  disableDefaultStyles: boolean;
+}
+
+const componentName = getComponentName("RichTextContent");
+
+const RichTextContentRoot = styled(EditorContent, {
+  name: componentName,
+  slot: "root",
+  overridesResolver: (
+    props: { ownerState?: RichTextContentOwnerState },
+    styles,
+  ) => [
+    styles.root,
+    props.ownerState?.editable ? styles.editable : styles.readonly,
+  ],
+})<{ ownerState: RichTextContentOwnerState }>(({ theme, ownerState }) =>
+  ownerState.disableDefaultStyles
+    ? {}
+    : {
+        "& .ProseMirror": { ...getEditorStyles(theme) },
+      },
 );
-
-const useStyles = makeStyles<{ disableDefaultStyles?: boolean }>({
-  name: { RichTextContent },
-})((theme, { disableDefaultStyles = false }) => {
-  return {
-    root: disableDefaultStyles
-      ? {}
-      : {
-          // We add `as CSSObject` to get around typing issues with our editor
-          // styles function. For future reference, this old issue and its
-          // solution are related, though not quite right
-          // https://github.com/garronej/tss-react/issues/2
-          // https://github.com/garronej/tss-react/commit/9dc3f6f9f70b6df0bd83cd5689c3313467fb4f06
-          "& .ProseMirror": {
-            ...getEditorStyles(theme),
-          } as CSSObject,
-        },
-
-    // Styles applied when the editor is in read-only mode (editable=false)
-    readonly: {},
-
-    // Styles applied when the editor is editable (editable=true)
-    editable: {},
-  };
-});
 
 /**
  * A component for rendering a MUI-styled version of Tiptap rich text editor
@@ -70,38 +66,44 @@ const useStyles = makeStyles<{ disableDefaultStyles?: boolean }>({
  * Must be a child of the RichTextEditorProvider so that the `editor` context is
  * available.
  */
-export default function RichTextContent({
-  className,
-  classes: overrideClasses = {},
-  disableDefaultStyles = false,
-  ...boxProps
-}: RichTextContentProps) {
-  const { classes, cx } = useStyles(
-    { disableDefaultStyles },
-    {
-      props: { classes: overrideClasses },
-    },
-  );
+export default function RichTextContent(inProps: RichTextContentProps) {
+  const props = useThemeProps({ props: inProps, name: componentName });
+  const {
+    innerRef,
+    className,
+    classes = {},
+    disableDefaultStyles = false,
+    sx,
+  } = props;
+
   const editor = useRichTextEditorContext();
+  const editable = !!editor?.isEditable;
+
+  const ownerState = useMemo(
+    () => ({ editable, disableDefaultStyles }),
+    [editable, disableDefaultStyles],
+  );
+
   const editorClasses = useMemo(
     () =>
-      cx(
+      clsx([
         richTextContentClasses.root,
         className,
         classes.root,
-        editor?.isEditable
+        editable
           ? [richTextContentClasses.editable, classes.editable]
           : [richTextContentClasses.readonly, classes.readonly],
-      ),
-    [className, classes, cx, editor?.isEditable],
+      ]),
+    [className, classes.root, classes.editable, classes.readonly, editable],
   );
 
   return (
-    <Box
-      {...boxProps}
-      className={editorClasses}
-      component={EditorContent}
+    <RichTextContentRoot
       editor={editor}
+      innerRef={innerRef}
+      ownerState={ownerState}
+      className={editorClasses}
+      sx={sx}
     />
   );
 }

--- a/src/RichTextContent.tsx
+++ b/src/RichTextContent.tsx
@@ -11,8 +11,13 @@ import { useRichTextEditorContext } from "./context";
 import { getEditorStyles, getUtilityComponentName } from "./styles";
 
 export type RichTextContentProps = {
-  /** Optional ref to provide to the EditorContent DOM element. */
-  innerRef?: EditorContentProps["innerRef"];
+  /**
+   * Optional ref to provide to the EditorContent DOM element.
+   *
+   * Only available in Tiptap >= 2.2.0, hence the conditional type
+   * (https://github.com/ueberdosis/tiptap/commit/fd8d4c090183a0d6106250a4a1c3f522283244e7).
+   */
+  innerRef?: EditorContentProps extends { innerRef?: infer T } ? T : never;
   /**
    * Whether to disable all default styles applied to the rich text content.
    *
@@ -101,7 +106,8 @@ export default function RichTextContent(inProps: RichTextContentProps) {
   return (
     <RichTextContentRoot
       editor={editor}
-      innerRef={innerRef}
+      // Use spread for innerRef to avoid TS errors in Tiptap < 2.2.0
+      {...{ innerRef }}
       ownerState={ownerState}
       className={editorClasses}
       sx={sx}

--- a/src/RichTextContent.tsx
+++ b/src/RichTextContent.tsx
@@ -34,9 +34,9 @@ export type RichTextContentProps = {
   sx?: SxProps;
 };
 
-interface RichTextContentOwnerState {
+interface RichTextContentOwnerState
+  extends Pick<RichTextContentProps, "disableDefaultStyles"> {
   editable: boolean;
-  disableDefaultStyles: boolean;
 }
 
 const componentName = getComponentName("RichTextContent");
@@ -45,11 +45,11 @@ const RichTextContentRoot = styled(EditorContent, {
   name: componentName,
   slot: "root",
   overridesResolver: (
-    props: { ownerState?: RichTextContentOwnerState },
+    props: { ownerState: RichTextContentOwnerState },
     styles,
   ) => [
     styles.root,
-    props.ownerState?.editable ? styles.editable : styles.readonly,
+    props.ownerState.editable ? styles.editable : styles.readonly,
   ],
 })<{ ownerState: RichTextContentOwnerState }>(({ theme, ownerState }) =>
   ownerState.disableDefaultStyles
@@ -79,10 +79,10 @@ export default function RichTextContent(inProps: RichTextContentProps) {
   const editor = useRichTextEditorContext();
   const editable = !!editor?.isEditable;
 
-  const ownerState = useMemo(
-    () => ({ editable, disableDefaultStyles }),
-    [editable, disableDefaultStyles],
-  );
+  const ownerState: RichTextContentOwnerState = {
+    editable,
+    disableDefaultStyles,
+  };
 
   const editorClasses = useMemo(
     () =>

--- a/src/RichTextContent.tsx
+++ b/src/RichTextContent.tsx
@@ -8,7 +8,7 @@ import {
   type RichTextContentClasses,
 } from "./RichTextContent.classes";
 import { useRichTextEditorContext } from "./context";
-import { getComponentName, getEditorStyles } from "./styles";
+import { getEditorStyles, getUtilityComponentName } from "./styles";
 
 export type RichTextContentProps = {
   /** Optional ref to provide to the EditorContent DOM element. */
@@ -40,7 +40,7 @@ interface RichTextContentOwnerState
   editable: boolean;
 }
 
-const componentName = getComponentName("RichTextContent");
+const componentName = getUtilityComponentName("RichTextContent");
 
 const RichTextContentRoot = styled(EditorContent, {
   name: componentName,

--- a/src/RichTextContent.tsx
+++ b/src/RichTextContent.tsx
@@ -4,6 +4,7 @@ import { clsx } from "clsx";
 import { useMemo } from "react";
 import {
   richTextContentClasses,
+  type RichTextContentClassKey,
   type RichTextContentClasses,
 } from "./RichTextContent.classes";
 import { useRichTextEditorContext } from "./context";
@@ -43,7 +44,7 @@ const componentName = getComponentName("RichTextContent");
 
 const RichTextContentRoot = styled(EditorContent, {
   name: componentName,
-  slot: "root",
+  slot: "root" satisfies RichTextContentClassKey,
   overridesResolver: (
     props: { ownerState: RichTextContentOwnerState },
     styles,

--- a/src/RichTextField.classes.ts
+++ b/src/RichTextField.classes.ts
@@ -1,0 +1,32 @@
+import { getUtilityClasses } from "./styles";
+
+export interface RichTextFieldClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the root element when variant="standard". */
+  standard: string;
+  /** Styles applied to the root element when variant="outlined". */
+  outlined: string;
+  /** Styles applied to the menu bar element. */
+  menuBar: string;
+  /** Styles applied to the menu bar content element. */
+  menuBarContent: string;
+  /** Styles applied to the content element. */
+  content: string;
+}
+
+export type RichTextFieldClassKey = keyof RichTextFieldClasses;
+
+const richTextFieldClassKeys = [
+  "root",
+  "standard",
+  "outlined",
+  "menuBar",
+  "menuBarContent",
+  "content",
+] as const satisfies ReadonlyArray<RichTextFieldClassKey>;
+
+export const richTextFieldClasses: RichTextFieldClasses = getUtilityClasses(
+  "RichTextField",
+  richTextFieldClassKeys,
+);

--- a/src/RichTextField.classes.ts
+++ b/src/RichTextField.classes.ts
@@ -17,16 +17,14 @@ export interface RichTextFieldClasses {
 
 export type RichTextFieldClassKey = keyof RichTextFieldClasses;
 
-const richTextFieldClassKeys = [
-  "root",
-  "standard",
-  "outlined",
-  "menuBar",
-  "menuBarContent",
-  "content",
-] as const satisfies ReadonlyArray<RichTextFieldClassKey>;
-
 export const richTextFieldClasses: RichTextFieldClasses = getUtilityClasses(
   "RichTextField",
-  richTextFieldClassKeys,
+  [
+    "root",
+    "standard",
+    "outlined",
+    "menuBar",
+    "menuBarContent",
+    "content",
+  ] satisfies RichTextFieldClassKey[],
 );

--- a/src/RichTextField.tsx
+++ b/src/RichTextField.tsx
@@ -92,6 +92,9 @@ const RichTextFieldRoot = styled(FieldContainer, {
   // This first class is added to allow convenient user overrides. Users can
   // similarly override the other classes below.
 
+  // TODO(Steven DeMartini): We could seemingly switch to using `styled()`
+  // wrappers for the content and menu bar elements, and apply the styles
+  // directly rather than with nested selectors.
   ...(ownerState.variant === "standard" && {
     // We don't need horizontal spacing when not using the outlined variant
     [`& .${richTextFieldClasses.content}`]: {

--- a/src/RichTextField.tsx
+++ b/src/RichTextField.tsx
@@ -6,6 +6,7 @@ import MenuBar, { type MenuBarProps } from "./MenuBar";
 import RichTextContent, { type RichTextContentProps } from "./RichTextContent";
 import {
   richTextFieldClasses,
+  type RichTextFieldClassKey,
   type RichTextFieldClasses,
 } from "./RichTextField.classes";
 import { useRichTextEditorContext } from "./context";
@@ -78,7 +79,7 @@ const componentName = getComponentName("RichTextField");
 
 const RichTextFieldRoot = styled(FieldContainer, {
   name: componentName,
-  slot: "root",
+  slot: "root" satisfies RichTextFieldClassKey,
   overridesResolver: (
     props: { ownerState: RichTextFieldOwnerState },
     styles,

--- a/src/RichTextField.tsx
+++ b/src/RichTextField.tsx
@@ -11,7 +11,7 @@ import {
 } from "./RichTextField.classes";
 import { useRichTextEditorContext } from "./context";
 import useDebouncedFocus from "./hooks/useDebouncedFocus";
-import { getComponentName } from "./styles";
+import { getUtilityComponentName } from "./styles";
 import DebounceRender from "./utils/DebounceRender";
 
 export type RichTextFieldProps = Omit<
@@ -75,7 +75,7 @@ interface RichTextFieldOwnerState
     "variant" | "disabled" | "disableDebounceRenderControls"
   > {}
 
-const componentName = getComponentName("RichTextField");
+const componentName = getUtilityComponentName("RichTextField");
 
 const RichTextFieldRoot = styled(FieldContainer, {
   name: componentName,

--- a/src/TableBubbleMenu.classes.ts
+++ b/src/TableBubbleMenu.classes.ts
@@ -11,13 +11,7 @@ export interface TableBubbleMenuClasses {
 
 export type TableBubbleMenuClassKey = keyof TableBubbleMenuClasses;
 
-const tableBubbleMenuClassKeys = [
-  "root",
-  "paper",
-  "content",
-] as const satisfies ReadonlyArray<TableBubbleMenuClassKey>;
-
 export const tableBubbleMenuClasses: TableBubbleMenuClasses = getUtilityClasses(
   "TableBubbleMenu",
-  tableBubbleMenuClassKeys,
+  ["root", "paper", "content"] satisfies TableBubbleMenuClassKey[],
 );

--- a/src/TableBubbleMenu.classes.ts
+++ b/src/TableBubbleMenu.classes.ts
@@ -1,0 +1,17 @@
+import { getUtilityClasses } from "./styles";
+
+export interface TableBubbleMenuClasses {
+  /** Styles applied to the controls element. */
+  controls: string;
+}
+
+export type TableBubbleMenuClassKey = keyof TableBubbleMenuClasses;
+
+const tableBubbleMenuClassKeys = [
+  "controls",
+] as const satisfies ReadonlyArray<TableBubbleMenuClassKey>;
+
+export const tableBubbleMenuClasses: TableBubbleMenuClasses = getUtilityClasses(
+  "TableBubbleMenu",
+  tableBubbleMenuClassKeys,
+);

--- a/src/TableBubbleMenu.classes.ts
+++ b/src/TableBubbleMenu.classes.ts
@@ -1,14 +1,20 @@
 import { getUtilityClasses } from "./styles";
 
 export interface TableBubbleMenuClasses {
-  /** Styles applied to the controls element. */
-  controls: string;
+  /** Styles applied to the root element (ControlledBubbleMenu root). */
+  root: string;
+  /** Styles applied to the Paper element (ControlledBubbleMenu paper). */
+  paper: string;
+  /** Styles applied to the content within the bubble menu. */
+  content: string;
 }
 
 export type TableBubbleMenuClassKey = keyof TableBubbleMenuClasses;
 
 const tableBubbleMenuClassKeys = [
-  "controls",
+  "root",
+  "paper",
+  "content",
 ] as const satisfies ReadonlyArray<TableBubbleMenuClassKey>;
 
 export const tableBubbleMenuClasses: TableBubbleMenuClasses = getUtilityClasses(

--- a/src/TableBubbleMenu.tsx
+++ b/src/TableBubbleMenu.tsx
@@ -147,17 +147,15 @@ export default function TableBubbleMenu(inProps: TableBubbleMenuProps) {
     [editor],
   );
 
-  const controlsClasses = useMemo(
-    () => clsx([tableBubbleMenuClasses.controls, classes.controls]),
-    [classes.controls],
-  );
-
   if (!editor?.isEditable) {
     return null;
   }
 
   const controls = (
-    <TableBubbleMenuControls className={controlsClasses} labels={labels} />
+    <TableBubbleMenuControls
+      className={clsx([tableBubbleMenuClasses.controls, classes.controls])}
+      labels={labels}
+    />
   );
 
   return (

--- a/src/TableBubbleMenu.tsx
+++ b/src/TableBubbleMenu.tsx
@@ -42,18 +42,13 @@ export type TableBubbleMenuProps = {
   classes?: Partial<TableBubbleMenuClasses>;
 } & Partial<Omit<ControlledBubbleMenuProps, "open" | "editor" | "children">>;
 
-type TableBubbleMenuOwnerState = object;
-
 const componentName = getComponentName("TableBubbleMenu");
 
 const TableBubbleMenuControls = styled(TableMenuControls, {
   name: componentName,
   slot: "controls",
-  overridesResolver: (
-    props: { ownerState?: TableBubbleMenuOwnerState },
-    styles,
-  ) => [styles.controls],
-})<{ ownerState: TableBubbleMenuOwnerState }>(({ theme }) => ({
+  overridesResolver: (props, styles) => [styles.controls],
+})(({ theme }) => ({
   maxWidth: "90vw",
   padding: theme.spacing(0.5, 1),
 }));
@@ -86,8 +81,6 @@ export default function TableBubbleMenu(inProps: TableBubbleMenuProps) {
   } = props;
 
   const editor = useRichTextEditorContext();
-
-  const ownerState = useMemo(() => ({}), []);
 
   // Because the user interactions with the table menu bar buttons unfocus the
   // editor (since it's not part of the editor content), we'll debounce our
@@ -164,11 +157,7 @@ export default function TableBubbleMenu(inProps: TableBubbleMenuProps) {
   }
 
   const controls = (
-    <TableBubbleMenuControls
-      className={controlsClasses}
-      labels={labels}
-      ownerState={ownerState}
-    />
+    <TableBubbleMenuControls className={controlsClasses} labels={labels} />
   );
 
   return (

--- a/src/TableBubbleMenu.tsx
+++ b/src/TableBubbleMenu.tsx
@@ -7,6 +7,7 @@ import ControlledBubbleMenu, {
 } from "./ControlledBubbleMenu";
 import {
   tableBubbleMenuClasses,
+  type TableBubbleMenuClassKey,
   type TableBubbleMenuClasses,
 } from "./TableBubbleMenu.classes";
 import { useRichTextEditorContext } from "./context";
@@ -40,14 +41,16 @@ export type TableBubbleMenuProps = {
   labels?: TableMenuControlsProps["labels"];
   /** Override or extend existing styles. */
   classes?: Partial<TableBubbleMenuClasses>;
-} & Partial<Omit<ControlledBubbleMenuProps, "open" | "editor" | "children">>;
+} & Partial<
+  Omit<ControlledBubbleMenuProps, "open" | "editor" | "children" | "classes">
+>;
 
 const componentName = getComponentName("TableBubbleMenu");
 
-const TableBubbleMenuControls = styled(TableMenuControls, {
+const TableBubbleMenuContent = styled(TableMenuControls, {
   name: componentName,
-  slot: "controls",
-  overridesResolver: (props, styles) => [styles.controls],
+  slot: "content" satisfies TableBubbleMenuClassKey,
+  overridesResolver: (props, styles) => styles.content,
 })(({ theme }) => ({
   maxWidth: "90vw",
   padding: theme.spacing(0.5, 1),
@@ -151,9 +154,9 @@ export default function TableBubbleMenu(inProps: TableBubbleMenuProps) {
     return null;
   }
 
-  const controls = (
-    <TableBubbleMenuControls
-      className={clsx([tableBubbleMenuClasses.controls, classes.controls])}
+  const controlsContent = (
+    <TableBubbleMenuContent
+      className={clsx([tableBubbleMenuClasses.content, classes.content])}
       labels={labels}
     />
   );
@@ -194,6 +197,10 @@ export default function TableBubbleMenu(inProps: TableBubbleMenuProps) {
       // overlapping the main menu bar.
       flipPadding={{ top: 35, left: 8, right: 8, bottom: -Infinity }}
       {...controlledBubbleMenuProps}
+      classes={{
+        root: clsx([tableBubbleMenuClasses.root, classes.root]),
+        paper: clsx([tableBubbleMenuClasses.paper, classes.paper]),
+      }}
     >
       {/* We debounce rendering of the controls to improve performance, since
       otherwise it will be expensive to re-render (since it relies on several
@@ -201,9 +208,9 @@ export default function TableBubbleMenu(inProps: TableBubbleMenuProps) {
       interaction like caret movement and typing). See DebounceRender.tsx for
       more notes on this rationale and approach. */}
       {disableDebounce ? (
-        controls
+        controlsContent
       ) : (
-        <DebounceRender {...DebounceProps}>{controls}</DebounceRender>
+        <DebounceRender {...DebounceProps}>{controlsContent}</DebounceRender>
       )}
     </ControlledBubbleMenu>
   );

--- a/src/TableBubbleMenu.tsx
+++ b/src/TableBubbleMenu.tsx
@@ -15,7 +15,7 @@ import TableMenuControls, {
   type TableMenuControlsProps,
 } from "./controls/TableMenuControls";
 import { useDebouncedFocus } from "./hooks";
-import { getComponentName } from "./styles";
+import { getUtilityComponentName } from "./styles";
 import DebounceRender, {
   type DebounceRenderProps,
 } from "./utils/DebounceRender";
@@ -45,7 +45,7 @@ export type TableBubbleMenuProps = {
   Omit<ControlledBubbleMenuProps, "open" | "editor" | "children" | "classes">
 >;
 
-const componentName = getComponentName("TableBubbleMenu");
+const componentName = getUtilityComponentName("TableBubbleMenu");
 
 const TableBubbleMenuContent = styled(TableMenuControls, {
   name: componentName,

--- a/src/__tests__/styles.test.ts
+++ b/src/__tests__/styles.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  getComponentName,
+  getUtilityClass,
+  getUtilityClasses,
+} from "../styles";
+
+describe("getComponentName()", () => {
+  it("returns component name with MuiTiptap prefix", () => {
+    expect(getComponentName("RichTextContent")).toBe(
+      "MuiTiptap-RichTextContent",
+    );
+    expect(getComponentName("MenuButton")).toBe("MuiTiptap-MenuButton");
+    expect(getComponentName("ColorPicker")).toBe("MuiTiptap-ColorPicker");
+  });
+});
+
+describe("getUtilityClass()", () => {
+  it("returns utility class with component name and slot", () => {
+    expect(getUtilityClass("Foo", "root")).toBe("MuiTiptap-Foo-root");
+    expect(getUtilityClass("MenuButton", "disabled")).toBe(
+      "MuiTiptap-MenuButton-disabled",
+    );
+    expect(getUtilityClass("ColorPicker", "popper")).toBe(
+      "MuiTiptap-ColorPicker-popper",
+    );
+  });
+
+  it("handles special characters in component name and slot", () => {
+    expect(getUtilityClass("MenuFoo", "sub-element")).toBe(
+      "MuiTiptap-MenuFoo-sub-element",
+    );
+    expect(getUtilityClass("MenuFoo", "sub_element")).toBe(
+      "MuiTiptap-MenuFoo-sub_element",
+    );
+  });
+});
+
+describe("getUtilityClasses()", () => {
+  it("returns record mapping slots to utility classes", () => {
+    const result = getUtilityClasses("Foo", ["root", "disabled"]);
+    expect(result).toEqual({
+      root: "MuiTiptap-Foo-root",
+      disabled: "MuiTiptap-Foo-disabled",
+    });
+  });
+
+  it("enforces type safety", () => {
+    interface MenuFooClasses {
+      root: string;
+      disabled: string;
+    }
+    type MenuFooClassKey = keyof MenuFooClasses;
+
+    getUtilityClasses("MenuFoo", [
+      "root",
+      "disabled",
+      // @ts-expect-error - Type error should be thrown for invalid extra key
+      "wat",
+    ] satisfies MenuFooClassKey[]);
+
+    // @ts-expect-error - Type error should be thrown for misspelled key
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const _result2: MenuFooClasses = getUtilityClasses("MenuFoo", [
+      "root",
+      "disabledTypo",
+    ]);
+
+    // @ts-expect-error - Type error should be thrown for omitted key
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const _result3: MenuFooClasses = getUtilityClasses("MenuFoo", ["root"]);
+  });
+});

--- a/src/__tests__/styles.test.ts
+++ b/src/__tests__/styles.test.ts
@@ -1,17 +1,19 @@
 import { describe, expect, it } from "vitest";
 import {
-  getComponentName,
   getUtilityClass,
   getUtilityClasses,
+  getUtilityComponentName,
 } from "../styles";
 
-describe("getComponentName()", () => {
+describe("getUtilityComponentName()", () => {
   it("returns component name with MuiTiptap prefix", () => {
-    expect(getComponentName("RichTextContent")).toBe(
+    expect(getUtilityComponentName("RichTextContent")).toBe(
       "MuiTiptap-RichTextContent",
     );
-    expect(getComponentName("MenuButton")).toBe("MuiTiptap-MenuButton");
-    expect(getComponentName("ColorPicker")).toBe("MuiTiptap-ColorPicker");
+    expect(getUtilityComponentName("MenuButton")).toBe("MuiTiptap-MenuButton");
+    expect(getUtilityComponentName("ColorPicker")).toBe(
+      "MuiTiptap-ColorPicker",
+    );
   });
 });
 

--- a/src/__tests__/styles.test.ts
+++ b/src/__tests__/styles.test.ts
@@ -18,11 +18,8 @@ describe("getComponentName()", () => {
 describe("getUtilityClass()", () => {
   it("returns utility class with component name and slot", () => {
     expect(getUtilityClass("Foo", "root")).toBe("MuiTiptap-Foo-root");
-    expect(getUtilityClass("MenuButton", "disabled")).toBe(
-      "MuiTiptap-MenuButton-disabled",
-    );
-    expect(getUtilityClass("ColorPicker", "popper")).toBe(
-      "MuiTiptap-ColorPicker-popper",
+    expect(getUtilityClass("RichTextField", "content")).toBe(
+      "MuiTiptap-RichTextField-content",
     );
   });
 

--- a/src/controls/ColorPicker.classes.ts
+++ b/src/controls/ColorPicker.classes.ts
@@ -1,0 +1,23 @@
+import { getUtilityClasses } from "../styles";
+
+export interface ColorPickerClasses {
+  /** Styles applied to the gradient picker element. */
+  gradientPicker: string;
+  /** Styles applied to the color text input element. */
+  colorTextInput: string;
+  /** Styles applied to the swatch container element. */
+  swatchContainer: string;
+}
+
+export type ColorPickerClassKey = keyof ColorPickerClasses;
+
+const colorPickerClassKeys = [
+  "gradientPicker",
+  "colorTextInput",
+  "swatchContainer",
+] as const satisfies ReadonlyArray<ColorPickerClassKey>;
+
+export const colorPickerClasses: ColorPickerClasses = getUtilityClasses(
+  "ColorPicker",
+  colorPickerClassKeys,
+);

--- a/src/controls/ColorPicker.classes.ts
+++ b/src/controls/ColorPicker.classes.ts
@@ -11,13 +11,11 @@ export interface ColorPickerClasses {
 
 export type ColorPickerClassKey = keyof ColorPickerClasses;
 
-const colorPickerClassKeys = [
-  "gradientPicker",
-  "colorTextInput",
-  "swatchContainer",
-] as const satisfies ReadonlyArray<ColorPickerClassKey>;
-
 export const colorPickerClasses: ColorPickerClasses = getUtilityClasses(
   "ColorPicker",
-  colorPickerClassKeys,
+  [
+    "gradientPicker",
+    "colorTextInput",
+    "swatchContainer",
+  ] satisfies ColorPickerClassKey[],
 );

--- a/src/controls/ColorPicker.tsx
+++ b/src/controls/ColorPicker.tsx
@@ -1,12 +1,15 @@
-import { TextField } from "@mui/material";
+import { TextField, styled, useThemeProps } from "@mui/material";
+import { clsx } from "clsx";
 import { useEffect, useRef } from "react";
 import { HexAlphaColorPicker, HexColorPicker } from "react-colorful";
-import { makeStyles } from "tss-react/mui";
-import { getUtilityClasses } from "../styles";
+import { getComponentName } from "../styles";
 import { colorToHex as colorToHexDefault } from "../utils/color";
+import {
+  colorPickerClasses,
+  type ColorPickerClassKey,
+  type ColorPickerClasses,
+} from "./ColorPicker.classes";
 import { ColorSwatchButton } from "./ColorSwatchButton";
-
-export type ColorPickerClasses = ReturnType<typeof useStyles>["classes"];
 
 export type ColorChangeSource = "gradient" | "text" | "swatch";
 
@@ -121,47 +124,65 @@ export type ColorPickerProps = {
   classes?: Partial<ColorPickerClasses>;
 };
 
-const colorPickerUtilityClasses: ColorPickerClasses = getUtilityClasses(
-  "ColorPicker",
-  ["gradientPicker", "colorTextInput", "swatchContainer"],
-);
+const componentName = getComponentName("ColorPicker");
 
-const useStyles = makeStyles({ name: { ColorPicker } })((theme) => ({
-  gradientPicker: {
-    // Increase specificity to override the styles
-    "&&": {
-      width: "100%",
-    },
+const StyledHexColorPicker = styled(HexColorPicker, {
+  name: componentName,
+  slot: "gradientPicker" satisfies ColorPickerClassKey,
+  overridesResolver: (props, styles) => styles.gradientPicker,
+})(() => ({
+  // Increase specificity to override the styles
+  "&&": {
+    width: "100%",
   },
+}));
 
-  colorTextInput: {
-    marginTop: theme.spacing(1),
+const StyledHexAlphaColorPicker = styled(HexAlphaColorPicker, {
+  name: componentName,
+  slot: "gradientPicker" satisfies ColorPickerClassKey,
+  overridesResolver: (props, styles) => styles.gradientPicker,
+})(() => ({
+  // Increase specificity to override the styles
+  "&&": {
+    width: "100%",
   },
+}));
 
-  swatchContainer: {
-    display: "flex",
-    flexWrap: "wrap",
-    gap: 5,
-    marginTop: theme.spacing(1),
-  },
+const ColorPickerColorTextInput = styled(TextField, {
+  name: componentName,
+  slot: "colorTextInput" satisfies ColorPickerClassKey,
+  overridesResolver: (props, styles) => styles.colorTextInput,
+})(({ theme }) => ({
+  marginTop: theme.spacing(1),
+}));
+
+const ColorPickerSwatchContainer = styled("div", {
+  name: componentName,
+  slot: "swatchContainer" satisfies ColorPickerClassKey,
+  overridesResolver: (props, styles) => styles.swatchContainer,
+})(({ theme }) => ({
+  display: "flex",
+  flexWrap: "wrap",
+  gap: 5,
+  marginTop: theme.spacing(1),
 }));
 
 /**
  * Component for the user to choose a color from a gradient-based hue/saturation
  * (and optionally alpha) color-picker or from the given swatch colors.
  */
-export function ColorPicker({
-  value,
-  onChange,
-  swatchColors,
-  colorToHex = colorToHexDefault,
-  disableAlpha = false,
-  labels = {},
-  classes: overrideClasses = {},
-}: ColorPickerProps) {
-  const { classes, cx } = useStyles(undefined, {
-    props: { classes: overrideClasses },
-  });
+export function ColorPicker(inProps: ColorPickerProps) {
+  const props = useThemeProps({ props: inProps, name: componentName });
+  const {
+    value,
+    onChange,
+    swatchColors,
+    colorToHex = colorToHexDefault,
+    disableAlpha = false,
+    labels = {},
+    classes = {},
+  } = props;
+
   const { textFieldPlaceholder = 'Ex: "#7cb5ec"' } = labels;
 
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -182,46 +203,47 @@ export function ColorPicker({
   );
 
   const colorValueAsHex = colorToHex(value);
+
   return (
     <>
       {/* Fall back to black with the HexColorPickers if there isn't a (valid)
       color value provided. This ensures consistent visual behavior and should
       be intuitive. */}
       {disableAlpha ? (
-        <HexColorPicker
+        <StyledHexColorPicker
           color={colorValueAsHex ?? "#000000"}
-          className={cx(
-            colorPickerUtilityClasses.gradientPicker,
+          className={clsx([
+            colorPickerClasses.gradientPicker,
             classes.gradientPicker,
-          )}
+          ])}
           onChange={(color) => {
             onChange(color, "gradient");
           }}
         />
       ) : (
-        <HexAlphaColorPicker
+        <StyledHexAlphaColorPicker
           color={colorValueAsHex ?? "#000000"}
-          className={cx(
-            colorPickerUtilityClasses.gradientPicker,
+          className={clsx([
+            colorPickerClasses.gradientPicker,
             classes.gradientPicker,
-          )}
+          ])}
           onChange={(color) => {
             onChange(color, "gradient");
           }}
         />
       )}
 
-      <TextField
+      <ColorPickerColorTextInput
         placeholder={textFieldPlaceholder}
         variant="outlined"
         size="small"
         defaultValue={value || ""}
         inputRef={inputRef}
         spellCheck={false}
-        className={cx(
-          colorPickerUtilityClasses.colorTextInput,
+        className={clsx([
+          colorPickerClasses.colorTextInput,
           classes.colorTextInput,
-        )}
+        ])}
         onChange={(event) => {
           const newColor = event.target.value;
           const newHexColor = colorToHex(newColor);
@@ -233,11 +255,11 @@ export function ColorPicker({
       />
 
       {swatchColorObjects.length > 0 && (
-        <div
-          className={cx(
-            colorPickerUtilityClasses.swatchContainer,
+        <ColorPickerSwatchContainer
+          className={clsx([
+            colorPickerClasses.swatchContainer,
             classes.swatchContainer,
-          )}
+          ])}
         >
           {swatchColorObjects.map((swatchColor) => (
             <ColorSwatchButton
@@ -260,7 +282,7 @@ export function ColorPicker({
               }
             />
           ))}
-        </div>
+        </ColorPickerSwatchContainer>
       )}
     </>
   );

--- a/src/controls/ColorPicker.tsx
+++ b/src/controls/ColorPicker.tsx
@@ -2,7 +2,7 @@ import { TextField, styled, useThemeProps } from "@mui/material";
 import { clsx } from "clsx";
 import { useEffect, useRef } from "react";
 import { HexAlphaColorPicker, HexColorPicker } from "react-colorful";
-import { getComponentName } from "../styles";
+import { getUtilityComponentName } from "../styles";
 import { colorToHex as colorToHexDefault } from "../utils/color";
 import {
   colorPickerClasses,
@@ -124,7 +124,7 @@ export type ColorPickerProps = {
   classes?: Partial<ColorPickerClasses>;
 };
 
-const componentName = getComponentName("ColorPicker");
+const componentName = getUtilityComponentName("ColorPicker");
 
 const StyledHexColorPicker = styled(HexColorPicker, {
   name: componentName,

--- a/src/controls/ColorPickerPopper.classes.ts
+++ b/src/controls/ColorPickerPopper.classes.ts
@@ -1,0 +1,15 @@
+import { getUtilityClasses } from "../styles";
+
+export interface ColorPickerPopperClasses {
+  /** Styles applied to the root popper element. */
+  root: string;
+}
+
+export type ColorPickerPopperClassKey = keyof ColorPickerPopperClasses;
+
+const colorPickerPopperClassKeys = [
+  "root",
+] as const satisfies ReadonlyArray<ColorPickerPopperClassKey>;
+
+export const colorPickerPopperClasses: ColorPickerPopperClasses =
+  getUtilityClasses("ColorPickerPopper", colorPickerPopperClassKeys);

--- a/src/controls/ColorPickerPopper.classes.ts
+++ b/src/controls/ColorPickerPopper.classes.ts
@@ -7,9 +7,7 @@ export interface ColorPickerPopperClasses {
 
 export type ColorPickerPopperClassKey = keyof ColorPickerPopperClasses;
 
-const colorPickerPopperClassKeys = [
-  "root",
-] as const satisfies ReadonlyArray<ColorPickerPopperClassKey>;
-
 export const colorPickerPopperClasses: ColorPickerPopperClasses =
-  getUtilityClasses("ColorPickerPopper", colorPickerPopperClassKeys);
+  getUtilityClasses("ColorPickerPopper", [
+    "root",
+  ] satisfies ColorPickerPopperClassKey[]);

--- a/src/controls/ColorPickerPopper.tsx
+++ b/src/controls/ColorPickerPopper.tsx
@@ -14,7 +14,7 @@ import {
 } from "@mui/material";
 import { clsx } from "clsx";
 import { useEffect, useState } from "react";
-import { getComponentName } from "../styles";
+import { getUtilityComponentName } from "../styles";
 import { ColorPicker } from "./ColorPicker";
 import {
   colorPickerPopperClasses,
@@ -120,7 +120,7 @@ export function ColorPickerPopperBody({
   );
 }
 
-const componentName = getComponentName("ColorPickerPopper");
+const componentName = getUtilityComponentName("ColorPickerPopper");
 
 const ColorPickerPopperRoot = styled(Popper, {
   name: componentName,

--- a/src/controls/ColorSwatchButton.classes.ts
+++ b/src/controls/ColorSwatchButton.classes.ts
@@ -11,11 +11,9 @@ export interface ColorSwatchButtonClasses {
 
 export type ColorSwatchButtonClassKey = keyof ColorSwatchButtonClasses;
 
-const colorSwatchButtonClassKeys = [
-  "root",
-  "activeIcon",
-  "colorNotSet",
-] as const satisfies ReadonlyArray<ColorSwatchButtonClassKey>;
-
 export const colorSwatchButtonClasses: ColorSwatchButtonClasses =
-  getUtilityClasses("ColorSwatchButton", colorSwatchButtonClassKeys);
+  getUtilityClasses("ColorSwatchButton", [
+    "root",
+    "activeIcon",
+    "colorNotSet",
+  ] satisfies ColorSwatchButtonClassKey[]);

--- a/src/controls/ColorSwatchButton.classes.ts
+++ b/src/controls/ColorSwatchButton.classes.ts
@@ -1,0 +1,21 @@
+import { getUtilityClasses } from "../styles";
+
+export interface ColorSwatchButtonClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the active check icon. */
+  activeIcon: string;
+  /** Styles applied to the root element when no color is set. */
+  colorNotSet: string;
+}
+
+export type ColorSwatchButtonClassKey = keyof ColorSwatchButtonClasses;
+
+const colorSwatchButtonClassKeys = [
+  "root",
+  "activeIcon",
+  "colorNotSet",
+] as const satisfies ReadonlyArray<ColorSwatchButtonClassKey>;
+
+export const colorSwatchButtonClasses: ColorSwatchButtonClasses =
+  getUtilityClasses("ColorSwatchButton", colorSwatchButtonClassKeys);

--- a/src/controls/ColorSwatchButton.tsx
+++ b/src/controls/ColorSwatchButton.tsx
@@ -6,10 +6,10 @@ import {
   type ComponentPropsWithoutRef,
   type ElementRef,
 } from "react";
-import { getComponentName } from "../styles";
+import { getUtilityComponentName } from "../styles";
 import {
-  ColorSwatchButtonClassKey,
   colorSwatchButtonClasses,
+  type ColorSwatchButtonClassKey,
   type ColorSwatchButtonClasses,
 } from "./ColorSwatchButton.classes";
 
@@ -50,7 +50,7 @@ interface ColorSwatchButtonOwnerState
   colorNotSet: boolean;
 }
 
-const componentName = getComponentName("ColorSwatchButton");
+const componentName = getUtilityComponentName("ColorSwatchButton");
 
 const ColorSwatchButtonRoot = styled("button", {
   name: componentName,

--- a/src/controls/ColorSwatchButton.tsx
+++ b/src/controls/ColorSwatchButton.tsx
@@ -1,16 +1,25 @@
 import Check from "@mui/icons-material/Check";
+import { styled, useTheme, useThemeProps, type SxProps } from "@mui/material";
+import { clsx } from "clsx";
 import {
   forwardRef,
   type ComponentPropsWithoutRef,
   type ElementRef,
 } from "react";
-import { makeStyles } from "tss-react/mui";
-import type { Except } from "type-fest";
+import { getComponentName } from "../styles";
+import {
+  ColorSwatchButtonClassKey,
+  colorSwatchButtonClasses,
+  type ColorSwatchButtonClasses,
+} from "./ColorSwatchButton.classes";
 
 export interface ColorSwatchButtonProps
   // Omit the default "color" prop so that it can't be confused for the `value`
   // prop
-  extends Except<ComponentPropsWithoutRef<"button">, "color"> {
+  extends Omit<
+    ComponentPropsWithoutRef<"button">,
+    "color" | "className" | "classes"
+  > {
   /**
    * What color is shown with this swatch. If not provided, shows a checkerboard
    * pattern, typically used as "not set" or "transparent".
@@ -28,7 +37,64 @@ export interface ColorSwatchButtonProps
   active?: boolean;
   /** If given, sets the padding between the color and the border of the swatch. */
   padding?: string | number;
+  /** Optional additional className to provide to the root element. */
+  className?: string;
+  /** Override or extend existing styles. */
+  classes?: Partial<ColorSwatchButtonClasses>;
+  /** Provide custom styles. */
+  sx?: SxProps;
 }
+
+interface ColorSwatchButtonOwnerState
+  extends Pick<ColorSwatchButtonProps, "active"> {
+  colorNotSet: boolean;
+}
+
+const componentName = getComponentName("ColorSwatchButton");
+
+const ColorSwatchButtonRoot = styled("button", {
+  name: componentName,
+  slot: "root" satisfies ColorSwatchButtonClassKey,
+  overridesResolver: (
+    props: { ownerState: ColorSwatchButtonOwnerState },
+    styles,
+  ) => [styles.root, props.ownerState.colorNotSet && styles.colorNotSet],
+})<{ ownerState: ColorSwatchButtonOwnerState }>(({ theme, ownerState }) => ({
+  height: theme.spacing(2.5),
+  width: theme.spacing(2.5),
+  minWidth: theme.spacing(2.5),
+  borderRadius: theme.shape.borderRadius,
+  borderColor:
+    theme.palette.mode === "dark"
+      ? theme.palette.grey[700]
+      : theme.palette.grey[400],
+  borderStyle: "solid",
+  borderWidth: 1,
+  cursor: "pointer",
+  // Use background-clip with content-box so that if a `padding` is specified by the
+  // user, it adds a gap between the color and the border.
+  padding: 0,
+  backgroundClip: "content-box",
+
+  ...(ownerState.colorNotSet && {
+    // To indicate that a color hasn't been chosen, we'll use a checkerboard pattern
+    // (https://stackoverflow.com/a/65129916/4543977)
+    background: `repeating-conic-gradient(
+      ${theme.palette.grey[400]} 0% 25%, ${theme.palette.common.white} 0% 50%)
+      50% / 12px 12px`,
+    backgroundClip: "content-box",
+  }),
+}));
+
+const ColorSwatchButtonActiveIcon = styled(Check, {
+  name: componentName,
+  slot: "activeIcon" satisfies ColorSwatchButtonClassKey,
+  overridesResolver: (props, styles) => styles.activeIcon,
+})(() => ({
+  height: "100%",
+  width: "80%",
+  verticalAlign: "middle",
+}));
 
 /**
  * Renders a button in the given color `value`, useful for showing and allowing
@@ -37,26 +103,54 @@ export interface ColorSwatchButtonProps
 export const ColorSwatchButton = forwardRef<
   ElementRef<"button">,
   ColorSwatchButtonProps
->(({ value: colorValue, label, padding, active, ...buttonProps }, ref) => {
-  const { classes, cx, theme } = useStyles();
+>((inProps, ref) => {
+  const props = useThemeProps({ props: inProps, name: componentName });
+  const {
+    value: colorValue,
+    label,
+    padding,
+    active,
+    className,
+    classes = {},
+    sx,
+    ...buttonProps
+  } = props;
+
+  const theme = useTheme();
+  const colorNotSet = !colorValue;
+
+  const ownerState: ColorSwatchButtonOwnerState = {
+    active,
+    colorNotSet,
+  };
+
   return (
-    <button
+    <ColorSwatchButtonRoot
       ref={ref}
       type="button"
       style={{ backgroundColor: colorValue, padding }}
       aria-label={label ?? colorValue}
       value={colorValue}
       {...buttonProps}
-      className={cx(
+      className={clsx([
+        colorSwatchButtonClasses.root,
+        colorNotSet && [
+          colorSwatchButtonClasses.colorNotSet,
+          classes.colorNotSet,
+        ],
         classes.root,
-        !colorValue && classes.colorNotSet,
-        buttonProps.className,
-      )}
+        className,
+      ])}
+      sx={sx}
+      ownerState={ownerState}
     >
       {active && (
-        <Check
+        <ColorSwatchButtonActiveIcon
           fontSize="small"
-          className={classes.activeIcon}
+          className={clsx([
+            colorSwatchButtonClasses.activeIcon,
+            classes.activeIcon,
+          ])}
           style={{
             color: colorValue
               ? theme.palette.getContrastText(colorValue)
@@ -64,43 +158,8 @@ export const ColorSwatchButton = forwardRef<
           }}
         />
       )}
-    </button>
+    </ColorSwatchButtonRoot>
   );
 });
-
-const useStyles = makeStyles({ name: { ColorSwatchButton } })((theme) => ({
-  root: {
-    height: theme.spacing(2.5),
-    width: theme.spacing(2.5),
-    minWidth: theme.spacing(2.5),
-    borderRadius: theme.shape.borderRadius,
-    borderColor:
-      theme.palette.mode === "dark"
-        ? theme.palette.grey[700]
-        : theme.palette.grey[400],
-    borderStyle: "solid",
-    borderWidth: 1,
-    cursor: "pointer",
-    // Use background-clip with content-box so that if a `padding` is specified by the
-    // user, it adds a gap between the color and the border.
-    padding: 0,
-    backgroundClip: "content-box",
-  },
-
-  activeIcon: {
-    height: "100%",
-    width: "80%",
-    verticalAlign: "middle",
-  },
-
-  colorNotSet: {
-    // To indicate that a color hasn't been chosen, we'll use a checkerboard pattern
-    // (https://stackoverflow.com/a/65129916/4543977)
-    background: `repeating-conic-gradient(
-      ${theme.palette.grey[400]} 0% 25%, ${theme.palette.common.white} 0% 50%)
-      50% / 12px 12px`,
-    backgroundClip: "content-box",
-  },
-}));
 
 ColorSwatchButton.displayName = "ColorSwatchButton";

--- a/src/controls/MenuButton.classes.ts
+++ b/src/controls/MenuButton.classes.ts
@@ -9,12 +9,7 @@ export interface MenuButtonClasses {
 
 export type MenuButtonClassKey = keyof MenuButtonClasses;
 
-const menuButtonClassKeys = [
-  "root",
-  "icon",
-] as const satisfies ReadonlyArray<MenuButtonClassKey>;
-
 export const menuButtonClasses: MenuButtonClasses = getUtilityClasses(
   "MenuButton",
-  menuButtonClassKeys,
+  ["root", "icon"] satisfies MenuButtonClassKey[],
 );

--- a/src/controls/MenuButton.classes.ts
+++ b/src/controls/MenuButton.classes.ts
@@ -4,14 +4,14 @@ export interface MenuButtonClasses {
   /** Styles applied to the root element. */
   root: string;
   /** Styles applied to the menu button icon. */
-  menuButtonIcon: string;
+  icon: string;
 }
 
 export type MenuButtonClassKey = keyof MenuButtonClasses;
 
 const menuButtonClassKeys = [
   "root",
-  "menuButtonIcon",
+  "icon",
 ] as const satisfies ReadonlyArray<MenuButtonClassKey>;
 
 export const menuButtonClasses: MenuButtonClasses = getUtilityClasses(

--- a/src/controls/MenuButton.classes.ts
+++ b/src/controls/MenuButton.classes.ts
@@ -1,0 +1,20 @@
+import { getUtilityClasses } from "../styles";
+
+export interface MenuButtonClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the menu button icon. */
+  menuButtonIcon: string;
+}
+
+export type MenuButtonClassKey = keyof MenuButtonClasses;
+
+const menuButtonClassKeys = [
+  "root",
+  "menuButtonIcon",
+] as const satisfies ReadonlyArray<MenuButtonClassKey>;
+
+export const menuButtonClasses: MenuButtonClasses = getUtilityClasses(
+  "MenuButton",
+  menuButtonClassKeys,
+);

--- a/src/controls/MenuButton.tsx
+++ b/src/controls/MenuButton.tsx
@@ -80,6 +80,10 @@ const MenuButtonRoot = styled("span", {
     border: "none",
     padding: 5,
   },
+
+  [`& .${menuButtonClasses.icon}`]: {
+    fontSize: MENU_BUTTON_FONT_SIZE_DEFAULT,
+  },
 }));
 
 /**
@@ -118,11 +122,7 @@ export default function MenuButton(inProps: MenuButtonProps) {
           {children ??
             (IconComponent && (
               <IconComponent
-                className={clsx([
-                  menuButtonClasses.menuButtonIcon,
-                  classes.menuButtonIcon,
-                ])}
-                style={{ fontSize: MENU_BUTTON_FONT_SIZE_DEFAULT }}
+                className={clsx([menuButtonClasses.icon, classes.icon])}
               />
             ))}
         </ToggleButton>

--- a/src/controls/MenuButton.tsx
+++ b/src/controls/MenuButton.tsx
@@ -80,10 +80,16 @@ const MenuButtonRoot = styled("span", {
     border: "none",
     padding: 5,
   },
+}));
 
-  [`& .${menuButtonClasses.icon}`]: {
-    fontSize: MENU_BUTTON_FONT_SIZE_DEFAULT,
-  },
+// We can use an arbitrary component here ("span"), since we use `as` below with
+// the `IconComponent` prop.
+const MenuButtonIcon = styled("span", {
+  name: componentName,
+  slot: "icon" satisfies MenuButtonClassKey,
+  overridesResolver: (props, styles) => styles.icon,
+})(() => ({
+  fontSize: MENU_BUTTON_FONT_SIZE_DEFAULT,
 }));
 
 /**
@@ -121,7 +127,8 @@ export default function MenuButton(inProps: MenuButtonProps) {
         >
           {children ??
             (IconComponent && (
-              <IconComponent
+              <MenuButtonIcon
+                as={IconComponent}
                 className={clsx([menuButtonClasses.icon, classes.icon])}
               />
             ))}

--- a/src/controls/MenuButton.tsx
+++ b/src/controls/MenuButton.tsx
@@ -9,7 +9,7 @@ import {
 import { clsx } from "clsx";
 import type { ReactNode, RefObject } from "react";
 import type { Except, SetOptional } from "type-fest";
-import { getComponentName } from "../styles";
+import { getUtilityComponentName } from "../styles";
 import {
   menuButtonClasses,
   type MenuButtonClassKey,
@@ -67,7 +67,7 @@ export interface MenuButtonProps
 
 export const MENU_BUTTON_FONT_SIZE_DEFAULT = "1.25rem";
 
-const componentName = getComponentName("MenuButton");
+const componentName = getUtilityComponentName("MenuButton");
 
 const MenuButtonRoot = styled("span", {
   name: componentName,

--- a/src/controls/MenuButtonColorPicker.classes.ts
+++ b/src/controls/MenuButtonColorPicker.classes.ts
@@ -11,11 +11,9 @@ export interface MenuButtonColorPickerClasses {
 
 export type MenuButtonColorPickerClassKey = keyof MenuButtonColorPickerClasses;
 
-const menuButtonColorPickerClassKeys = [
-  "icon",
-  "colorIndicatorIcon",
-  "colorIndicatorIconDisabled",
-] as const satisfies ReadonlyArray<MenuButtonColorPickerClassKey>;
-
 export const menuButtonColorPickerClasses: MenuButtonColorPickerClasses =
-  getUtilityClasses("MenuButtonColorPicker", menuButtonColorPickerClassKeys);
+  getUtilityClasses("MenuButtonColorPicker", [
+    "icon",
+    "colorIndicatorIcon",
+    "colorIndicatorIconDisabled",
+  ] satisfies MenuButtonColorPickerClassKey[]);

--- a/src/controls/MenuButtonColorPicker.classes.ts
+++ b/src/controls/MenuButtonColorPicker.classes.ts
@@ -1,0 +1,21 @@
+import { getUtilityClasses } from "../styles";
+
+export interface MenuButtonColorPickerClasses {
+  /** Styles applied to the button icon. */
+  icon: string;
+  /** Styles applied to the color indicator icon. */
+  colorIndicatorIcon: string;
+  /** Styles applied to the color indicator icon when disabled. */
+  colorIndicatorIconDisabled: string;
+}
+
+export type MenuButtonColorPickerClassKey = keyof MenuButtonColorPickerClasses;
+
+const menuButtonColorPickerClassKeys = [
+  "icon",
+  "colorIndicatorIcon",
+  "colorIndicatorIconDisabled",
+] as const satisfies ReadonlyArray<MenuButtonColorPickerClassKey>;
+
+export const menuButtonColorPickerClasses: MenuButtonColorPickerClasses =
+  getUtilityClasses("MenuButtonColorPicker", menuButtonColorPickerClassKeys);

--- a/src/controls/MenuButtonColorPicker.tsx
+++ b/src/controls/MenuButtonColorPicker.tsx
@@ -1,20 +1,26 @@
-import type { PopperProps } from "@mui/material";
+import { styled, useThemeProps, type PopperProps } from "@mui/material";
+import { clsx } from "clsx";
 import { useState, type ReactNode } from "react";
-import { makeStyles } from "tss-react/mui";
 import type { Except } from "type-fest";
 import { FormatColorBar } from "../icons";
+import { getComponentName } from "../styles";
 import type { ColorPickerProps, SwatchColorOption } from "./ColorPicker";
 import { ColorPickerPopper } from "./ColorPickerPopper";
 import MenuButton, {
   MENU_BUTTON_FONT_SIZE_DEFAULT,
   type MenuButtonProps,
 } from "./MenuButton";
+import {
+  menuButtonColorPickerClasses,
+  type MenuButtonColorPickerClassKey,
+  type MenuButtonColorPickerClasses,
+} from "./MenuButtonColorPicker.classes";
 
 export interface MenuButtonColorPickerProps
   // Omit the default `color`, `value`, and `onChange` toggle button props so
   // that "color" can't be confused for the `value` prop, and so that we can use
   // our own types for `value` and `onChange`.
-  extends Except<MenuButtonProps, "color" | "value" | "onChange"> {
+  extends Except<MenuButtonProps, "color" | "value" | "onChange" | "classes"> {
   /** The current CSS color string value. */
   value: string | undefined;
   /** Callback when the color changes. */
@@ -70,35 +76,67 @@ export interface MenuButtonColorPickerProps
      */
     textFieldPlaceholder?: string;
   };
+  /** Override or extend existing styles. */
+  classes?: Partial<MenuButtonColorPickerClasses>;
 }
 
-const useStyles = makeStyles({ name: { MenuButtonColorPicker } })((theme) => ({
-  icon: {
+interface MenuButtonColorPickerOwnerState
+  extends Pick<MenuButtonColorPickerProps, "disabled"> {}
+
+const componentName = getComponentName("MenuButtonColorPicker");
+
+// We can use an arbitrary component here ("span"), since we use `as` below with
+// the `IconComponent` prop.
+const MenuButtonColorPickerIcon = styled("span", {
+  name: componentName,
+  slot: "icon" satisfies MenuButtonColorPickerClassKey,
+  overridesResolver: (props, styles) => styles.icon,
+})<{ ownerState: MenuButtonColorPickerOwnerState }>({
+  fontSize: MENU_BUTTON_FONT_SIZE_DEFAULT,
+});
+
+const MenuButtonColorPickerIndicatorIcon = styled(FormatColorBar, {
+  name: componentName,
+  slot: "colorIndicatorIcon" satisfies MenuButtonColorPickerClassKey,
+  overridesResolver: (
+    props: { ownerState: MenuButtonColorPickerOwnerState },
+    styles,
+  ) => [
+    styles.colorIndicatorIcon,
+    props.ownerState.disabled && styles.colorIndicatorIconDisabled,
+  ],
+})<{ ownerState: MenuButtonColorPickerOwnerState }>(
+  ({ theme, ownerState }) => ({
     fontSize: MENU_BUTTON_FONT_SIZE_DEFAULT,
-  },
-
-  colorIndicatorIcon: {
     position: "absolute",
-  },
+    ...(ownerState.disabled && {
+      color: theme.palette.action.disabled,
+    }),
+  }),
+);
 
-  colorIndicatorIconDisabled: {
-    color: theme.palette.action.disabled,
-  },
-}));
+export default function MenuButtonColorPicker(
+  inProps: MenuButtonColorPickerProps,
+) {
+  const props = useThemeProps({ props: inProps, name: componentName });
+  const {
+    value: colorValue,
+    onChange,
+    swatchColors,
+    labels,
+    hideColorIndicator = false,
+    popperId,
+    PopperProps,
+    ColorPickerProps,
+    classes = {},
+    ...menuButtonProps
+  } = props;
 
-export function MenuButtonColorPicker({
-  value: colorValue,
-  onChange,
-  swatchColors,
-  labels,
-  hideColorIndicator = false,
-  popperId,
-  PopperProps,
-  ColorPickerProps,
-  ...menuButtonProps
-}: MenuButtonColorPickerProps) {
-  const { classes, cx } = useStyles();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  const ownerState: MenuButtonColorPickerOwnerState = {
+    disabled: menuButtonProps.disabled,
+  };
 
   const handleClose = () => {
     setAnchorEl(null);
@@ -121,20 +159,32 @@ export function MenuButtonColorPicker({
       >
         {children ?? (
           <>
-            {IconComponent && <IconComponent className={classes.icon} />}
+            {IconComponent && (
+              <MenuButtonColorPickerIcon
+                as={IconComponent}
+                ownerState={ownerState}
+                className={clsx([
+                  menuButtonColorPickerClasses.icon,
+                  classes.icon,
+                ])}
+              />
+            )}
 
             {/* We only show the color indicator if a color has been set. (It's
             effectively "transparent" otherwise, indicating no color has been
             chosen.) This bar indicator icon pairs well with the *NoBar icons
             like FormatColorTextNoBar. */}
             {!hideColorIndicator && colorValue && (
-              <FormatColorBar
-                className={cx(
-                  classes.icon,
+              <MenuButtonColorPickerIndicatorIcon
+                ownerState={ownerState}
+                className={clsx([
+                  menuButtonColorPickerClasses.colorIndicatorIcon,
                   classes.colorIndicatorIcon,
-                  menuButtonProps.disabled &&
+                  menuButtonProps.disabled && [
+                    menuButtonColorPickerClasses.colorIndicatorIconDisabled,
                     classes.colorIndicatorIconDisabled,
-                )}
+                  ],
+                ])}
                 style={
                   menuButtonProps.disabled ? undefined : { color: colorValue }
                 }

--- a/src/controls/MenuButtonColorPicker.tsx
+++ b/src/controls/MenuButtonColorPicker.tsx
@@ -3,7 +3,7 @@ import { clsx } from "clsx";
 import { useState, type ReactNode } from "react";
 import type { Except } from "type-fest";
 import { FormatColorBar } from "../icons";
-import { getComponentName } from "../styles";
+import { getUtilityComponentName } from "../styles";
 import type { ColorPickerProps, SwatchColorOption } from "./ColorPicker";
 import { ColorPickerPopper } from "./ColorPickerPopper";
 import MenuButton, {
@@ -83,7 +83,7 @@ export interface MenuButtonColorPickerProps
 interface MenuButtonColorPickerOwnerState
   extends Pick<MenuButtonColorPickerProps, "disabled"> {}
 
-const componentName = getComponentName("MenuButtonColorPicker");
+const componentName = getUtilityComponentName("MenuButtonColorPicker");
 
 // We can use an arbitrary component here ("span"), since we use `as` below with
 // the `IconComponent` prop.

--- a/src/controls/MenuButtonColorPicker.tsx
+++ b/src/controls/MenuButtonColorPicker.tsx
@@ -73,7 +73,7 @@ export interface MenuButtonColorPickerProps
 }
 
 const useStyles = makeStyles({ name: { MenuButtonColorPicker } })((theme) => ({
-  menuButtonIcon: {
+  icon: {
     fontSize: MENU_BUTTON_FONT_SIZE_DEFAULT,
   },
 
@@ -121,9 +121,7 @@ export function MenuButtonColorPicker({
       >
         {children ?? (
           <>
-            {IconComponent && (
-              <IconComponent className={classes.menuButtonIcon} />
-            )}
+            {IconComponent && <IconComponent className={classes.icon} />}
 
             {/* We only show the color indicator if a color has been set. (It's
             effectively "transparent" otherwise, indicating no color has been
@@ -132,7 +130,7 @@ export function MenuButtonColorPicker({
             {!hideColorIndicator && colorValue && (
               <FormatColorBar
                 className={cx(
-                  classes.menuButtonIcon,
+                  classes.icon,
                   classes.colorIndicatorIcon,
                   menuButtonProps.disabled &&
                     classes.colorIndicatorIconDisabled,

--- a/src/controls/MenuButtonHighlightColor.tsx
+++ b/src/controls/MenuButtonHighlightColor.tsx
@@ -1,8 +1,7 @@
 /// <reference types="@tiptap/extension-highlight" />
 import { useRichTextEditorContext } from "../context";
 import { FormatInkHighlighterNoBar } from "../icons";
-import {
-  MenuButtonColorPicker,
+import MenuButtonColorPicker, {
   type MenuButtonColorPickerProps,
 } from "./MenuButtonColorPicker";
 

--- a/src/controls/MenuButtonTextColor.tsx
+++ b/src/controls/MenuButtonTextColor.tsx
@@ -3,8 +3,7 @@ import type { Editor } from "@tiptap/core";
 import { useRichTextEditorContext } from "../context";
 import { FormatColorTextNoBar } from "../icons";
 import { getAttributesForEachSelected } from "../utils";
-import {
-  MenuButtonColorPicker,
+import MenuButtonColorPicker, {
   type MenuButtonColorPickerProps,
 } from "./MenuButtonColorPicker";
 

--- a/src/controls/MenuButtonTooltip.classes.ts
+++ b/src/controls/MenuButtonTooltip.classes.ts
@@ -26,12 +26,10 @@ export interface MenuButtonTooltipClasses {
 
 export type MenuButtonTooltipClassKey = keyof MenuButtonTooltipClasses;
 
-const menuButtonTooltipClassKeys = [
-  "titleContainer",
-  "label",
-  "shortcutKey",
-  "contentWrapper",
-] as const satisfies ReadonlyArray<MenuButtonTooltipClassKey>;
-
 export const menuButtonTooltipClasses: MenuButtonTooltipClasses =
-  getUtilityClasses("MenuButtonTooltip", menuButtonTooltipClassKeys);
+  getUtilityClasses("MenuButtonTooltip", [
+    "titleContainer",
+    "label",
+    "shortcutKey",
+    "contentWrapper",
+  ] satisfies MenuButtonTooltipClassKey[]);

--- a/src/controls/MenuButtonTooltip.classes.ts
+++ b/src/controls/MenuButtonTooltip.classes.ts
@@ -1,0 +1,33 @@
+import { getUtilityClasses } from "../styles";
+
+export interface MenuButtonTooltipClasses {
+  /**
+   * Styles applied to the container element of the Tooltip's `title`, wrapping
+   * the label and shortcut keys.
+   */
+  titleContainer: string;
+  /** Styles applied to the label element. */
+  label: string;
+  /** Styles applied to each shortcut key element from `shortcutKeys`. */
+  shortcutKey: string;
+  /**
+   * Styles applied to the element that contains the children content.
+   *
+   * We add an intermediary element since Tooltip requires a non-disabled child
+   * element in order to render, and we want to allow tooltips to show up even
+   * when buttons are disabled.
+   */
+  contentWrapper: string;
+}
+
+export type MenuButtonTooltipClassKey = keyof MenuButtonTooltipClasses;
+
+const menuButtonTooltipClassKeys = [
+  "titleContainer",
+  "label",
+  "shortcutKey",
+  "contentWrapper",
+] as const satisfies ReadonlyArray<MenuButtonTooltipClassKey>;
+
+export const menuButtonTooltipClasses: MenuButtonTooltipClasses =
+  getUtilityClasses("MenuButtonTooltip", menuButtonTooltipClassKeys);

--- a/src/controls/MenuButtonTooltip.classes.ts
+++ b/src/controls/MenuButtonTooltip.classes.ts
@@ -16,6 +16,10 @@ export interface MenuButtonTooltipClasses {
    * We add an intermediary element since Tooltip requires a non-disabled child
    * element in order to render, and we want to allow tooltips to show up even
    * when buttons are disabled.
+   *
+   * This is effectively the "root" element that is rendered in the DOM at the
+   * location of the MenuButtonTooltip, so will also receive the `className`
+   * prop's class name. The tooltip itself will render in a portal.
    */
   contentWrapper: string;
 }

--- a/src/controls/MenuButtonTooltip.tsx
+++ b/src/controls/MenuButtonTooltip.tsx
@@ -39,12 +39,12 @@ export type MenuButtonTooltipProps = {
   /** Where the tooltip should be placed. By default "top" (above). */
   placement?: TooltipProps["placement"];
   /**
+   * @deprecated Use `classes.contentWrapper` instead.
+   *
    * Class applied to the element that contains the children content. We add an
    * intermediary element since Tooltip requires a non-disabled child element in
    * order to render, and we want to allow tooltips to show up even when buttons
    * are disabled.
-   *
-   * @deprecated Use `classes.contentWrapper` instead.
    */
   contentWrapperClassName?: string;
   /** The menu element for which we're showing a tooltip when hovering. */
@@ -154,14 +154,17 @@ export default function MenuButtonTooltip(inProps: MenuButtonTooltipProps) {
       }
       placement={placement}
       arrow
-      className={className}
       sx={sx}
       {...otherTooltipProps}
     >
       {/* Use a span around the children so we show a tooltip even if the
-      element inside is disabled */}
+      element inside is disabled.
+      https://mui.com/material-ui/react-tooltip/#disabled-elements */}
       <MenuButtonTooltipContentWrapper
         className={clsx([
+          // Applying className here is equivalent to if we applied it to the
+          // Tooltip above, since it just forwards the value to its root child.
+          className,
           menuButtonTooltipClasses.contentWrapper,
           classes.contentWrapper,
           contentWrapperClassName,

--- a/src/controls/MenuButtonTooltip.tsx
+++ b/src/controls/MenuButtonTooltip.tsx
@@ -8,7 +8,7 @@ import {
   type TooltipProps,
 } from "@mui/material";
 import { clsx } from "clsx";
-import { getComponentName } from "../styles";
+import { getUtilityComponentName } from "../styles";
 import { getModShortcutKey } from "../utils/platform";
 import {
   menuButtonTooltipClasses,
@@ -57,7 +57,7 @@ export type MenuButtonTooltipProps = {
   sx?: SxProps;
 } & Pick<TooltipProps, "open" | "onOpen" | "onClose">;
 
-const componentName = getComponentName("MenuButtonTooltip");
+const componentName = getUtilityComponentName("MenuButtonTooltip");
 
 const MenuButtonTooltipTitleContainer = styled("div", {
   name: componentName,

--- a/src/controls/MenuControlsContainer.classes.ts
+++ b/src/controls/MenuControlsContainer.classes.ts
@@ -7,9 +7,7 @@ export interface MenuControlsContainerClasses {
 
 export type MenuControlsContainerClassKey = keyof MenuControlsContainerClasses;
 
-const menuControlsContainerClassKeys = [
-  "root",
-] as const satisfies ReadonlyArray<MenuControlsContainerClassKey>;
-
 export const menuControlsContainerClasses: MenuControlsContainerClasses =
-  getUtilityClasses("MenuControlsContainer", menuControlsContainerClassKeys);
+  getUtilityClasses("MenuControlsContainer", [
+    "root",
+  ] satisfies MenuControlsContainerClassKey[]);

--- a/src/controls/MenuControlsContainer.classes.ts
+++ b/src/controls/MenuControlsContainer.classes.ts
@@ -1,0 +1,15 @@
+import { getUtilityClasses } from "../styles";
+
+export interface MenuControlsContainerClasses {
+  /** Styles applied to the root element. */
+  root: string;
+}
+
+export type MenuControlsContainerClassKey = keyof MenuControlsContainerClasses;
+
+const menuControlsContainerClassKeys = [
+  "root",
+] as const satisfies ReadonlyArray<MenuControlsContainerClassKey>;
+
+export const menuControlsContainerClasses: MenuControlsContainerClasses =
+  getUtilityClasses("MenuControlsContainer", menuControlsContainerClassKeys);

--- a/src/controls/MenuControlsContainer.tsx
+++ b/src/controls/MenuControlsContainer.tsx
@@ -1,7 +1,7 @@
 import { Box, styled, useThemeProps, type BoxProps } from "@mui/material";
 import { clsx } from "clsx";
 import type { Except } from "type-fest";
-import { getComponentName } from "../styles";
+import { getUtilityComponentName } from "../styles";
 import DebounceRender, {
   type DebounceRenderProps,
 } from "../utils/DebounceRender";
@@ -38,7 +38,7 @@ export type MenuControlsContainerProps = Except<
   DebounceProps?: Partial<Except<DebounceRenderProps, "children">>;
 };
 
-const componentName = getComponentName("MenuControlsContainer");
+const componentName = getUtilityComponentName("MenuControlsContainer");
 
 const MenuControlsContainerRoot = styled(Box, {
   name: componentName,

--- a/src/controls/MenuControlsContainer.tsx
+++ b/src/controls/MenuControlsContainer.tsx
@@ -1,14 +1,26 @@
-import { Box, type BoxProps } from "@mui/material";
-import { makeStyles } from "tss-react/mui";
+import { Box, styled, useThemeProps, type BoxProps } from "@mui/material";
+import { clsx } from "clsx";
 import type { Except } from "type-fest";
+import { getComponentName } from "../styles";
 import DebounceRender, {
   type DebounceRenderProps,
 } from "../utils/DebounceRender";
+import {
+  menuControlsContainerClasses,
+  type MenuControlsContainerClassKey,
+  type MenuControlsContainerClasses,
+} from "./MenuControlsContainer.classes";
 
-export type MenuControlsContainerProps = Except<BoxProps, "children"> & {
+export type MenuControlsContainerProps = Except<
+  BoxProps,
+  "children" | "className" | "classes"
+> & {
   /** The set of controls (buttons, etc) to include in the menu bar. */
   children?: React.ReactNode;
+  /** Class applied to the `root` element. */
   className?: string;
+  /** Override or extend existing styles. */
+  classes?: Partial<MenuControlsContainerClasses>;
   /**
    * If true, the rendering of the children content here will be debounced, as a
    * way to improve performance. If this component is rendered in the same
@@ -23,37 +35,52 @@ export type MenuControlsContainerProps = Except<BoxProps, "children"> & {
    * Override the props/options used with debounce rendering such as the wait
    * interval, if `debounced` is true.
    */
-  DebounceProps?: Except<DebounceRenderProps, "children">;
+  DebounceProps?: Partial<Except<DebounceRenderProps, "children">>;
 };
 
-const useStyles = makeStyles({
-  name: { MenuControlsContainer: MenuControlsContainer },
-})((theme) => {
-  return {
-    root: {
-      display: "flex",
-      rowGap: theme.spacing(0.3),
-      columnGap: theme.spacing(0.3),
-      alignItems: "center",
-      flexWrap: "wrap",
-    },
-  };
-});
+const componentName = getComponentName("MenuControlsContainer");
+
+const MenuControlsContainerRoot = styled(Box, {
+  name: componentName,
+  slot: "root" satisfies MenuControlsContainerClassKey,
+  overridesResolver: (props, styles) => styles.root,
+})(({ theme }) => ({
+  display: "flex",
+  rowGap: theme.spacing(0.3),
+  columnGap: theme.spacing(0.3),
+  alignItems: "center",
+  flexWrap: "wrap",
+}));
 
 /** Provides consistent spacing between different editor controls components. */
-export default function MenuControlsContainer({
-  children,
-  className,
-  debounced,
-  DebounceProps,
-  ...boxProps
-}: MenuControlsContainerProps) {
-  const { classes, cx } = useStyles();
+export default function MenuControlsContainer(
+  inProps: MenuControlsContainerProps,
+) {
+  const props = useThemeProps({ props: inProps, name: componentName });
+  const {
+    children,
+    className,
+    classes = {},
+    sx,
+    debounced,
+    DebounceProps,
+    ...boxProps
+  } = props;
+
   const content = (
-    <Box {...boxProps} className={cx(classes.root, className)}>
+    <MenuControlsContainerRoot
+      {...boxProps}
+      className={clsx([
+        menuControlsContainerClasses.root,
+        className,
+        classes.root,
+      ])}
+      sx={sx}
+    >
       {children}
-    </Box>
+    </MenuControlsContainerRoot>
   );
+
   return debounced ? (
     <DebounceRender {...DebounceProps}>{content}</DebounceRender>
   ) : (

--- a/src/controls/MenuSelect.classes.ts
+++ b/src/controls/MenuSelect.classes.ts
@@ -1,0 +1,20 @@
+import { getUtilityClasses } from "../styles";
+
+export interface MenuSelectClasses {
+  /** Styles applied to the root (Select) element. */
+  root: string;
+  /** Styles applied to the root tooltip wrapper element. */
+  tooltip: string;
+}
+
+export type MenuSelectClassKey = keyof MenuSelectClasses;
+
+const menuSelectClassKeys = [
+  "root",
+  "tooltip",
+] as const satisfies ReadonlyArray<MenuSelectClassKey>;
+
+export const menuSelectClasses: MenuSelectClasses = getUtilityClasses(
+  "MenuSelect",
+  menuSelectClassKeys,
+);

--- a/src/controls/MenuSelect.classes.ts
+++ b/src/controls/MenuSelect.classes.ts
@@ -9,12 +9,7 @@ export interface MenuSelectClasses {
 
 export type MenuSelectClassKey = keyof MenuSelectClasses;
 
-const menuSelectClassKeys = [
-  "root",
-  "tooltip",
-] as const satisfies ReadonlyArray<MenuSelectClassKey>;
-
 export const menuSelectClasses: MenuSelectClasses = getUtilityClasses(
   "MenuSelect",
-  menuSelectClassKeys,
+  ["root", "tooltip"] satisfies MenuSelectClassKey[],
 );

--- a/src/controls/MenuSelect.tsx
+++ b/src/controls/MenuSelect.tsx
@@ -10,7 +10,7 @@ import {
 } from "@mui/material";
 import { clsx } from "clsx";
 import { useState } from "react";
-import { getComponentName } from "../styles";
+import { getUtilityComponentName } from "../styles";
 import MenuButtonTooltip from "./MenuButtonTooltip";
 import {
   menuSelectClasses,
@@ -28,7 +28,7 @@ export interface MenuSelectProps<T>
   sx?: SxProps;
 }
 
-const componentName = getComponentName("MenuSelect");
+const componentName = getUtilityComponentName("MenuSelect");
 
 const MenuSelectRoot = styled(Select, {
   name: componentName,

--- a/src/controls/MenuSelect.tsx
+++ b/src/controls/MenuSelect.tsx
@@ -58,17 +58,15 @@ const MenuSelectRoot = styled(Select, {
   },
 
   [`& .${selectClasses.select}`]: {
-    // Increase specificity to override MUI's styles
-    "&&&": {
-      paddingLeft: theme.spacing(1),
-      paddingRight: theme.spacing(3),
-    },
-  },
-
-  [`& .${selectClasses.nativeInput}`]: {
     paddingTop: "3px",
     paddingBottom: "3px",
     fontSize: "0.9em",
+  },
+
+  // Increase specificity to override MUI's styles
+  [`&&& .${selectClasses.select}`]: {
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(3),
   },
 
   [`& .${selectClasses.icon}`]: {
@@ -81,6 +79,14 @@ const MenuSelectRoot = styled(Select, {
   // `styled` wrapper, per https://stackoverflow.com/a/72163115,
   // https://github.com/mui/material-ui/blob/7e90b18d0e21ece648e5074970900b05fea03989/docs/data/material/guides/typescript/typescript.md#complications-with-the-component-prop
 })) as unknown as typeof Select;
+
+const MenuSelectTooltip = styled(MenuButtonTooltip, {
+  name: componentName,
+  slot: "tooltip" satisfies MenuSelectClassKey,
+  overridesResolver: (props, styles) => styles.tooltip,
+})({
+  display: "inline-flex",
+});
 
 /** A Select that is styled to work well with other menu bar controls. */
 export default function MenuSelect<T>(inProps: MenuSelectProps<T>) {
@@ -142,20 +148,13 @@ export default function MenuSelect<T>(inProps: MenuSelectProps<T>) {
   );
 
   return tooltipTitle ? (
-    <MenuButtonTooltip
+    <MenuSelectTooltip
       label={tooltipTitle}
       open={tooltipOpen}
-      classes={{
-        contentWrapper: clsx([menuSelectClasses.tooltip, classes.tooltip]),
-      }}
-      sx={{
-        [`& .${menuSelectClasses.tooltip}`]: {
-          display: "inline-flex",
-        },
-      }}
+      className={clsx([menuSelectClasses.tooltip, classes.tooltip])}
     >
       {select}
-    </MenuButtonTooltip>
+    </MenuSelectTooltip>
   ) : (
     select
   );

--- a/src/controls/MenuSelect.tsx
+++ b/src/controls/MenuSelect.tsx
@@ -2,84 +2,100 @@ import {
   Select,
   outlinedInputClasses,
   selectClasses,
+  styled,
   svgIconClasses,
+  useThemeProps,
   type SelectProps,
+  type SxProps,
 } from "@mui/material";
+import { clsx } from "clsx";
 import { useState } from "react";
-import { makeStyles } from "tss-react/mui";
+import { getComponentName } from "../styles";
 import MenuButtonTooltip from "./MenuButtonTooltip";
+import {
+  menuSelectClasses,
+  type MenuSelectClassKey,
+  type MenuSelectClasses,
+} from "./MenuSelect.classes";
 
-export type MenuSelectProps<T> = SelectProps<T> & {
+export interface MenuSelectProps<T>
+  extends Omit<SelectProps<T>, "margin" | "variant" | "size" | "classes"> {
   /** An optional tooltip to show when hovering over this Select. */
   tooltipTitle?: string;
-};
+  /** Override or extend existing styles. */
+  classes?: Partial<MenuSelectClasses>;
+  /** Provide custom styles. */
+  sx?: SxProps;
+}
 
-const useStyles = makeStyles({ name: { MenuSelect } })((theme) => {
-  return {
-    rootTooltipWrapper: {
-      display: "inline-flex",
+const componentName = getComponentName("MenuSelect");
+
+const MenuSelectRoot = styled(Select, {
+  name: componentName,
+  slot: "root" satisfies MenuSelectClassKey,
+  overridesResolver: (props, styles) => styles.root,
+})(({ theme }) => ({
+  // Don't show the default outline when not hovering or focused, for better
+  // style consistency with the MenuButtons
+  [`&:not(:hover):not(.${outlinedInputClasses.focused}) .${outlinedInputClasses.notchedOutline}`]:
+    {
+      borderWidth: 0,
     },
 
-    selectRoot: {
-      // Don't show the default outline when not hovering or focused, for better
-      // style consistency with the MenuButtons
-      [`&:not(:hover):not(.${outlinedInputClasses.focused}) .${outlinedInputClasses.notchedOutline}`]:
-        {
-          borderWidth: 0,
-        },
+  [`& .${svgIconClasses.root}`]: {
+    // Ensure that if an icon is used as the `renderValue` result, it uses
+    // the same color as the default ToggleButton icon and the Select
+    // dropdown arrow icon
+    // https://github.com/mui/material-ui/blob/2cb9664b16d5a862a3796add7c8e3b088b47acb5/packages/mui-material/src/ToggleButton/ToggleButton.js#L60,
+    // https://github.com/mui/material-ui/blob/0b7beb93c9015da6e35c2a31510f679126cf0de1/packages/mui-material/src/NativeSelect/NativeSelectInput.js#L96
+    color: theme.palette.action.active,
+  },
 
-      [`& .${svgIconClasses.root}`]: {
-        // Ensure that if an icon is used as the `renderValue` result, it uses
-        // the same color as the default ToggleButton icon and the Select
-        // dropdown arrow icon
-        // https://github.com/mui/material-ui/blob/2cb9664b16d5a862a3796add7c8e3b088b47acb5/packages/mui-material/src/ToggleButton/ToggleButton.js#L60,
-        // https://github.com/mui/material-ui/blob/0b7beb93c9015da6e35c2a31510f679126cf0de1/packages/mui-material/src/NativeSelect/NativeSelectInput.js#L96
-        color: theme.palette.action.active,
-      },
+  [`&.${selectClasses.disabled} .${svgIconClasses.root}`]: {
+    // Matching
+    // https://github.com/mui/material-ui/blob/2cb9664b16d5a862a3796add7c8e3b088b47acb5/packages/mui-material/src/ToggleButton/ToggleButton.js#L65
+    color: theme.palette.action.disabled,
+  },
 
-      [`&.${selectClasses.disabled} .${svgIconClasses.root}`]: {
-        // Matching
-        // https://github.com/mui/material-ui/blob/2cb9664b16d5a862a3796add7c8e3b088b47acb5/packages/mui-material/src/ToggleButton/ToggleButton.js#L65
-        color: theme.palette.action.disabled,
-      },
+  [`& .${selectClasses.select}`]: {
+    // Increase specificity to override MUI's styles
+    "&&&": {
+      paddingLeft: theme.spacing(1),
+      paddingRight: theme.spacing(3),
     },
+  },
 
-    select: {
-      // Increase specificity to override MUI's styles
-      "&&&": {
-        paddingLeft: theme.spacing(1),
-        paddingRight: theme.spacing(3),
-      },
-    },
+  [`& .${selectClasses.nativeInput}`]: {
+    paddingTop: "3px",
+    paddingBottom: "3px",
+    fontSize: "0.9em",
+  },
 
-    selectDropdownIcon: {
-      // Move the caret icon closer to the right than default so the button is
-      // more compact
-      right: 1,
-    },
+  [`& .${selectClasses.icon}`]: {
+    // Move the caret icon closer to the right than default so the button is
+    // more compact
+    right: 1,
+  },
 
-    input: {
-      paddingTop: "3px",
-      paddingBottom: "3px",
-      fontSize: "0.9em",
-    },
-  };
-});
+  // The type casting below is a hacky workaround to support generics with the
+  // `styled` wrapper, per https://stackoverflow.com/a/72163115,
+  // https://github.com/mui/material-ui/blob/7e90b18d0e21ece648e5074970900b05fea03989/docs/data/material/guides/typescript/typescript.md#complications-with-the-component-prop
+})) as unknown as typeof Select;
 
 /** A Select that is styled to work well with other menu bar controls. */
-export default function MenuSelect<T>({
-  tooltipTitle,
-  ...selectProps
-}: MenuSelectProps<T>) {
-  const { classes, cx } = useStyles();
+export default function MenuSelect<T>(inProps: MenuSelectProps<T>) {
+  const props = useThemeProps({ props: inProps, name: componentName });
+  const { tooltipTitle, classes = {}, sx, ...selectProps } = props;
+
   // We use a controlled tooltip here because otherwise it seems the tooltip can
   // get stuck open after selecting something (as it can re-trigger the
   // Tooltip's onOpen upon clicking a MenuItem). We instead trigger it to
   // open/close based on interaction specifically with the Select (not the usual
   // Tooltip onOpen/onClose)
   const [tooltipOpen, setTooltipOpen] = useState(false);
+
   const select = (
-    <Select<T>
+    <MenuSelectRoot<T>
       margin="none"
       variant="outlined"
       size="small"
@@ -103,10 +119,6 @@ export default function MenuSelect<T>({
         setTooltipOpen(false);
         selectProps.onOpen?.(...args);
       }}
-      inputProps={{
-        ...selectProps.inputProps,
-        className: cx(classes.input, selectProps.inputProps?.className),
-      }}
       // Always show the dropdown options directly below the select input,
       // aligned to left-most edge
       MenuProps={{
@@ -120,19 +132,27 @@ export default function MenuSelect<T>({
         },
         ...selectProps.MenuProps,
       }}
-      className={cx(classes.selectRoot, selectProps.className)}
-      classes={{
-        ...selectProps.classes,
-        select: cx(classes.select, selectProps.classes?.select),
-        icon: cx(classes.selectDropdownIcon, selectProps.classes?.icon),
-      }}
+      className={clsx([
+        menuSelectClasses.root,
+        classes.root,
+        selectProps.className,
+      ])}
+      sx={sx}
     />
   );
+
   return tooltipTitle ? (
     <MenuButtonTooltip
       label={tooltipTitle}
-      contentWrapperClassName={classes.rootTooltipWrapper}
       open={tooltipOpen}
+      classes={{
+        contentWrapper: clsx([menuSelectClasses.tooltip, classes.tooltip]),
+      }}
+      sx={{
+        [`& .${menuSelectClasses.tooltip}`]: {
+          display: "inline-flex",
+        },
+      }}
     >
       {select}
     </MenuButtonTooltip>

--- a/src/controls/MenuSelectFontFamily.classes.ts
+++ b/src/controls/MenuSelectFontFamily.classes.ts
@@ -1,0 +1,18 @@
+import { getUtilityClasses } from "../styles";
+
+export interface MenuSelectFontFamilyClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the Select input element. */
+  selectInput: string;
+}
+
+export type MenuSelectFontFamilyClassKey = keyof MenuSelectFontFamilyClasses;
+
+const menuSelectFontFamilyClassKeys = [
+  "root",
+  "selectInput",
+] as const satisfies ReadonlyArray<MenuSelectFontFamilyClassKey>;
+
+export const menuSelectFontFamilyClasses: MenuSelectFontFamilyClasses =
+  getUtilityClasses("MenuSelectFontFamily", menuSelectFontFamilyClassKeys);

--- a/src/controls/MenuSelectFontFamily.classes.ts
+++ b/src/controls/MenuSelectFontFamily.classes.ts
@@ -9,10 +9,8 @@ export interface MenuSelectFontFamilyClasses {
 
 export type MenuSelectFontFamilyClassKey = keyof MenuSelectFontFamilyClasses;
 
-const menuSelectFontFamilyClassKeys = [
-  "root",
-  "selectInput",
-] as const satisfies ReadonlyArray<MenuSelectFontFamilyClassKey>;
-
 export const menuSelectFontFamilyClasses: MenuSelectFontFamilyClasses =
-  getUtilityClasses("MenuSelectFontFamily", menuSelectFontFamilyClassKeys);
+  getUtilityClasses("MenuSelectFontFamily", [
+    "root",
+    "selectInput",
+  ] satisfies MenuSelectFontFamilyClassKey[]);

--- a/src/controls/MenuSelectFontFamily.tsx
+++ b/src/controls/MenuSelectFontFamily.tsx
@@ -5,7 +5,7 @@ import { clsx } from "clsx";
 import type { ReactNode } from "react";
 import type { Except } from "type-fest";
 import { useRichTextEditorContext } from "../context";
-import { getComponentName } from "../styles";
+import { getUtilityComponentName } from "../styles";
 import { getAttributesForEachSelected } from "../utils/getAttributesForEachSelected";
 import MenuSelect, { type MenuSelectProps } from "./MenuSelect";
 import {
@@ -70,7 +70,7 @@ export type MenuSelectFontFamilyProps = Except<
   sx?: SxProps;
 };
 
-const componentName = getComponentName("MenuSelectFontFamily");
+const componentName = getUtilityComponentName("MenuSelectFontFamily");
 
 const MenuSelectFontFamilyRoot = styled(MenuSelect<string>, {
   name: componentName,

--- a/src/controls/MenuSelectFontSize.classes.ts
+++ b/src/controls/MenuSelectFontSize.classes.ts
@@ -1,0 +1,21 @@
+import { getUtilityClasses } from "../styles";
+
+export interface MenuSelectFontSizeClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the Select input element. */
+  selectInput: string;
+  /** Styles applied to the menu button icon. */
+  menuButtonIcon: string;
+}
+
+export type MenuSelectFontSizeClassKey = keyof MenuSelectFontSizeClasses;
+
+const menuSelectFontSizeClassKeys = [
+  "root",
+  "selectInput",
+  "menuButtonIcon",
+] as const satisfies ReadonlyArray<MenuSelectFontSizeClassKey>;
+
+export const menuSelectFontSizeClasses: MenuSelectFontSizeClasses =
+  getUtilityClasses("MenuSelectFontSize", menuSelectFontSizeClassKeys);

--- a/src/controls/MenuSelectFontSize.classes.ts
+++ b/src/controls/MenuSelectFontSize.classes.ts
@@ -11,11 +11,9 @@ export interface MenuSelectFontSizeClasses {
 
 export type MenuSelectFontSizeClassKey = keyof MenuSelectFontSizeClasses;
 
-const menuSelectFontSizeClassKeys = [
-  "root",
-  "selectInput",
-  "icon",
-] as const satisfies ReadonlyArray<MenuSelectFontSizeClassKey>;
-
 export const menuSelectFontSizeClasses: MenuSelectFontSizeClasses =
-  getUtilityClasses("MenuSelectFontSize", menuSelectFontSizeClassKeys);
+  getUtilityClasses("MenuSelectFontSize", [
+    "root",
+    "selectInput",
+    "icon",
+  ] satisfies MenuSelectFontSizeClassKey[]);

--- a/src/controls/MenuSelectFontSize.classes.ts
+++ b/src/controls/MenuSelectFontSize.classes.ts
@@ -5,8 +5,8 @@ export interface MenuSelectFontSizeClasses {
   root: string;
   /** Styles applied to the Select input element. */
   selectInput: string;
-  /** Styles applied to the menu button icon. */
-  menuButtonIcon: string;
+  /** Styles applied to the icon shown when no font size is set. */
+  icon: string;
 }
 
 export type MenuSelectFontSizeClassKey = keyof MenuSelectFontSizeClasses;
@@ -14,7 +14,7 @@ export type MenuSelectFontSizeClassKey = keyof MenuSelectFontSizeClasses;
 const menuSelectFontSizeClassKeys = [
   "root",
   "selectInput",
-  "menuButtonIcon",
+  "icon",
 ] as const satisfies ReadonlyArray<MenuSelectFontSizeClassKey>;
 
 export const menuSelectFontSizeClasses: MenuSelectFontSizeClasses =

--- a/src/controls/MenuSelectFontSize.tsx
+++ b/src/controls/MenuSelectFontSize.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from "react";
 import type { Except } from "type-fest";
 import { useRichTextEditorContext } from "../context";
 import type { FontSizeAttrs } from "../extensions/FontSize";
-import { getComponentName } from "../styles";
+import { getUtilityComponentName } from "../styles";
 import { getAttributesForEachSelected } from "../utils/getAttributesForEachSelected";
 import { MENU_BUTTON_FONT_SIZE_DEFAULT } from "./MenuButton";
 import MenuSelect, { type MenuSelectProps } from "./MenuSelect";
@@ -80,7 +80,7 @@ export type MenuSelectFontSizeProps = Except<
   sx?: SxProps;
 };
 
-const componentName = getComponentName("MenuSelectFontSize");
+const componentName = getUtilityComponentName("MenuSelectFontSize");
 
 const MenuSelectFontSizeRoot = styled(MenuSelect<string>, {
   name: componentName,

--- a/src/controls/MenuSelectFontSize.tsx
+++ b/src/controls/MenuSelectFontSize.tsx
@@ -144,26 +144,23 @@ const MULTIPLE_SIZES_SELECTED_VALUE = "MULTIPLE";
 export default function MenuSelectFontSize(inProps: MenuSelectFontSizeProps) {
   const props = useThemeProps({ props: inProps, name: componentName });
   const {
-    options: propOptions = DEFAULT_FONT_SIZE_SELECT_OPTIONS,
+    // Handle deprecated legacy names for some props
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     sizeOptions,
-    hideUnsetOption = false,
-    unsetOptionLabel: propUnsetOptionLabel = "Default",
+    options = sizeOptions ?? DEFAULT_FONT_SIZE_SELECT_OPTIONS,
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     unsetOptionContent,
-    emptyLabel: propEmptyLabel,
+    unsetOptionLabel = unsetOptionContent ?? "Default",
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     emptyValue,
+    emptyLabel = emptyValue,
+    hideUnsetOption = false,
     classes = {},
     sx,
     ...menuSelectProps
   } = props;
   const editor = useRichTextEditorContext();
 
-  // Handle deprecated legacy names for some props:
-  const emptyLabel = emptyValue ?? propEmptyLabel;
-  const unsetOptionLabel = unsetOptionContent ?? propUnsetOptionLabel;
-  const options = sizeOptions ?? propOptions;
   const optionObjects: FontSizeSelectOptionObject[] = (options ?? []).map(
     (option) => (typeof option === "string" ? { value: option } : option),
   );

--- a/src/controls/MenuSelectFontSize.tsx
+++ b/src/controls/MenuSelectFontSize.tsx
@@ -99,7 +99,7 @@ const MenuSelectFontSizeRoot = styled(MenuSelect<string>, {
     alignItems: "center",
   },
 
-  [`& .${menuSelectFontSizeClasses.menuButtonIcon}`]: {
+  [`& .${menuSelectFontSizeClasses.icon}`]: {
     fontSize: MENU_BUTTON_FONT_SIZE_DEFAULT,
   },
 }));
@@ -235,10 +235,7 @@ export default function MenuSelectFontSize(inProps: MenuSelectFontSizeProps) {
           return (
             emptyLabel ?? (
               <FormatSize
-                className={clsx([
-                  menuSelectFontSizeClasses.menuButtonIcon,
-                  classes.menuButtonIcon,
-                ])}
+                className={clsx([menuSelectFontSizeClasses.icon, classes.icon])}
               />
             )
           );

--- a/src/controls/MenuSelectFontSize.tsx
+++ b/src/controls/MenuSelectFontSize.tsx
@@ -98,10 +98,14 @@ const MenuSelectFontSizeRoot = styled(MenuSelect<string>, {
     display: "flex",
     alignItems: "center",
   },
+}));
 
-  [`& .${menuSelectFontSizeClasses.icon}`]: {
-    fontSize: MENU_BUTTON_FONT_SIZE_DEFAULT,
-  },
+const MenuSelectFontSizeIcon = styled(FormatSize, {
+  name: componentName,
+  slot: "icon" satisfies MenuSelectFontSizeClassKey,
+  overridesResolver: (props, styles) => styles.icon,
+})(() => ({
+  fontSize: MENU_BUTTON_FONT_SIZE_DEFAULT,
 }));
 
 const DEFAULT_FONT_SIZE_SELECT_OPTIONS: MenuSelectFontSizeProps["options"] = [
@@ -234,7 +238,7 @@ export default function MenuSelectFontSize(inProps: MenuSelectFontSizeProps) {
           // placeholder value here
           return (
             emptyLabel ?? (
-              <FormatSize
+              <MenuSelectFontSizeIcon
                 className={clsx([menuSelectFontSizeClasses.icon, classes.icon])}
               />
             )

--- a/src/controls/MenuSelectHeading.classes.ts
+++ b/src/controls/MenuSelectHeading.classes.ts
@@ -1,0 +1,48 @@
+import { getUtilityClasses } from "../styles";
+
+export interface MenuSelectHeadingClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the Select input element. */
+  selectInput: string;
+  /** Styles applied to the content wrapper inside each menu item. */
+  menuOption: string;
+  /** Styles applied to the paragraph option (in addition to `menuOption`). */
+  paragraphOption: string;
+  /**
+   * Styles applied to each heading option (in addition to `menuOption`), not
+   * applied to the paragraph option.
+   */
+  headingOption: string;
+  /** Styles applied to heading 1 options. */
+  headingOption1: string;
+  /** Styles applied to heading 2 options. */
+  headingOption2: string;
+  /** Styles applied to heading 3 options. */
+  headingOption3: string;
+  /** Styles applied to heading 4 options. */
+  headingOption4: string;
+  /** Styles applied to heading 5 options. */
+  headingOption5: string;
+  /** Styles applied to heading 6 options. */
+  headingOption6: string;
+}
+
+export type MenuSelectHeadingClassKey = keyof MenuSelectHeadingClasses;
+
+const menuSelectHeadingClassKeys = [
+  "root",
+  "selectInput",
+  "menuOption",
+  "paragraphOption",
+  "headingOption",
+  "headingOption1",
+  "headingOption2",
+  "headingOption3",
+  "headingOption4",
+  "headingOption5",
+  "headingOption6",
+] as const satisfies ReadonlyArray<MenuSelectHeadingClassKey>;
+
+export const menuSelectHeadingClasses: MenuSelectHeadingClasses =
+  getUtilityClasses("MenuSelectHeading", menuSelectHeadingClassKeys);

--- a/src/controls/MenuSelectHeading.classes.ts
+++ b/src/controls/MenuSelectHeading.classes.ts
@@ -30,19 +30,17 @@ export interface MenuSelectHeadingClasses {
 
 export type MenuSelectHeadingClassKey = keyof MenuSelectHeadingClasses;
 
-const menuSelectHeadingClassKeys = [
-  "root",
-  "selectInput",
-  "menuOption",
-  "paragraphOption",
-  "headingOption",
-  "headingOption1",
-  "headingOption2",
-  "headingOption3",
-  "headingOption4",
-  "headingOption5",
-  "headingOption6",
-] as const satisfies ReadonlyArray<MenuSelectHeadingClassKey>;
-
 export const menuSelectHeadingClasses: MenuSelectHeadingClasses =
-  getUtilityClasses("MenuSelectHeading", menuSelectHeadingClassKeys);
+  getUtilityClasses("MenuSelectHeading", [
+    "root",
+    "selectInput",
+    "menuOption",
+    "paragraphOption",
+    "headingOption",
+    "headingOption1",
+    "headingOption2",
+    "headingOption3",
+    "headingOption4",
+    "headingOption5",
+    "headingOption6",
+  ] satisfies MenuSelectHeadingClassKey[]);

--- a/src/controls/MenuSelectHeading.tsx
+++ b/src/controls/MenuSelectHeading.tsx
@@ -11,7 +11,7 @@ import { clsx } from "clsx";
 import { useCallback, useMemo, type ReactNode } from "react";
 import type { Except } from "type-fest";
 import { useRichTextEditorContext } from "../context";
-import { getComponentName, getEditorStyles } from "../styles";
+import { getEditorStyles, getUtilityComponentName } from "../styles";
 import { getAttributesForEachSelected } from "../utils/getAttributesForEachSelected";
 import MenuButtonTooltip from "./MenuButtonTooltip";
 import MenuSelect, { type MenuSelectProps } from "./MenuSelect";
@@ -64,7 +64,7 @@ export type MenuSelectHeadingProps = Except<
   sx?: SxProps;
 };
 
-const componentName = getComponentName("MenuSelectHeading");
+const componentName = getUtilityComponentName("MenuSelectHeading");
 
 const MenuSelectHeadingRoot = styled(MenuSelect<HeadingOptionValue | "">, {
   name: componentName,

--- a/src/controls/MenuSelectHeading.tsx
+++ b/src/controls/MenuSelectHeading.tsx
@@ -70,55 +70,84 @@ const MenuSelectHeadingRoot = styled(MenuSelect<HeadingOptionValue | "">, {
   name: componentName,
   slot: "root" satisfies MenuSelectHeadingClassKey,
   overridesResolver: (props, styles) => styles.root,
-})((theme) => {
-  const editorStyles = getEditorStyles(theme.theme);
-  return {
-    [`& .${menuSelectHeadingClasses.selectInput}`]: {
-      // We use a fixed width so that the Select element won't change sizes as
-      // the selected option changes (which would shift other elements in the
-      // menu bar)
-      width: 77,
-    },
-
-    [`& .${menuSelectHeadingClasses.menuOption}`]: {
-      // These styles ensure the item fills its MenuItem container, and the
-      // tooltip appears in the same place when hovering over the item generally
-      // (not just the text of the item)
-      display: "block",
-      width: "100%",
-    },
-
-    [`& .${menuSelectHeadingClasses.headingOption}`]: {
-      marginBlockStart: 0,
-      marginBlockEnd: 0,
-      fontWeight: "bold",
-    },
-
-    [`& .${menuSelectHeadingClasses.headingOption1}`]: {
-      fontSize: editorStyles["& h1"].fontSize,
-    },
-
-    [`& .${menuSelectHeadingClasses.headingOption2}`]: {
-      fontSize: editorStyles["& h2"].fontSize,
-    },
-
-    [`& .${menuSelectHeadingClasses.headingOption3}`]: {
-      fontSize: editorStyles["& h3"].fontSize,
-    },
-
-    [`& .${menuSelectHeadingClasses.headingOption4}`]: {
-      fontSize: editorStyles["& h4"].fontSize,
-    },
-
-    [`& .${menuSelectHeadingClasses.headingOption5}`]: {
-      fontSize: editorStyles["& h5"].fontSize,
-    },
-
-    [`& .${menuSelectHeadingClasses.headingOption6}`]: {
-      fontSize: editorStyles["& h6"].fontSize,
-    },
-  };
+})({
+  [`& .${menuSelectHeadingClasses.selectInput}`]: {
+    // We use a fixed width so that the Select element won't change sizes as
+    // the selected option changes (which would shift other elements in the
+    // menu bar)
+    width: 77,
+  },
 });
+
+const MenuSelectMenuOption = styled(MenuButtonTooltip, {
+  name: componentName,
+  slot: "menuOption" satisfies MenuSelectHeadingClassKey,
+  overridesResolver: (props, styles) => styles.menuOption,
+})({
+  // These styles ensure the item fills its MenuItem container, and the
+  // tooltip appears in the same place when hovering over the item generally
+  // (not just the text of the item)
+  display: "block",
+  width: "100%",
+});
+
+const MenuSelectHeadingOption = styled(MenuSelectMenuOption, {
+  name: componentName,
+  slot: "headingOption" satisfies MenuSelectHeadingClassKey,
+  overridesResolver: (props, styles) => styles.option,
+})({
+  marginBlockStart: 0,
+  marginBlockEnd: 0,
+  fontWeight: "bold",
+});
+
+const MenuSelectHeadingOption1 = styled(MenuSelectHeadingOption, {
+  name: componentName,
+  slot: "headingOption1" satisfies MenuSelectHeadingClassKey,
+  overridesResolver: (props, styles) => styles.headingOption1,
+})(({ theme }) => ({
+  fontSize: getEditorStyles(theme)["& h1"].fontSize,
+}));
+
+const MenuSelectHeadingOption2 = styled(MenuSelectHeadingOption, {
+  name: componentName,
+  slot: "headingOption2" satisfies MenuSelectHeadingClassKey,
+  overridesResolver: (props, styles) => styles.headingOption2,
+})(({ theme }) => ({
+  fontSize: getEditorStyles(theme)["& h2"].fontSize,
+}));
+
+const MenuSelectHeadingOption3 = styled(MenuSelectHeadingOption, {
+  name: componentName,
+  slot: "headingOption3" satisfies MenuSelectHeadingClassKey,
+  overridesResolver: (props, styles) => styles.headingOption3,
+})(({ theme }) => ({
+  fontSize: getEditorStyles(theme)["& h3"].fontSize,
+}));
+
+const MenuSelectHeadingOption4 = styled(MenuSelectHeadingOption, {
+  name: componentName,
+  slot: "headingOption4" satisfies MenuSelectHeadingClassKey,
+  overridesResolver: (props, styles) => styles.headingOption4,
+})(({ theme }) => ({
+  fontSize: getEditorStyles(theme)["& h4"].fontSize,
+}));
+
+const MenuSelectHeadingOption5 = styled(MenuSelectHeadingOption, {
+  name: componentName,
+  slot: "headingOption5" satisfies MenuSelectHeadingClassKey,
+  overridesResolver: (props, styles) => styles.headingOption5,
+})(({ theme }) => ({
+  fontSize: getEditorStyles(theme)["& h5"].fontSize,
+}));
+
+const MenuSelectHeadingOption6 = styled(MenuSelectHeadingOption, {
+  name: componentName,
+  slot: "headingOption6" satisfies MenuSelectHeadingClassKey,
+  overridesResolver: (props, styles) => styles.headingOption6,
+})(({ theme }) => ({
+  fontSize: getEditorStyles(theme)["& h6"].fontSize,
+}));
 
 const HEADING_OPTION_VALUES = {
   Paragraph: "Paragraph",
@@ -302,7 +331,7 @@ export default function MenuSelectHeading(inProps: MenuSelectHeadingProps) {
         value={HEADING_OPTION_VALUES.Paragraph}
         disabled={!isCurrentlyParagraphOrHeading && !canSetParagraph}
       >
-        <MenuButtonTooltip
+        <MenuSelectMenuOption
           label=""
           shortcutKeys={hideShortcuts ? undefined : ["mod", "alt", "0"]}
           placement="right"
@@ -316,7 +345,7 @@ export default function MenuSelectHeading(inProps: MenuSelectHeadingProps) {
           }}
         >
           {labels?.paragraph ?? HEADING_OPTION_VALUES.Paragraph}
-        </MenuButtonTooltip>
+        </MenuSelectMenuOption>
       </MenuItem>
 
       {enabledHeadingLevels.has(1) && (
@@ -324,23 +353,21 @@ export default function MenuSelectHeading(inProps: MenuSelectHeadingProps) {
           value={HEADING_OPTION_VALUES.Heading1}
           disabled={!canSetHeading}
         >
-          <MenuButtonTooltip
+          <MenuSelectHeadingOption1
             label=""
             shortcutKeys={hideShortcuts ? undefined : ["mod", "alt", "1"]}
             placement="right"
-            classes={{
-              contentWrapper: clsx([
-                menuSelectHeadingClasses.menuOption,
-                classes.menuOption,
-                menuSelectHeadingClasses.headingOption,
-                classes.headingOption,
-                menuSelectHeadingClasses.headingOption1,
-                classes.headingOption1,
-              ]),
-            }}
+            className={clsx([
+              menuSelectHeadingClasses.menuOption,
+              classes.menuOption,
+              menuSelectHeadingClasses.headingOption,
+              classes.headingOption,
+              menuSelectHeadingClasses.headingOption1,
+              classes.headingOption1,
+            ])}
           >
             {labels?.heading1 ?? HEADING_OPTION_VALUES.Heading1}
-          </MenuButtonTooltip>
+          </MenuSelectHeadingOption1>
         </MenuItem>
       )}
 
@@ -349,23 +376,21 @@ export default function MenuSelectHeading(inProps: MenuSelectHeadingProps) {
           value={HEADING_OPTION_VALUES.Heading2}
           disabled={!canSetHeading}
         >
-          <MenuButtonTooltip
+          <MenuSelectHeadingOption2
             label=""
             shortcutKeys={hideShortcuts ? undefined : ["mod", "alt", "2"]}
             placement="right"
-            classes={{
-              contentWrapper: clsx([
-                menuSelectHeadingClasses.menuOption,
-                classes.menuOption,
-                menuSelectHeadingClasses.headingOption,
-                classes.headingOption,
-                menuSelectHeadingClasses.headingOption2,
-                classes.headingOption2,
-              ]),
-            }}
+            className={clsx([
+              menuSelectHeadingClasses.menuOption,
+              classes.menuOption,
+              menuSelectHeadingClasses.headingOption,
+              classes.headingOption,
+              menuSelectHeadingClasses.headingOption2,
+              classes.headingOption2,
+            ])}
           >
             {labels?.heading2 ?? HEADING_OPTION_VALUES.Heading2}
-          </MenuButtonTooltip>
+          </MenuSelectHeadingOption2>
         </MenuItem>
       )}
 
@@ -374,23 +399,21 @@ export default function MenuSelectHeading(inProps: MenuSelectHeadingProps) {
           value={HEADING_OPTION_VALUES.Heading3}
           disabled={!canSetHeading}
         >
-          <MenuButtonTooltip
+          <MenuSelectHeadingOption3
             label=""
             shortcutKeys={hideShortcuts ? undefined : ["mod", "alt", "3"]}
             placement="right"
-            classes={{
-              contentWrapper: clsx([
-                menuSelectHeadingClasses.menuOption,
-                classes.menuOption,
-                menuSelectHeadingClasses.headingOption,
-                classes.headingOption,
-                menuSelectHeadingClasses.headingOption3,
-                classes.headingOption3,
-              ]),
-            }}
+            className={clsx([
+              menuSelectHeadingClasses.menuOption,
+              classes.menuOption,
+              menuSelectHeadingClasses.headingOption,
+              classes.headingOption,
+              menuSelectHeadingClasses.headingOption3,
+              classes.headingOption3,
+            ])}
           >
             {labels?.heading3 ?? HEADING_OPTION_VALUES.Heading3}
-          </MenuButtonTooltip>
+          </MenuSelectHeadingOption3>
         </MenuItem>
       )}
 
@@ -399,23 +422,21 @@ export default function MenuSelectHeading(inProps: MenuSelectHeadingProps) {
           value={HEADING_OPTION_VALUES.Heading4}
           disabled={!canSetHeading}
         >
-          <MenuButtonTooltip
+          <MenuSelectHeadingOption4
             label=""
             shortcutKeys={hideShortcuts ? undefined : ["mod", "alt", "4"]}
             placement="right"
-            classes={{
-              contentWrapper: clsx([
-                menuSelectHeadingClasses.menuOption,
-                classes.menuOption,
-                menuSelectHeadingClasses.headingOption,
-                classes.headingOption,
-                menuSelectHeadingClasses.headingOption4,
-                classes.headingOption4,
-              ]),
-            }}
+            className={clsx([
+              menuSelectHeadingClasses.menuOption,
+              classes.menuOption,
+              menuSelectHeadingClasses.headingOption,
+              classes.headingOption,
+              menuSelectHeadingClasses.headingOption4,
+              classes.headingOption4,
+            ])}
           >
             {labels?.heading4 ?? HEADING_OPTION_VALUES.Heading4}
-          </MenuButtonTooltip>
+          </MenuSelectHeadingOption4>
         </MenuItem>
       )}
 
@@ -424,23 +445,21 @@ export default function MenuSelectHeading(inProps: MenuSelectHeadingProps) {
           value={HEADING_OPTION_VALUES.Heading5}
           disabled={!canSetHeading}
         >
-          <MenuButtonTooltip
+          <MenuSelectHeadingOption5
             label=""
             shortcutKeys={hideShortcuts ? undefined : ["mod", "alt", "5"]}
             placement="right"
-            classes={{
-              contentWrapper: clsx([
-                menuSelectHeadingClasses.menuOption,
-                classes.menuOption,
-                menuSelectHeadingClasses.headingOption,
-                classes.headingOption,
-                menuSelectHeadingClasses.headingOption5,
-                classes.headingOption5,
-              ]),
-            }}
+            className={clsx([
+              menuSelectHeadingClasses.menuOption,
+              classes.menuOption,
+              menuSelectHeadingClasses.headingOption,
+              classes.headingOption,
+              menuSelectHeadingClasses.headingOption5,
+              classes.headingOption5,
+            ])}
           >
             {labels?.heading5 ?? HEADING_OPTION_VALUES.Heading5}
-          </MenuButtonTooltip>
+          </MenuSelectHeadingOption5>
         </MenuItem>
       )}
 
@@ -449,23 +468,21 @@ export default function MenuSelectHeading(inProps: MenuSelectHeadingProps) {
           value={HEADING_OPTION_VALUES.Heading6}
           disabled={!canSetHeading}
         >
-          <MenuButtonTooltip
+          <MenuSelectHeadingOption6
             label=""
             shortcutKeys={hideShortcuts ? undefined : ["mod", "alt", "6"]}
             placement="right"
-            classes={{
-              contentWrapper: clsx([
-                menuSelectHeadingClasses.menuOption,
-                classes.menuOption,
-                menuSelectHeadingClasses.headingOption,
-                classes.headingOption,
-                menuSelectHeadingClasses.headingOption6,
-                classes.headingOption6,
-              ]),
-            }}
+            className={clsx([
+              menuSelectHeadingClasses.menuOption,
+              classes.menuOption,
+              menuSelectHeadingClasses.headingOption,
+              classes.headingOption,
+              menuSelectHeadingClasses.headingOption6,
+              classes.headingOption6,
+            ])}
           >
             {labels?.heading6 ?? HEADING_OPTION_VALUES.Heading6}
-          </MenuButtonTooltip>
+          </MenuSelectHeadingOption6>
         </MenuItem>
       )}
     </MenuSelectHeadingRoot>

--- a/src/controls/MenuSelectTextAlign.classes.ts
+++ b/src/controls/MenuSelectTextAlign.classes.ts
@@ -9,8 +9,8 @@ export interface MenuSelectTextAlignClasses {
   menuItem: string;
   /** Styles applied to the content wrapper inside each menu item. */
   menuOption: string;
-  /** Styles applied to the menu button icon. */
-  menuButtonIcon: string;
+  /** Styles applied to the menu option icon. */
+  icon: string;
 }
 
 export type MenuSelectTextAlignClassKey = keyof MenuSelectTextAlignClasses;
@@ -20,7 +20,7 @@ const menuSelectTextAlignClassKeys = [
   "selectInput",
   "menuItem",
   "menuOption",
-  "menuButtonIcon",
+  "icon",
 ] as const satisfies ReadonlyArray<MenuSelectTextAlignClassKey>;
 
 export const menuSelectTextAlignClasses: MenuSelectTextAlignClasses =

--- a/src/controls/MenuSelectTextAlign.classes.ts
+++ b/src/controls/MenuSelectTextAlign.classes.ts
@@ -15,13 +15,11 @@ export interface MenuSelectTextAlignClasses {
 
 export type MenuSelectTextAlignClassKey = keyof MenuSelectTextAlignClasses;
 
-const menuSelectTextAlignClassKeys = [
-  "root",
-  "selectInput",
-  "menuItem",
-  "menuOption",
-  "icon",
-] as const satisfies ReadonlyArray<MenuSelectTextAlignClassKey>;
-
 export const menuSelectTextAlignClasses: MenuSelectTextAlignClasses =
-  getUtilityClasses("MenuSelectTextAlign", menuSelectTextAlignClassKeys);
+  getUtilityClasses("MenuSelectTextAlign", [
+    "root",
+    "selectInput",
+    "menuItem",
+    "menuOption",
+    "icon",
+  ] satisfies MenuSelectTextAlignClassKey[]);

--- a/src/controls/MenuSelectTextAlign.classes.ts
+++ b/src/controls/MenuSelectTextAlign.classes.ts
@@ -1,0 +1,27 @@
+import { getUtilityClasses } from "../styles";
+
+export interface MenuSelectTextAlignClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the Select input element. */
+  selectInput: string;
+  /** Styles applied to each MenuItem element. */
+  menuItem: string;
+  /** Styles applied to the content wrapper inside each menu item. */
+  menuOption: string;
+  /** Styles applied to the menu button icon. */
+  menuButtonIcon: string;
+}
+
+export type MenuSelectTextAlignClassKey = keyof MenuSelectTextAlignClasses;
+
+const menuSelectTextAlignClassKeys = [
+  "root",
+  "selectInput",
+  "menuItem",
+  "menuOption",
+  "menuButtonIcon",
+] as const satisfies ReadonlyArray<MenuSelectTextAlignClassKey>;
+
+export const menuSelectTextAlignClasses: MenuSelectTextAlignClasses =
+  getUtilityClasses("MenuSelectTextAlign", menuSelectTextAlignClassKeys);

--- a/src/controls/MenuSelectTextAlign.tsx
+++ b/src/controls/MenuSelectTextAlign.tsx
@@ -9,7 +9,6 @@ import {
   type CSSObject,
   type SelectChangeEvent,
   type SxProps,
-  type Theme,
 } from "@mui/material";
 import { clsx } from "clsx";
 import { useCallback, useMemo } from "react";
@@ -98,11 +97,12 @@ export type MenuSelectTextAlignProps = Except<
 
 const componentName = getComponentName("MenuSelectTextAlign");
 
-const sharedChildrenStyles = (theme: Theme): Record<string, CSSObject> => ({
-  // TODO(Steven DeMartini): Once we support `slots`, we can use a `styled`
-  // component to apply these styles directly to the menuOption, rather than
-  // using a child selector, by overriding the component for the
-  // MenuButtonTooltip's contentWrapper slot.
+// TODO(Steven DeMartini): Once we support `slots`
+// (https://github.com/sjdemartini/mui-tiptap/issues/382), we can use a `styled`
+// component to apply these styles directly to the menuOption, rather than using
+// a child selector, by overriding the component for the MenuButtonTooltip's
+// contentWrapper slot.
+const sharedChildrenStyles: Record<string, CSSObject> = {
   [`& .${menuSelectTextAlignClasses.menuOption}`]: {
     // These styles ensure the item fills its MenuItem container, and the
     // tooltip appears in the same place when hovering over the item generally
@@ -111,22 +111,28 @@ const sharedChildrenStyles = (theme: Theme): Record<string, CSSObject> => ({
     width: "100%",
     justifyContent: "center",
   },
+};
 
-  [`& .${menuSelectTextAlignClasses.icon}`]: {
-    fontSize: MENU_BUTTON_FONT_SIZE_DEFAULT,
-    // For consistency with toggle button default icon color and the Select
-    // dropdown arrow icon color
-    // https://github.com/mui/material-ui/blob/2cb9664b16d5a862a3796add7c8e3b088b47acb5/packages/mui-material/src/ToggleButton/ToggleButton.js#L60,
-    // https://github.com/mui/material-ui/blob/0b7beb93c9015da6e35c2a31510f679126cf0de1/packages/mui-material/src/NativeSelect/NativeSelectInput.js#L96
-    color: theme.palette.action.active,
-  },
-});
+// We can use an arbitrary component here ("span"), since we use `as` below with
+// the alignment option's `IconComponent`.
+const MenuSelectTextAlignIcon = styled("span", {
+  name: componentName,
+  slot: "icon" satisfies MenuSelectTextAlignClassKey,
+  overridesResolver: (props, styles) => styles.icon,
+})(({ theme }) => ({
+  fontSize: MENU_BUTTON_FONT_SIZE_DEFAULT,
+  // For consistency with toggle button default icon color and the Select
+  // dropdown arrow icon color
+  // https://github.com/mui/material-ui/blob/2cb9664b16d5a862a3796add7c8e3b088b47acb5/packages/mui-material/src/ToggleButton/ToggleButton.js#L60,
+  // https://github.com/mui/material-ui/blob/0b7beb93c9015da6e35c2a31510f679126cf0de1/packages/mui-material/src/NativeSelect/NativeSelectInput.js#L96
+  color: theme.palette.action.active,
+}));
 
 const MenuSelectTextAlignRoot = styled(MenuSelect<string>, {
   name: componentName,
   slot: "root" satisfies MenuSelectTextAlignClassKey,
   overridesResolver: (props, styles) => styles.root,
-})(({ theme }) => ({
+})({
   [`& .${menuSelectTextAlignClasses.selectInput}`]: {
     // We use a fixed width equal to the size of the menu button icon so that
     // the Select element won't change sizes even if we show the "blank"
@@ -135,19 +141,19 @@ const MenuSelectTextAlignRoot = styled(MenuSelect<string>, {
     width: MENU_BUTTON_FONT_SIZE_DEFAULT,
   },
 
-  ...sharedChildrenStyles(theme),
-}));
+  ...sharedChildrenStyles,
+});
 
 const MenuSelectTextAlignMenuItem = styled(MenuItem, {
   name: componentName,
   slot: "menuItem" satisfies MenuSelectTextAlignClassKey,
   overridesResolver: (props, styles) => styles.menuItem,
-})(({ theme }) => ({
+})({
   paddingLeft: 0,
   paddingRight: 0,
 
-  ...sharedChildrenStyles(theme),
-}));
+  ...sharedChildrenStyles,
+});
 
 const DEFAULT_ALIGNMENT_OPTIONS: TextAlignSelectOption[] = [
   {
@@ -244,7 +250,8 @@ export default function MenuSelectTextAlign(inProps: MenuSelectTextAlignProps) {
             (option) => option.value === value,
           );
           content = alignmentOptionForValue ? (
-            <alignmentOptionForValue.IconComponent
+            <MenuSelectTextAlignIcon
+              as={alignmentOptionForValue.IconComponent}
               className={clsx([menuSelectTextAlignClasses.icon, classes.icon])}
             />
           ) : (
@@ -309,7 +316,8 @@ export default function MenuSelectTextAlign(inProps: MenuSelectTextAlignProps) {
                 ]),
               }}
             >
-              <alignmentOption.IconComponent
+              <MenuSelectTextAlignIcon
+                as={alignmentOption.IconComponent}
                 className={clsx([
                   menuSelectTextAlignClasses.icon,
                   classes.icon,

--- a/src/controls/MenuSelectTextAlign.tsx
+++ b/src/controls/MenuSelectTextAlign.tsx
@@ -167,23 +167,20 @@ const DEFAULT_ALIGNMENT_OPTIONS: TextAlignSelectOption[] = [
 export default function MenuSelectTextAlign(inProps: MenuSelectTextAlignProps) {
   const props = useThemeProps({ props: inProps, name: componentName });
   const {
-    options: propOptions = DEFAULT_ALIGNMENT_OPTIONS,
     emptyLabel = "",
+    // Handle the deprecated name for the `options` prop if present
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     alignmentOptions,
+    options = alignmentOptions?.map((option) => ({
+      ...option,
+      value: option.alignment,
+    })) ?? DEFAULT_ALIGNMENT_OPTIONS,
     classes = {},
     sx,
     ...menuSelectProps
   } = props;
 
   const editor = useRichTextEditorContext();
-
-  // Handle the deprecated name for the `options` prop if present
-  const options =
-    alignmentOptions?.map((option) => ({
-      ...option,
-      value: option.alignment,
-    })) ?? propOptions;
 
   const handleAlignmentSelect: (event: SelectChangeEvent) => void = useCallback(
     (event) => {

--- a/src/controls/MenuSelectTextAlign.tsx
+++ b/src/controls/MenuSelectTextAlign.tsx
@@ -13,7 +13,7 @@ import {
 import { clsx } from "clsx";
 import { useCallback, useMemo } from "react";
 import { useRichTextEditorContext } from "../context";
-import { getComponentName } from "../styles";
+import { getUtilityComponentName } from "../styles";
 import MenuButtonTooltip, {
   type MenuButtonTooltipProps,
 } from "./MenuButtonTooltip";
@@ -95,7 +95,7 @@ export type MenuSelectTextAlignProps = Except<
   sx?: SxProps;
 };
 
-const componentName = getComponentName("MenuSelectTextAlign");
+const componentName = getUtilityComponentName("MenuSelectTextAlign");
 
 // TODO(Steven DeMartini): Once we support `slots`
 // (https://github.com/sjdemartini/mui-tiptap/issues/382), we can use a `styled`

--- a/src/controls/MenuSelectTextAlign.tsx
+++ b/src/controls/MenuSelectTextAlign.tsx
@@ -6,8 +6,10 @@ import {
   MenuItem,
   styled,
   useThemeProps,
+  type CSSObject,
   type SelectChangeEvent,
   type SxProps,
+  type Theme,
 } from "@mui/material";
 import { clsx } from "clsx";
 import { useCallback, useMemo } from "react";
@@ -96,6 +98,30 @@ export type MenuSelectTextAlignProps = Except<
 
 const componentName = getComponentName("MenuSelectTextAlign");
 
+const sharedChildrenStyles = (theme: Theme): Record<string, CSSObject> => ({
+  // TODO(Steven DeMartini): Once we support `slots`, we can use a `styled`
+  // component to apply these styles directly to the menuOption, rather than
+  // using a child selector, by overriding the component for the
+  // MenuButtonTooltip's contentWrapper slot.
+  [`& .${menuSelectTextAlignClasses.menuOption}`]: {
+    // These styles ensure the item fills its MenuItem container, and the
+    // tooltip appears in the same place when hovering over the item generally
+    // (not just the text of the item)
+    display: "flex",
+    width: "100%",
+    justifyContent: "center",
+  },
+
+  [`& .${menuSelectTextAlignClasses.icon}`]: {
+    fontSize: MENU_BUTTON_FONT_SIZE_DEFAULT,
+    // For consistency with toggle button default icon color and the Select
+    // dropdown arrow icon color
+    // https://github.com/mui/material-ui/blob/2cb9664b16d5a862a3796add7c8e3b088b47acb5/packages/mui-material/src/ToggleButton/ToggleButton.js#L60,
+    // https://github.com/mui/material-ui/blob/0b7beb93c9015da6e35c2a31510f679126cf0de1/packages/mui-material/src/NativeSelect/NativeSelectInput.js#L96
+    color: theme.palette.action.active,
+  },
+});
+
 const MenuSelectTextAlignRoot = styled(MenuSelect<string>, {
   name: componentName,
   slot: "root" satisfies MenuSelectTextAlignClassKey,
@@ -109,33 +135,19 @@ const MenuSelectTextAlignRoot = styled(MenuSelect<string>, {
     width: MENU_BUTTON_FONT_SIZE_DEFAULT,
   },
 
-  [`& .${menuSelectTextAlignClasses.menuOption}`]: {
-    // These styles ensure the item fills its MenuItem container, and the
-    // tooltip appears in the same place when hovering over the item generally
-    // (not just the text of the item)
-    display: "flex",
-    width: "100%",
-    justifyContent: "center",
-  },
-
-  [`& .${menuSelectTextAlignClasses.menuButtonIcon}`]: {
-    fontSize: MENU_BUTTON_FONT_SIZE_DEFAULT,
-    // For consistency with toggle button default icon color and the Select
-    // dropdown arrow icon color
-    // https://github.com/mui/material-ui/blob/2cb9664b16d5a862a3796add7c8e3b088b47acb5/packages/mui-material/src/ToggleButton/ToggleButton.js#L60,
-    // https://github.com/mui/material-ui/blob/0b7beb93c9015da6e35c2a31510f679126cf0de1/packages/mui-material/src/NativeSelect/NativeSelectInput.js#L96
-    color: theme.palette.action.active,
-  },
+  ...sharedChildrenStyles(theme),
 }));
 
 const MenuSelectTextAlignMenuItem = styled(MenuItem, {
   name: componentName,
   slot: "menuItem" satisfies MenuSelectTextAlignClassKey,
   overridesResolver: (props, styles) => styles.menuItem,
-})({
+})(({ theme }) => ({
   paddingLeft: 0,
   paddingRight: 0,
-});
+
+  ...sharedChildrenStyles(theme),
+}));
 
 const DEFAULT_ALIGNMENT_OPTIONS: TextAlignSelectOption[] = [
   {
@@ -233,10 +245,7 @@ export default function MenuSelectTextAlign(inProps: MenuSelectTextAlignProps) {
           );
           content = alignmentOptionForValue ? (
             <alignmentOptionForValue.IconComponent
-              className={clsx([
-                menuSelectTextAlignClasses.menuButtonIcon,
-                classes.menuButtonIcon,
-              ])}
+              className={clsx([menuSelectTextAlignClasses.icon, classes.icon])}
             />
           ) : (
             value
@@ -302,8 +311,8 @@ export default function MenuSelectTextAlign(inProps: MenuSelectTextAlignProps) {
             >
               <alignmentOption.IconComponent
                 className={clsx([
-                  menuSelectTextAlignClasses.menuButtonIcon,
-                  classes.menuButtonIcon,
+                  menuSelectTextAlignClasses.icon,
+                  classes.icon,
                 ])}
               />
             </MenuButtonTooltip>

--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -2,6 +2,7 @@ export * from "./ColorPicker";
 export * from "./ColorPickerPopper";
 export * from "./ColorSwatchButton";
 export { default as MenuButton, type MenuButtonProps } from "./MenuButton";
+export { menuButtonClasses } from "./MenuButton.classes";
 export {
   default as MenuButtonAddImage,
   type MenuButtonAddImageProps,
@@ -130,26 +131,32 @@ export {
   default as MenuControlsContainer,
   type MenuControlsContainerProps,
 } from "./MenuControlsContainer";
+export { menuControlsContainerClasses } from "./MenuControlsContainer.classes";
 export { default as MenuSelect, type MenuSelectProps } from "./MenuSelect";
+export { menuSelectClasses } from "./MenuSelect.classes";
 export {
   default as MenuSelectFontFamily,
   type FontFamilySelectOption,
   type MenuSelectFontFamilyProps,
 } from "./MenuSelectFontFamily";
+export { menuSelectFontFamilyClasses } from "./MenuSelectFontFamily.classes";
 export {
   default as MenuSelectFontSize,
   type MenuSelectFontSizeProps,
 } from "./MenuSelectFontSize";
+export { menuSelectFontSizeClasses } from "./MenuSelectFontSize.classes";
 export {
   default as MenuSelectHeading,
   type HeadingOptionValue,
   type MenuSelectHeadingProps,
 } from "./MenuSelectHeading";
+export { menuSelectHeadingClasses } from "./MenuSelectHeading.classes";
 export {
   default as MenuSelectTextAlign,
   type MenuSelectTextAlignProps,
   type TextAlignSelectOption,
 } from "./MenuSelectTextAlign";
+export { menuSelectTextAlignClasses } from "./MenuSelectTextAlign.classes";
 export {
   default as TableMenuControls,
   type TableMenuControlsProps,

--- a/src/controls/index.ts
+++ b/src/controls/index.ts
@@ -46,7 +46,10 @@ export {
   default as MenuButtonCodeBlock,
   type MenuButtonCodeBlockProps,
 } from "./MenuButtonCodeBlock";
-export * from "./MenuButtonColorPicker";
+export {
+  default as MenuButtonColorPicker,
+  type MenuButtonColorPickerProps,
+} from "./MenuButtonColorPicker";
 export {
   default as MenuButtonEditLink,
   type MenuButtonEditLinkProps,

--- a/src/extensions/HeadingWithAnchorComponent.classes.ts
+++ b/src/extensions/HeadingWithAnchorComponent.classes.ts
@@ -1,0 +1,28 @@
+import { getUtilityClasses } from "../styles";
+
+export interface HeadingWithAnchorComponentClasses {
+  /** Styles applied to the root element. */
+  root: string;
+  /** Styles applied to the container element. */
+  container: string;
+  /** Styles applied to the link element. */
+  link: string;
+  /** Styles applied to the link icon. */
+  linkIcon: string;
+}
+
+export type HeadingWithAnchorComponentClassKey =
+  keyof HeadingWithAnchorComponentClasses;
+
+const headingWithAnchorComponentClassKeys = [
+  "root",
+  "container",
+  "link",
+  "linkIcon",
+] as const satisfies ReadonlyArray<HeadingWithAnchorComponentClassKey>;
+
+export const headingWithAnchorComponentClasses: HeadingWithAnchorComponentClasses =
+  getUtilityClasses(
+    "HeadingWithAnchorComponent",
+    headingWithAnchorComponentClassKeys,
+  );

--- a/src/extensions/HeadingWithAnchorComponent.classes.ts
+++ b/src/extensions/HeadingWithAnchorComponent.classes.ts
@@ -14,15 +14,10 @@ export interface HeadingWithAnchorComponentClasses {
 export type HeadingWithAnchorComponentClassKey =
   keyof HeadingWithAnchorComponentClasses;
 
-const headingWithAnchorComponentClassKeys = [
-  "root",
-  "container",
-  "link",
-  "linkIcon",
-] as const satisfies ReadonlyArray<HeadingWithAnchorComponentClassKey>;
-
 export const headingWithAnchorComponentClasses: HeadingWithAnchorComponentClasses =
-  getUtilityClasses(
-    "HeadingWithAnchorComponent",
-    headingWithAnchorComponentClassKeys,
-  );
+  getUtilityClasses("HeadingWithAnchorComponent", [
+    "root",
+    "container",
+    "link",
+    "linkIcon",
+  ] satisfies HeadingWithAnchorComponentClassKey[]);

--- a/src/extensions/HeadingWithAnchorComponent.tsx
+++ b/src/extensions/HeadingWithAnchorComponent.tsx
@@ -30,7 +30,7 @@ interface HeadingNode extends ProseMirrorNode {
   attrs: HeadingNodeAttributes;
 }
 
-interface Props extends NodeViewProps {
+export interface HeadingWithAnchorComponentProps extends NodeViewProps {
   node: HeadingNode;
   extension: typeof Heading;
   /** Override or extend existing styles. */
@@ -113,7 +113,9 @@ const HeadingWithAnchorComponentLinkIcon = styled(LinkIcon, {
   },
 }));
 
-export default function HeadingWithAnchorComponent(inProps: Props) {
+export default function HeadingWithAnchorComponent(
+  inProps: HeadingWithAnchorComponentProps,
+) {
   const props = useThemeProps({ props: inProps, name: componentName });
   const { editor, node, extension, classes = {}, sx } = props;
 

--- a/src/extensions/HeadingWithAnchorComponent.tsx
+++ b/src/extensions/HeadingWithAnchorComponent.tsx
@@ -1,4 +1,5 @@
 import LinkIcon from "@mui/icons-material/Link";
+import { styled, useThemeProps, type SxProps } from "@mui/material";
 import {
   getText,
   getTextSerializersFromSchema,
@@ -7,10 +8,15 @@ import {
 import type { Heading, Level } from "@tiptap/extension-heading";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { NodeViewContent, NodeViewWrapper } from "@tiptap/react";
+import { clsx } from "clsx";
 import { useMemo } from "react";
-import { makeStyles } from "tss-react/mui";
-import { getUtilityClasses } from "../styles";
+import { getComponentName } from "../styles";
 import slugify from "../utils/slugify";
+import {
+  headingWithAnchorComponentClasses,
+  type HeadingWithAnchorComponentClassKey,
+  type HeadingWithAnchorComponentClasses,
+} from "./HeadingWithAnchorComponent.classes";
 
 // Based on
 // https://github.com/ueberdosis/tiptap/blob/c9eb6a6299796450c7c1cfdc3552d76070c78c65/packages/extension-heading/src/heading.ts#L41-L48
@@ -27,83 +33,90 @@ interface HeadingNode extends ProseMirrorNode {
 interface Props extends NodeViewProps {
   node: HeadingNode;
   extension: typeof Heading;
+  /** Override or extend existing styles. */
+  classes?: Partial<HeadingWithAnchorComponentClasses>;
+  /** Provide custom styles. */
+  sx?: SxProps;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-const useStyles = makeStyles<void, "link">({
-  name: { HeadingWithAnchorComponent },
-  uniqId: "kNc4LD", // https://docs.tss-react.dev/nested-selectors#ssr
-})((theme, _params, classes) => ({
-  root: {
-    // Reference the "link" class defined below so that when the header is
-    // hovered over, we make the anchor link visible.
-    [`&:hover .${classes.link}`]: {
-      opacity: 100,
-    },
+const componentName = getComponentName("HeadingWithAnchorComponent");
+
+const HeadingWithAnchorComponentRoot = styled(NodeViewWrapper, {
+  name: componentName,
+  slot: "root" satisfies HeadingWithAnchorComponentClassKey,
+  overridesResolver: (props, styles) => styles.root,
+  // Unlike default behavior of `styled`, allow the 'as' prop be forwarded to
+  // NodeViewWrapper, which itself supports `as`. Otherwise providing `as` will
+  // sidestep using NodeViewWrapper altogether.
+  shouldForwardProp: (prop) =>
+    prop !== "ownerState" && prop !== "theme" && prop !== "sx",
+})({
+  // Reference the "link" class defined below so that when the header is
+  // hovered over, we make the anchor link visible.
+  [`&:hover .${headingWithAnchorComponentClasses.link}`]: {
+    opacity: 100,
+  },
+});
+
+const HeadingWithAnchorComponentContainer = styled("span", {
+  name: componentName,
+  slot: "container" satisfies HeadingWithAnchorComponentClassKey,
+  overridesResolver: (props, styles) => styles.container,
+})({
+  // Use inline-block so that the container is only as big as the inner
+  // heading content
+  display: "inline-block",
+  // Use relative position so that the link is positioned relative to
+  // the inner heading content position (via this common container)
+  position: "relative",
+});
+
+const HeadingWithAnchorComponentLink = styled("a", {
+  name: componentName,
+  slot: "link" satisfies HeadingWithAnchorComponentClassKey,
+  overridesResolver: (props, styles) => styles.link,
+})(({ theme }) => ({
+  position: "absolute",
+  left: -21,
+  color: `${theme.palette.text.secondary} !important`,
+  opacity: 0, // This is changed by the root hover above
+  transition: theme.transitions.create("opacity"),
+  textDecoration: "none",
+  outline: "none",
+
+  [theme.breakpoints.down("sm")]: {
+    left: -18,
   },
 
-  container: {
-    // Use inline-block so that the container is only as big as the inner
-    // heading content
-    display: "inline-block",
-    // Use relative position so that the link is positioned relative to
-    // the inner heading content position (via this common container)
-    position: "relative",
-  },
-
-  link: {
-    position: "absolute",
-    left: -21,
-    color: `${theme.palette.text.secondary} !important`,
-    opacity: 0, // This is changed by the root hover above
-    transition: theme.transitions.create("opacity"),
-    textDecoration: "none",
-    outline: "none",
-
-    [theme.breakpoints.down("sm")]: {
-      left: -18,
-    },
-
-    // As described here https://github.com/ueberdosis/tiptap/issues/3775,
-    // updates to editor isEditable do not trigger re-rendering of node views.
-    // Even editor state changes external to a given ReactNodeView component
-    // will not trigger re-render (which is probably a good thing most of the
-    // time, in terms of performance). As such, we always render the link in the
-    // DOM, but hide it with CSS when the editor is editable.
-    '.ProseMirror[contenteditable="true"] &': {
-      display: "none",
-    },
-  },
-
-  linkIcon: {
-    // Looks better to have at an angle, similar to the GitHub icon
-    transform: "rotate(-45deg)",
-
-    fontSize: "1.25rem",
-    [theme.breakpoints.down("sm")]: {
-      fontSize: "1.15rem",
-    },
+  // As described here https://github.com/ueberdosis/tiptap/issues/3775,
+  // updates to editor isEditable do not trigger re-rendering of node views.
+  // Even editor state changes external to a given ReactNodeView component
+  // will not trigger re-render (which is probably a good thing most of the
+  // time, in terms of performance). As such, we always render the link in the
+  // DOM, but hide it with CSS when the editor is editable.
+  '.ProseMirror[contenteditable="true"] &': {
+    display: "none",
   },
 }));
 
-export type HeadingWithAnchorComponentClasses = ReturnType<
-  typeof useStyles
->["classes"];
+const HeadingWithAnchorComponentLinkIcon = styled(LinkIcon, {
+  name: componentName,
+  slot: "linkIcon" satisfies HeadingWithAnchorComponentClassKey,
+  overridesResolver: (props, styles) => styles.linkIcon,
+})(({ theme }) => ({
+  // Looks better to have at an angle, similar to the GitHub icon
+  transform: "rotate(-45deg)",
 
-const headingWithAnchorComponentClasses: HeadingWithAnchorComponentClasses =
-  getUtilityClasses("HeadingWithAnchorComponent", [
-    "root",
-    "container",
-    "link",
-    "linkIcon",
-  ]);
+  fontSize: "1.25rem",
+  [theme.breakpoints.down("sm")]: {
+    fontSize: "1.15rem",
+  },
+}));
 
-export default function HeadingWithAnchorComponent({
-  editor,
-  node,
-  extension,
-}: Props) {
-  const { classes, cx } = useStyles();
+export default function HeadingWithAnchorComponent(inProps: Props) {
+  const props = useThemeProps({ props: inProps, name: componentName });
+  const { editor, node, extension, classes = {}, sx } = props;
+
   // Some of the logic here is based on the renderHTML definition from the
   // original Heading Node
   // (https://github.com/ueberdosis/tiptap/blob/c9eb6a6299796450c7c1cfdc3552d76070c78c65/packages/extension-heading/src/heading.ts#L58-L65)
@@ -127,17 +140,18 @@ export default function HeadingWithAnchorComponent({
   );
 
   return (
-    <NodeViewWrapper
+    <HeadingWithAnchorComponentRoot
       as={HeadingTag}
       id={headingId}
       {...extension.options.HTMLAttributes}
-      className={cx(headingWithAnchorComponentClasses.root, classes.root)}
+      className={clsx([headingWithAnchorComponentClasses.root, classes.root])}
       // Handle @tiptap/extension-text-align. Ideally we'd be able to inherit
       // this style from TextAlign's GlobalAttributes directly, but those are
       // only applied via `renderHTML` and not the `NodeView` renderer
       // (https://github.com/ueberdosis/tiptap/blob/6c34dec33ac39c9f037a0a72e4525f3fc6d422bf/packages/extension-text-align/src/text-align.ts#L43-L49),
       // so we have to do this manually/redundantly here.
       style={{ textAlign: node.attrs.textAlign }}
+      sx={sx}
     >
       {/* We need a separate inner container here in order to (1) have the node
       view wrapper take up the full width of its parent div created by
@@ -145,27 +159,30 @@ export default function HeadingWithAnchorComponent({
       elements), and (2) position the anchor link/icon relative to the *aligned*
       position of the inner text content, by having this inner container match
       the dimensions and location of the its content. */}
-      <span
-        className={cx(
+      <HeadingWithAnchorComponentContainer
+        className={clsx([
           headingWithAnchorComponentClasses.container,
           classes.container,
-        )}
+        ])}
       >
-        <a
+        <HeadingWithAnchorComponentLink
           href={`#${headingId}`}
           contentEditable={false}
-          className={cx(headingWithAnchorComponentClasses.link, classes.link)}
+          className={clsx([
+            headingWithAnchorComponentClasses.link,
+            classes.link,
+          ])}
         >
-          <LinkIcon
-            className={cx(
+          <HeadingWithAnchorComponentLinkIcon
+            className={clsx([
               headingWithAnchorComponentClasses.linkIcon,
               classes.linkIcon,
-            )}
+            ])}
           />
-        </a>
+        </HeadingWithAnchorComponentLink>
         {/* This is the editable content of the header: */}
         <NodeViewContent as="span" />
-      </span>
-    </NodeViewWrapper>
+      </HeadingWithAnchorComponentContainer>
+    </HeadingWithAnchorComponentRoot>
   );
 }

--- a/src/extensions/HeadingWithAnchorComponent.tsx
+++ b/src/extensions/HeadingWithAnchorComponent.tsx
@@ -10,7 +10,7 @@ import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { NodeViewContent, NodeViewWrapper } from "@tiptap/react";
 import { clsx } from "clsx";
 import { useMemo } from "react";
-import { getComponentName } from "../styles";
+import { getUtilityComponentName } from "../styles";
 import slugify from "../utils/slugify";
 import {
   headingWithAnchorComponentClasses,
@@ -39,7 +39,7 @@ export interface HeadingWithAnchorComponentProps extends NodeViewProps {
   sx?: SxProps;
 }
 
-const componentName = getComponentName("HeadingWithAnchorComponent");
+const componentName = getUtilityComponentName("HeadingWithAnchorComponent");
 
 const HeadingWithAnchorComponentRoot = styled(NodeViewWrapper, {
   name: componentName,

--- a/src/extensions/ResizableImageComponent.classes.ts
+++ b/src/extensions/ResizableImageComponent.classes.ts
@@ -1,0 +1,28 @@
+import { getUtilityClasses } from "../styles";
+
+export interface ResizableImageComponentClasses {
+  /** Styles applied to the image container element. */
+  imageContainer: string;
+  /** Styles applied to the image element. */
+  image: string;
+  /** Styles applied to the image element when selected. */
+  imageSelected: string;
+  /** Styles applied to the resizer element. */
+  resizer: string;
+}
+
+export type ResizableImageComponentClassKey =
+  keyof ResizableImageComponentClasses;
+
+const resizableImageComponentClassKeys = [
+  "imageContainer",
+  "image",
+  "imageSelected",
+  "resizer",
+] as const satisfies ReadonlyArray<ResizableImageComponentClassKey>;
+
+export const resizableImageComponentClasses: ResizableImageComponentClasses =
+  getUtilityClasses(
+    "ResizableImageComponent",
+    resizableImageComponentClassKeys,
+  );

--- a/src/extensions/ResizableImageComponent.classes.ts
+++ b/src/extensions/ResizableImageComponent.classes.ts
@@ -14,15 +14,10 @@ export interface ResizableImageComponentClasses {
 export type ResizableImageComponentClassKey =
   keyof ResizableImageComponentClasses;
 
-const resizableImageComponentClassKeys = [
-  "imageContainer",
-  "image",
-  "imageSelected",
-  "resizer",
-] as const satisfies ReadonlyArray<ResizableImageComponentClassKey>;
-
 export const resizableImageComponentClasses: ResizableImageComponentClasses =
-  getUtilityClasses(
-    "ResizableImageComponent",
-    resizableImageComponentClassKeys,
-  );
+  getUtilityClasses("ResizableImageComponent", [
+    "imageContainer",
+    "image",
+    "imageSelected",
+    "resizer",
+  ] satisfies ResizableImageComponentClassKey[]);

--- a/src/extensions/ResizableImageComponent.tsx
+++ b/src/extensions/ResizableImageComponent.tsx
@@ -12,7 +12,7 @@ import {
   type ResizableImageComponentClassKey,
   type ResizableImageComponentClasses,
 } from "./ResizableImageComponent.classes";
-import { ResizableImageResizer } from "./ResizableImageResizer";
+import ResizableImageResizer from "./ResizableImageResizer";
 
 // Based on
 // https://github.com/ueberdosis/tiptap/blob/ab4a0e2507b4b92c46d293a0bb06bb00a04af6e0/packages/extension-image/src/image.ts#L47-L59
@@ -33,7 +33,7 @@ interface ResizableImageNode extends ProseMirrorNode {
   attrs: ResizableImageNodeAttributes;
 }
 
-interface Props extends NodeViewProps {
+export interface ResizableImageComponentProps extends NodeViewProps {
   node: ResizableImageNode;
   extension: typeof ResizableImage;
   /** Override or extend existing styles. */
@@ -42,7 +42,8 @@ interface Props extends NodeViewProps {
   sx?: SxProps;
 }
 
-interface ResizableImageComponentOwnerState extends Pick<Props, "selected"> {
+interface ResizableImageComponentOwnerState
+  extends Pick<ResizableImageComponentProps, "selected"> {
   selectedOrResizing: boolean;
 }
 
@@ -105,7 +106,7 @@ const ResizableImageComponentResizer = styled(ResizableImageResizer, {
   },
 }));
 
-function ResizableImageComponent(inProps: Props) {
+function ResizableImageComponent(inProps: ResizableImageComponentProps) {
   const props = useThemeProps({ props: inProps, name: componentName });
   const {
     node,

--- a/src/extensions/ResizableImageComponent.tsx
+++ b/src/extensions/ResizableImageComponent.tsx
@@ -5,7 +5,7 @@ import { NodeViewWrapper } from "@tiptap/react";
 import { clsx } from "clsx";
 import throttle from "lodash/throttle";
 import { useMemo, useRef, useState } from "react";
-import { getComponentName } from "../styles";
+import { getUtilityComponentName } from "../styles";
 import type ResizableImage from "./ResizableImage";
 import {
   resizableImageComponentClasses,
@@ -49,7 +49,7 @@ interface ResizableImageComponentOwnerState
 
 const IMAGE_MINIMUM_WIDTH_PIXELS = 15;
 
-const componentName = getComponentName("ResizableImageComponent");
+const componentName = getUtilityComponentName("ResizableImageComponent");
 
 const ResizableImageComponentImageContainer = styled("div", {
   name: componentName,

--- a/src/extensions/ResizableImageResizer.classes.ts
+++ b/src/extensions/ResizableImageResizer.classes.ts
@@ -7,9 +7,7 @@ export interface ResizableImageResizerClasses {
 
 export type ResizableImageResizerClassKey = keyof ResizableImageResizerClasses;
 
-const resizableImageResizerClassKeys = [
-  "root",
-] as const satisfies ReadonlyArray<ResizableImageResizerClassKey>;
-
 export const resizableImageResizerClasses: ResizableImageResizerClasses =
-  getUtilityClasses("ResizableImageResizer", resizableImageResizerClassKeys);
+  getUtilityClasses("ResizableImageResizer", [
+    "root",
+  ] satisfies ResizableImageResizerClassKey[]);

--- a/src/extensions/ResizableImageResizer.classes.ts
+++ b/src/extensions/ResizableImageResizer.classes.ts
@@ -1,0 +1,15 @@
+import { getUtilityClasses } from "../styles";
+
+export interface ResizableImageResizerClasses {
+  /** Styles applied to the root element. */
+  root: string;
+}
+
+export type ResizableImageResizerClassKey = keyof ResizableImageResizerClasses;
+
+const resizableImageResizerClassKeys = [
+  "root",
+] as const satisfies ReadonlyArray<ResizableImageResizerClassKey>;
+
+export const resizableImageResizerClasses: ResizableImageResizerClasses =
+  getUtilityClasses("ResizableImageResizer", resizableImageResizerClassKeys);

--- a/src/extensions/ResizableImageResizer.tsx
+++ b/src/extensions/ResizableImageResizer.tsx
@@ -6,7 +6,7 @@ import {
   type Dispatch,
   type SetStateAction,
 } from "react";
-import { getComponentName } from "../styles";
+import { getUtilityComponentName } from "../styles";
 import {
   resizableImageResizerClasses,
   type ResizableImageResizerClassKey,
@@ -24,7 +24,7 @@ export type ResizableImageResizerProps = {
   sx?: SxProps;
 };
 
-const componentName = getComponentName("ResizableImageResizer");
+const componentName = getUtilityComponentName("ResizableImageResizer");
 
 const ResizableImageResizerRoot = styled("div", {
   name: componentName,

--- a/src/extensions/ResizableImageResizer.tsx
+++ b/src/extensions/ResizableImageResizer.tsx
@@ -1,39 +1,57 @@
+import { styled, useThemeProps, type SxProps } from "@mui/material";
+import { clsx } from "clsx";
 import {
   useCallback,
   useEffect,
   type Dispatch,
   type SetStateAction,
 } from "react";
-import { makeStyles } from "tss-react/mui";
+import { getComponentName } from "../styles";
+import {
+  resizableImageResizerClasses,
+  type ResizableImageResizerClassKey,
+  type ResizableImageResizerClasses,
+} from "./ResizableImageResizer.classes";
 
 type ResizableImageResizerProps = {
   className?: string;
   onResize: (event: MouseEvent) => void;
   mouseDown: boolean;
   setMouseDown: Dispatch<SetStateAction<boolean>>;
+  /** Override or extend existing styles. */
+  classes?: Partial<ResizableImageResizerClasses>;
+  /** Provide custom styles. */
+  sx?: SxProps;
 };
 
-const useStyles = makeStyles({ name: { ResizableImageResizer } })((theme) => ({
-  root: {
-    position: "absolute",
-    // The `outline` styles of the selected image add 3px to the edges, so we'll
-    // position this offset by 3px outside to the bottom right
-    bottom: -3,
-    right: -3,
-    width: 12,
-    height: 12,
-    background: theme.palette.primary.main,
-    cursor: "nwse-resize",
-  },
+const componentName = getComponentName("ResizableImageResizer");
+
+const ResizableImageResizerRoot = styled("div", {
+  name: componentName,
+  slot: "root" satisfies ResizableImageResizerClassKey,
+  overridesResolver: (props, styles) => styles.root,
+})(({ theme }) => ({
+  position: "absolute",
+  // The `outline` styles of the selected image add 3px to the edges, so we'll
+  // position this offset by 3px outside to the bottom right
+  bottom: -3,
+  right: -3,
+  width: 12,
+  height: 12,
+  background: theme.palette.primary.main,
+  cursor: "nwse-resize",
 }));
 
-export function ResizableImageResizer({
-  onResize,
-  className,
-  mouseDown,
-  setMouseDown,
-}: ResizableImageResizerProps) {
-  const { classes, cx } = useStyles();
+export function ResizableImageResizer(inProps: ResizableImageResizerProps) {
+  const props = useThemeProps({ props: inProps, name: componentName });
+  const {
+    onResize,
+    className,
+    mouseDown,
+    setMouseDown,
+    classes = {},
+    sx,
+  } = props;
 
   useEffect(() => {
     if (!mouseDown) {
@@ -80,14 +98,19 @@ export function ResizableImageResizer({
     // closest, as described here https://stackoverflow.com/a/43022983/4543977,
     // but we don't do keyboard-based resizing at this time so it doesn't make
     // sense to have it keyboard focusable)
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-    <div
+
+    <ResizableImageResizerRoot
       // TODO(Steven DeMartini): Add keyboard support and better accessibility
       // here, and allow users to override the aria-label when that happens to
       // support localization.
       // aria-label="resize image"
-      className={cx(classes.root, className)}
+      className={clsx([
+        resizableImageResizerClasses.root,
+        className,
+        classes.root,
+      ])}
       onMouseDown={handleMouseDown}
+      sx={sx}
     />
   );
 }

--- a/src/extensions/ResizableImageResizer.tsx
+++ b/src/extensions/ResizableImageResizer.tsx
@@ -13,7 +13,7 @@ import {
   type ResizableImageResizerClasses,
 } from "./ResizableImageResizer.classes";
 
-type ResizableImageResizerProps = {
+export type ResizableImageResizerProps = {
   className?: string;
   onResize: (event: MouseEvent) => void;
   mouseDown: boolean;
@@ -42,7 +42,9 @@ const ResizableImageResizerRoot = styled("div", {
   cursor: "nwse-resize",
 }));
 
-export function ResizableImageResizer(inProps: ResizableImageResizerProps) {
+export default function ResizableImageResizer(
+  inProps: ResizableImageResizerProps,
+) {
   const props = useThemeProps({ props: inProps, name: componentName });
   const {
     onResize,

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -8,9 +8,13 @@ export {
   scrollToCurrentHeadingAnchor,
   type HeadingWithAnchorOptions,
 } from "./HeadingWithAnchor";
+export { default as HeadingWithAnchorComponent } from "./HeadingWithAnchorComponent";
+export { headingWithAnchorComponentClasses } from "./HeadingWithAnchorComponent.classes";
 export {
   default as LinkBubbleMenuHandler,
   type LinkBubbleMenuHandlerStorage,
 } from "./LinkBubbleMenuHandler";
 export { default as ResizableImage } from "./ResizableImage";
+export { default as ResizableImageComponent } from "./ResizableImageComponent";
+export { resizableImageComponentClasses } from "./ResizableImageComponent.classes";
 export { default as TableImproved } from "./TableImproved";

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -8,13 +8,23 @@ export {
   scrollToCurrentHeadingAnchor,
   type HeadingWithAnchorOptions,
 } from "./HeadingWithAnchor";
-export { default as HeadingWithAnchorComponent } from "./HeadingWithAnchorComponent";
+export {
+  default as HeadingWithAnchorComponent,
+  type HeadingWithAnchorComponentProps,
+} from "./HeadingWithAnchorComponent";
 export { headingWithAnchorComponentClasses } from "./HeadingWithAnchorComponent.classes";
 export {
   default as LinkBubbleMenuHandler,
   type LinkBubbleMenuHandlerStorage,
 } from "./LinkBubbleMenuHandler";
 export { default as ResizableImage } from "./ResizableImage";
-export { default as ResizableImageComponent } from "./ResizableImageComponent";
+export {
+  default as ResizableImageComponent,
+  type ResizableImageComponentProps,
+} from "./ResizableImageComponent";
 export { resizableImageComponentClasses } from "./ResizableImageComponent.classes";
+export {
+  default as ResizableImageResizer,
+  type ResizableImageResizerProps,
+} from "./ResizableImageResizer";
 export { default as TableImproved } from "./TableImproved";

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,11 @@ export {
 } from "./ControlledBubbleMenu";
 export { controlledBubbleMenuClasses } from "./ControlledBubbleMenu.classes";
 export {
+  default as FieldContainer,
+  type FieldContainerProps,
+} from "./FieldContainer";
+export { fieldContainerClasses } from "./FieldContainer.classes";
+export {
   default as LinkBubbleMenu,
   type LinkBubbleMenuProps,
 } from "./LinkBubbleMenu";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,16 +2,21 @@ export {
   default as ControlledBubbleMenu,
   type ControlledBubbleMenuProps,
 } from "./ControlledBubbleMenu";
+export { controlledBubbleMenuClasses } from "./ControlledBubbleMenu.classes";
 export {
   default as LinkBubbleMenu,
   type LinkBubbleMenuProps,
 } from "./LinkBubbleMenu";
+export { linkBubbleMenuClasses } from "./LinkBubbleMenu/LinkBubbleMenu.classes";
 export { default as MenuBar, type MenuBarProps } from "./MenuBar";
+export { menuBarClasses } from "./MenuBar.classes";
 export { default as MenuDivider, type MenuDividerProps } from "./MenuDivider";
+export { menuDividerClasses } from "./MenuDivider.classes";
 export {
   default as RichTextContent,
   type RichTextContentProps,
 } from "./RichTextContent";
+export { richTextContentClasses } from "./RichTextContent.classes";
 export {
   default as RichTextEditor,
   type RichTextEditorProps,
@@ -25,6 +30,7 @@ export {
   default as RichTextField,
   type RichTextFieldProps,
 } from "./RichTextField";
+export { richTextFieldClasses } from "./RichTextField.classes";
 export {
   default as RichTextReadOnly,
   type RichTextReadOnlyProps,
@@ -33,6 +39,7 @@ export {
   default as TableBubbleMenu,
   type TableBubbleMenuProps,
 } from "./TableBubbleMenu";
+export { tableBubbleMenuClasses } from "./TableBubbleMenu.classes";
 export { RichTextEditorContext, useRichTextEditorContext } from "./context";
 export * from "./controls";
 export * from "./extensions";

--- a/src/overrides.d.ts
+++ b/src/overrides.d.ts
@@ -1,0 +1,238 @@
+import type {
+  ComponentsOverrides,
+  ComponentsVariants,
+  Theme as MuiTheme,
+} from "@mui/material/styles";
+import type { ControlledBubbleMenuProps } from "./ControlledBubbleMenu";
+import type { ControlledBubbleMenuClassKey } from "./ControlledBubbleMenu.classes";
+import type { FieldContainerProps } from "./FieldContainer";
+import type { FieldContainerClassKey } from "./FieldContainer.classes";
+import type { LinkBubbleMenuProps } from "./LinkBubbleMenu";
+import type { LinkBubbleMenuClassKey } from "./LinkBubbleMenu/LinkBubbleMenu.classes";
+import type { ViewLinkMenuContentProps } from "./LinkBubbleMenu/ViewLinkMenuContent";
+import type { ViewLinkMenuContentClassKey } from "./LinkBubbleMenu/ViewLinkMenuContent.classes";
+import type { MenuBarProps } from "./MenuBar";
+import type { MenuBarClassKey } from "./MenuBar.classes";
+import type { MenuDividerProps } from "./MenuDivider";
+import type { MenuDividerClassKey } from "./MenuDivider.classes";
+import type { RichTextContentProps } from "./RichTextContent";
+import type { RichTextContentClassKey } from "./RichTextContent.classes";
+import type { RichTextFieldProps } from "./RichTextField";
+import type { RichTextFieldClassKey } from "./RichTextField.classes";
+import type { TableBubbleMenuProps } from "./TableBubbleMenu";
+import type { TableBubbleMenuClassKey } from "./TableBubbleMenu.classes";
+import type { ColorPickerProps } from "./controls/ColorPicker";
+import type { ColorPickerClassKey } from "./controls/ColorPicker.classes";
+import type { ColorPickerPopperProps } from "./controls/ColorPickerPopper";
+import type { ColorPickerPopperClassKey } from "./controls/ColorPickerPopper.classes";
+import type { ColorSwatchButtonProps } from "./controls/ColorSwatchButton";
+import type { ColorSwatchButtonClassKey } from "./controls/ColorSwatchButton.classes";
+import type { MenuButtonProps } from "./controls/MenuButton";
+import type { MenuButtonClassKey } from "./controls/MenuButton.classes";
+import type { MenuButtonColorPickerProps } from "./controls/MenuButtonColorPicker";
+import type { MenuButtonColorPickerClassKey } from "./controls/MenuButtonColorPicker.classes";
+import type { MenuButtonTooltipProps } from "./controls/MenuButtonTooltip";
+import type { MenuButtonTooltipClassKey } from "./controls/MenuButtonTooltip.classes";
+import type { MenuControlsContainerProps } from "./controls/MenuControlsContainer";
+import type { MenuControlsContainerClassKey } from "./controls/MenuControlsContainer.classes";
+import type { MenuSelectProps } from "./controls/MenuSelect";
+import type { MenuSelectClassKey } from "./controls/MenuSelect.classes";
+import type { MenuSelectFontFamilyProps } from "./controls/MenuSelectFontFamily";
+import type { MenuSelectFontFamilyClassKey } from "./controls/MenuSelectFontFamily.classes";
+import type { MenuSelectFontSizeProps } from "./controls/MenuSelectFontSize";
+import type { MenuSelectFontSizeClassKey } from "./controls/MenuSelectFontSize.classes";
+import type { MenuSelectHeadingProps } from "./controls/MenuSelectHeading";
+import type { MenuSelectHeadingClassKey } from "./controls/MenuSelectHeading.classes";
+import type { MenuSelectTextAlignProps } from "./controls/MenuSelectTextAlign";
+import type { MenuSelectTextAlignClassKey } from "./controls/MenuSelectTextAlign.classes";
+import type { HeadingWithAnchorComponentProps } from "./extensions/HeadingWithAnchorComponent";
+import type { HeadingWithAnchorComponentClassKey } from "./extensions/HeadingWithAnchorComponent.classes";
+import type { ResizableImageComponentProps } from "./extensions/ResizableImageComponent";
+import type { ResizableImageComponentClassKey } from "./extensions/ResizableImageComponent.classes";
+import type { ResizableImageResizerProps } from "./extensions/ResizableImageResizer";
+import type { ResizableImageResizerClassKey } from "./extensions/ResizableImageResizer.classes";
+
+// Following
+// https://mui.com/material-ui/customization/creating-themed-components/#typescript
+// to allow TypeScript affordances for style overrides.
+
+type Theme = Omit<MuiTheme, "components">;
+
+declare module "@mui/material/styles" {
+  interface ComponentNameToClassKey {
+    "MuiTiptap-ColorPicker": ColorPickerClassKey;
+    "MuiTiptap-ColorPickerPopper": ColorPickerPopperClassKey;
+    "MuiTiptap-ColorSwatchButton": ColorSwatchButtonClassKey;
+    "MuiTiptap-ControlledBubbleMenu": ControlledBubbleMenuClassKey;
+    "MuiTiptap-FieldContainer": FieldContainerClassKey;
+    "MuiTiptap-HeadingWithAnchorComponent": HeadingWithAnchorComponentClassKey;
+    "MuiTiptap-LinkBubbleMenu": LinkBubbleMenuClassKey;
+    "MuiTiptap-MenuBar": MenuBarClassKey;
+    "MuiTiptap-MenuButton": MenuButtonClassKey;
+    "MuiTiptap-MenuButtonColorPicker": MenuButtonColorPickerClassKey;
+    "MuiTiptap-MenuButtonTooltip": MenuButtonTooltipClassKey;
+    "MuiTiptap-MenuControlsContainer": MenuControlsContainerClassKey;
+    "MuiTiptap-MenuDivider": MenuDividerClassKey;
+    "MuiTiptap-MenuSelect": MenuSelectClassKey;
+    "MuiTiptap-MenuSelectFontFamily": MenuSelectFontFamilyClassKey;
+    "MuiTiptap-MenuSelectFontSize": MenuSelectFontSizeClassKey;
+    "MuiTiptap-MenuSelectHeading": MenuSelectHeadingClassKey;
+    "MuiTiptap-MenuSelectTextAlign": MenuSelectTextAlignClassKey;
+    "MuiTiptap-ResizableImageComponent": ResizableImageComponentClassKey;
+    "MuiTiptap-ResizableImageResizer": ResizableImageResizerClassKey;
+    "MuiTiptap-RichTextContent": RichTextContentClassKey;
+    "MuiTiptap-RichTextField": RichTextFieldClassKey;
+    "MuiTiptap-TableBubbleMenu": TableBubbleMenuClassKey;
+    "MuiTiptap-ViewLinkMenuContent": ViewLinkMenuContentClassKey;
+  }
+
+  interface ComponentsPropsList {
+    "MuiTiptap-ColorPicker": Partial<ColorPickerProps>;
+    "MuiTiptap-ColorPickerPopper": Partial<ColorPickerPopperProps>;
+    "MuiTiptap-ColorSwatchButton": Partial<ColorSwatchButtonProps>;
+    "MuiTiptap-ControlledBubbleMenu": Partial<ControlledBubbleMenuProps>;
+    "MuiTiptap-FieldContainer": Partial<FieldContainerProps>;
+    "MuiTiptap-HeadingWithAnchorComponent": Partial<HeadingWithAnchorComponentProps>;
+    "MuiTiptap-LinkBubbleMenu": Partial<LinkBubbleMenuProps>;
+    "MuiTiptap-MenuBar": Partial<MenuBarProps>;
+    "MuiTiptap-MenuButton": Partial<MenuButtonProps>;
+    "MuiTiptap-MenuButtonColorPicker": Partial<MenuButtonColorPickerProps>;
+    "MuiTiptap-MenuButtonTooltip": Partial<MenuButtonTooltipProps>;
+    "MuiTiptap-MenuControlsContainer": Partial<MenuControlsContainerProps>;
+    "MuiTiptap-MenuDivider": Partial<MenuDividerProps>;
+    "MuiTiptap-MenuSelect": Partial<MenuSelectProps<unknown>>;
+    "MuiTiptap-MenuSelectFontFamily": Partial<MenuSelectFontFamilyProps>;
+    "MuiTiptap-MenuSelectFontSize": Partial<MenuSelectFontSizeProps>;
+    "MuiTiptap-MenuSelectHeading": Partial<MenuSelectHeadingProps>;
+    "MuiTiptap-MenuSelectTextAlign": Partial<MenuSelectTextAlignProps>;
+    "MuiTiptap-ResizableImageComponent": Partial<ResizableImageComponentProps>;
+    "MuiTiptap-ResizableImageResizer": Partial<ResizableImageResizerProps>;
+    "MuiTiptap-RichTextContent": Partial<RichTextContentProps>;
+    "MuiTiptap-RichTextField": Partial<RichTextFieldProps>;
+    "MuiTiptap-TableBubbleMenu": Partial<TableBubbleMenuProps>;
+    "MuiTiptap-ViewLinkMenuContent": Partial<ViewLinkMenuContentProps>;
+  }
+
+  interface Components {
+    "MuiTiptap-ColorPicker"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-ColorPicker"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-ColorPicker"];
+      variants?: ComponentsVariants["MuiTiptap-ColorPicker"];
+    };
+    "MuiTiptap-ColorPickerPopper"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-ColorPickerPopper"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-ColorPickerPopper"];
+      variants?: ComponentsVariants["MuiTiptap-ColorPickerPopper"];
+    };
+    "MuiTiptap-ColorSwatchButton"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-ColorSwatchButton"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-ColorSwatchButton"];
+      variants?: ComponentsVariants["MuiTiptap-ColorSwatchButton"];
+    };
+    "MuiTiptap-ControlledBubbleMenu"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-ControlledBubbleMenu"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-ControlledBubbleMenu"];
+      variants?: ComponentsVariants["MuiTiptap-ControlledBubbleMenu"];
+    };
+    "MuiTiptap-FieldContainer"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-FieldContainer"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-FieldContainer"];
+      variants?: ComponentsVariants["MuiTiptap-FieldContainer"];
+    };
+    "MuiTiptap-HeadingWithAnchorComponent"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-HeadingWithAnchorComponent"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-HeadingWithAnchorComponent"];
+      variants?: ComponentsVariants["MuiTiptap-HeadingWithAnchorComponent"];
+    };
+    "MuiTiptap-LinkBubbleMenu"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-LinkBubbleMenu"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-LinkBubbleMenu"];
+      variants?: ComponentsVariants["MuiTiptap-LinkBubbleMenu"];
+    };
+    "MuiTiptap-MenuBar"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-MenuBar"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuBar"];
+      variants?: ComponentsVariants["MuiTiptap-MenuBar"];
+    };
+    "MuiTiptap-MenuButton"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-MenuButton"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuButton"];
+      variants?: ComponentsVariants["MuiTiptap-MenuButton"];
+    };
+    "MuiTiptap-MenuButtonColorPicker"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-MenuButtonColorPicker"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuButtonColorPicker"];
+      variants?: ComponentsVariants["MuiTiptap-MenuButtonColorPicker"];
+    };
+    "MuiTiptap-MenuButtonTooltip"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-MenuButtonTooltip"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuButtonTooltip"];
+      variants?: ComponentsVariants["MuiTiptap-MenuButtonTooltip"];
+    };
+    "MuiTiptap-MenuControlsContainer"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-MenuControlsContainer"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuControlsContainer"];
+      variants?: ComponentsVariants["MuiTiptap-MenuControlsContainer"];
+    };
+    "MuiTiptap-MenuDivider"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-MenuDivider"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuDivider"];
+      variants?: ComponentsVariants["MuiTiptap-MenuDivider"];
+    };
+    "MuiTiptap-MenuSelect"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-MenuSelect"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuSelect"];
+      variants?: ComponentsVariants["MuiTiptap-MenuSelect"];
+    };
+    "MuiTiptap-MenuSelectFontFamily"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-MenuSelectFontFamily"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuSelectFontFamily"];
+      variants?: ComponentsVariants["MuiTiptap-MenuSelectFontFamily"];
+    };
+    "MuiTiptap-MenuSelectFontSize"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-MenuSelectFontSize"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuSelectFontSize"];
+      variants?: ComponentsVariants["MuiTiptap-MenuSelectFontSize"];
+    };
+    "MuiTiptap-MenuSelectHeading"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-MenuSelectHeading"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuSelectHeading"];
+      variants?: ComponentsVariants["MuiTiptap-MenuSelectHeading"];
+    };
+    "MuiTiptap-MenuSelectTextAlign"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-MenuSelectTextAlign"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuSelectTextAlign"];
+      variants?: ComponentsVariants["MuiTiptap-MenuSelectTextAlign"];
+    };
+    "MuiTiptap-ResizableImageComponent"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-ResizableImageComponent"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-ResizableImageComponent"];
+      variants?: ComponentsVariants["MuiTiptap-ResizableImageComponent"];
+    };
+    "MuiTiptap-ResizableImageResizer"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-ResizableImageResizer"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-ResizableImageResizer"];
+      variants?: ComponentsVariants["MuiTiptap-ResizableImageResizer"];
+    };
+    "MuiTiptap-RichTextContent"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-RichTextContent"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-RichTextContent"];
+      variants?: ComponentsVariants["MuiTiptap-RichTextContent"];
+    };
+    "MuiTiptap-RichTextField"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-RichTextField"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-RichTextField"];
+      variants?: ComponentsVariants["MuiTiptap-RichTextField"];
+    };
+    "MuiTiptap-TableBubbleMenu"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-TableBubbleMenu"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-TableBubbleMenu"];
+      variants?: ComponentsVariants["MuiTiptap-TableBubbleMenu"];
+    };
+    "MuiTiptap-ViewLinkMenuContent"?: {
+      defaultProps?: ComponentsPropsList["MuiTiptap-ViewLinkMenuContent"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-ViewLinkMenuContent"];
+      variants?: ComponentsVariants["MuiTiptap-ViewLinkMenuContent"];
+    };
+  }
+}

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -581,7 +581,7 @@ export function getUtilityClass(componentName: string, slot: string): string {
  */
 export function getUtilityClasses<T extends string>(
   componentName: string,
-  slots: ReadonlyArray<T>,
+  slots: T[],
 ): Record<T, string> {
   const result: Record<string, string> = {};
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -542,13 +542,13 @@ export function getImageBackgroundColorStyles(theme: Pick<Theme, "palette">): {
 const COMPONENT_NAME_AND_UTILITY_CLASS_PREFIX = "MuiTiptap-";
 
 /**
- * Get the component name for a given component, used with `styled` to specify
- * the component name used in the MUI `theme` and `styleOverrides`.
+ * Get the utility name for a given component, used with `styled` to specify the
+ * component name used in the MUI `theme` and `styleOverrides`.
  *
  * @param name The name without the prefix, ex: "RichTextContent".
  * @returns The full component name, ex: "MuiTiptap-RichTextContent".
  */
-export function getComponentName(name: string): string {
+export function getUtilityComponentName(name: string): string {
   return `${COMPONENT_NAME_AND_UTILITY_CLASS_PREFIX}${name}`;
 }
 
@@ -567,7 +567,7 @@ export function getComponentName(name: string): string {
  * nested components.
  */
 export function getUtilityClass(componentName: string, slot: string): string {
-  return `${COMPONENT_NAME_AND_UTILITY_CLASS_PREFIX}${componentName}-${slot}`;
+  return `${getUtilityComponentName(componentName)}-${slot}`;
 }
 
 /**

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,12 +1,12 @@
 import {
   alpha,
   darken,
+  keyframes,
   lighten,
   type CSSObject,
   type Theme,
 } from "@mui/material";
 import omit from "lodash/omit";
-import { keyframes } from "tss-react";
 
 type StyleRules = Record<string, CSSObject>;
 
@@ -564,8 +564,7 @@ export function getComponentName(name: string): string {
  * https://mui.com/base-ui/getting-started/customization/#applying-custom-css-rules).
  *
  * A utility class is just used for targeting elements and overriding styles in
- * nested components (rather than us delivering CSS for the utility class
- * directly, since we instead use tss-react to generate CSS).
+ * nested components.
  */
 export function getUtilityClass(componentName: string, slot: string): string {
   return `${COMPONENT_NAME_AND_UTILITY_CLASS_PREFIX}${componentName}-${slot}`;
@@ -576,8 +575,7 @@ export function getUtilityClass(componentName: string, slot: string): string {
  * that component.
  *
  * These returned utility classes are used for targeting and overriding styles
- * in nested components (rather than us delivering CSS for the utility classes
- * directly, since we instead use tss-react to generate CSS).
+ * in nested components.
  *
  * Ex: {"root": "MuiTiptap-Foo-root"} for the <Foo /> component.
  */

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -535,7 +535,22 @@ export function getImageBackgroundColorStyles(theme: Pick<Theme, "palette">): {
   };
 }
 
-const UTILITY_CLASS_PREFIX_DEFAULT = "MuiTiptap-";
+/**
+ * The default prefix for all styled component names (used by consumers in `styleOverrides`)
+ * and utility classes generated for mui-tiptap components.
+ */
+const COMPONENT_NAME_AND_UTILITY_CLASS_PREFIX = "MuiTiptap-";
+
+/**
+ * Get the component name for a given component, used with `styled` to specify
+ * the component name used in the MUI `theme` and `styleOverrides`.
+ *
+ * @param name The name without the prefix, ex: "RichTextContent".
+ * @returns The full component name, ex: "MuiTiptap-RichTextContent".
+ */
+export function getComponentName(name: string): string {
+  return `${COMPONENT_NAME_AND_UTILITY_CLASS_PREFIX}${name}`;
+}
 
 /**
  * Get a utility class of the form "MuiTiptap-Foo-root" for the <Foo />
@@ -553,7 +568,7 @@ const UTILITY_CLASS_PREFIX_DEFAULT = "MuiTiptap-";
  * directly, since we instead use tss-react to generate CSS).
  */
 export function getUtilityClass(componentName: string, slot: string): string {
-  return `${UTILITY_CLASS_PREFIX_DEFAULT}${componentName}-${slot}`;
+  return `${COMPONENT_NAME_AND_UTILITY_CLASS_PREFIX}${componentName}-${slot}`;
 }
 
 /**
@@ -568,7 +583,7 @@ export function getUtilityClass(componentName: string, slot: string): string {
  */
 export function getUtilityClasses<T extends string>(
   componentName: string,
-  slots: T[],
+  slots: ReadonlyArray<T>,
 ): Record<T, string> {
   const result: Record<string, string> = {};
 


### PR DESCRIPTION
Resolves #378, #205

This PR:
- Switches to using MUI's `styled` utility for applying all its styling
- Removes the direct dependency `tss-react`, which as of the prior version of mui-tiptap was 22.7% of the bundle size impact (https://bundlephobia.com/package/mui-tiptap@1.23.1). (The size of mui-tiptap itself has gone up here a more marginal amount ~9%, seemingly mostly due to the fact that we now utilize utility classes across more components to make customization easier; see below.)
- Allows for theme-based `styleOverrides` for mui-tiptap components and slots (see bullet 2 in the new "Style customization" section of the README)
- Adds utility classes across more components, exports them for direct programmatic use by consumers (rather than hardcoding class names), and officially documents them (see bullet 3 in the new "Style customization" in the README)

There may be some slight specificity changes to CSS rules (both for some rules themselves and also due to how `tss-react` vs `styled` apply/merge styles), but I've tried to preserve all prior visuals within mui-tiptap itself.