### PR TITLE
Avoid passing `innerRef` when not defined

### DIFF
--- a/src/RichTextContent.tsx
+++ b/src/RichTextContent.tsx
@@ -106,8 +106,9 @@ export default function RichTextContent(inProps: RichTextContentProps) {
   return (
     <RichTextContentRoot
       editor={editor}
-      // Use spread for innerRef to avoid TS errors in Tiptap < 2.2.0
-      {...{ innerRef }}
+      // Use spread for innerRef to avoid TS errors in Tiptap < 2.2.0, and only
+      // include if present
+      {...(innerRef ? { innerRef } : {})}
       ownerState={ownerState}
       className={editorClasses}
       sx={sx}


### PR DESCRIPTION
Otherwise in older Tiptap v2 versions, this will result in a React error about `innerRef` not being a supported prop.