### PR TITLE
Render empty string `alt`/`title` attrs if explicitly set for `ResizableImage`

### DIFF
--- a/src/extensions/ResizableImageComponent.tsx
+++ b/src/extensions/ResizableImageComponent.tsx
@@ -219,8 +219,8 @@ function ResizableImageComponent(inProps: ResizableImageComponentProps) {
           height="auto"
           width={attrs.width ? attrs.width : undefined}
           {...{
-            alt: attrs.alt || undefined,
-            title: attrs.title || undefined,
+            alt: attrs.alt ?? undefined,
+            title: attrs.title ?? undefined,
           }}
           className={clsx([
             resizableImageComponentClasses.image,


### PR DESCRIPTION
Fixes https://github.com/sjdemartini/mui-tiptap/issues/453

Empty string `title` does have a specific purpose
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/title#title_attribute_inheritance, so we may as well support it too.