### PR TITLE
Validate minimum TS version in CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,6 +29,16 @@ jobs:
         # version used in our lockfile, an older version we support, the latest
         # v2 version, and the latest v3 major.
         tiptap-version: [null, 2.0.4, "^2.10.0", "^3.0.0"]
+        # Test with current TypeScript (from package.json) and an older version
+        # for backward compatibility. We only test the old TS version against
+        # the current repo Tiptap version and one older version to avoid
+        # excessive matrix combinations.
+        typescript-version: [null, 4.9]
+        exclude:
+          - tiptap-version: "^2.10.0"
+            typescript-version: 4.9
+          - tiptap-version: "^3.0.0"
+            typescript-version: 4.9
         include:
           # Specify the version of y-prosemirror to use to ensure proper peer
           # dependency compatibility and resolution on older Tiptap versions.
@@ -56,6 +66,10 @@ jobs:
           cache: "pnpm"
 
       - run: pnpm install
+
+      - if: ${{ matrix.typescript-version != null }}
+        name: Install TypeScript ${{ matrix.typescript-version }}
+        run: pnpm add -D "typescript@${{ matrix.typescript-version }}"
 
       - name: Dependencies audit
         run: pnpm audit --audit-level=high

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,14 +26,15 @@ jobs:
     strategy:
       matrix:
         node-version: [20]
-        # Test across different versions of Tiptap to ensure compatibility: the
+        # Run against different versions of Tiptap to ensure compatibility: the
         # version used in our lockfile, an older version we support, the latest
         # v2 version, and the latest v3 major.
         tiptap-version: [null, 2.0.4, "^2.10.0", "^3.0.0"]
-        # Test with current TypeScript (from package.json) and an older version
-        # for backward compatibility. We only test the old TS version against
-        # the current repo Tiptap version and one older version to avoid
-        # excessive matrix combinations.
+        # Run against this package's TS version, as well as the minimum TS
+        # version that MUI supports, based on DefinitelyType's support window
+        # (https://mui.com/material-ui/getting-started/supported-platforms/#typescript).
+        # We skip testing against some combinations of TS+Tiptap versions to
+        # avoid excessive CI runs.
         typescript-version: [null, 4.9]
         exclude:
           - tiptap-version: "^2.10.0"
@@ -70,7 +71,10 @@ jobs:
 
       - if: ${{ matrix.typescript-version != null }}
         name: Install TypeScript ${{ matrix.typescript-version }}
-        run: pnpm add -D "typescript@${{ matrix.typescript-version }}"
+        # Install in both projects for consistent linting
+        run: |
+          pnpm add -D "typescript@${{ matrix.typescript-version }}"
+          pnpm --dir example add -D "typescript@${{ matrix.typescript-version }}"
 
       - name: Dependencies audit
         run: pnpm audit --audit-level=high

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   build_and_test:
+    name: tiptap=${{ matrix.tiptap-version || 'current' }}, TS=${{ matrix.typescript-version || 'current' }}
     # Dedupe PRs from branches created by collaborators within this repo:
     # - Always run for internal branch `push` (for/before a PR) and
     # `workflow_call` (releases).
@@ -140,7 +141,10 @@ jobs:
         # also like to type-check.
         run: pnpm run type:check
 
-      - name: Format check
+      # prettier's organize-imports plugin depends on TypeScript, so we only run
+      # format-checking against the current TS version
+      - if: ${{ matrix.typescript-version == null }}
+        name: Format check
         run: pnpm run format:check
 
       - name: Lint check

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -6,8 +6,7 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
As an extra guarantee of correctness, to make it easier to confidently bump TS in the dev dependencies of the package without worrying about breaking things for users on older TS.