### PR TITLE
Make HeadingWithAnchor autoscroll work consistently on Tiptap 3.6+

### DIFF
--- a/src/extensions/HeadingWithAnchor.ts
+++ b/src/extensions/HeadingWithAnchor.ts
@@ -97,7 +97,7 @@ export function scrollToCurrentHeadingAnchor(editor: Editor) {
 
   // We'll only scroll if the given hash points to an element that's part of our
   // editor content (i.e., ignore external anchors)
-  if (elementForHash && editor.options.element?.contains(elementForHash)) {
+  if (elementForHash && editor.view.dom.contains(elementForHash)) {
     elementForHash.scrollIntoView({
       behavior: "smooth",
       block: "start",


### PR DESCRIPTION
`editor.options.element` wasn't the most precise way of checking this, though did the trick. As of Tiptap 3.6 though, that option is more dynamic (https://github.com/ueberdosis/tiptap/releases/tag/v3.6.0), so we must use the view. Should've really been `editor.view.dom` all along.

Revealed in
https://github.com/sjdemartini/mui-tiptap/actions/runs/18062457728/job/51400637779

Tested autoscroll in the demo with this quick diff:

```diff
diff --git a/src/demo/Editor.tsx b/src/demo/Editor.tsx
index fe820aa..cd0e8c1 100644
--- a/src/demo/Editor.tsx
+++ b/src/demo/Editor.tsx
@@ -6,7 +6,7 @@ import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import type { EditorOptions } from "@tiptap/core";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   LinkBubbleMenu,
   MenuButton,
@@ -129,12 +129,19 @@ export default function Editor({ disableStickyMenuBar }: Props) {
 
   const [submittedContent, setSubmittedContent] = useState("");
 
+  const [showSubmitted, setShowSubmitted] = useState(false);
+  useEffect(() => {
+    setTimeout(() => {
+      setShowSubmitted(true);
+    }, 2000);
+  }, []);
+
   return (
     <>
       <RichTextEditor
         ref={rteRef}
         extensions={extensions}
-        content={exampleContent}
+        // content={exampleContent}
         editable={isEditable}
         editorProps={{
           handleDrop: handleDrop,
@@ -230,7 +237,7 @@ export default function Editor({ disableStickyMenuBar }: Props) {
         Saved result:
       </Typography>
 
-      {submittedContent ? (
+      {showSubmitted ? (
         <>
           <pre style={{ marginTop: 10, overflow: "auto", maxWidth: "100%" }}>
             <code>{submittedContent}</code>
@@ -242,7 +249,7 @@ export default function Editor({ disableStickyMenuBar }: Props) {
             </Typography>
 
             <RichTextReadOnly
-              content={submittedContent}
+              content={exampleContent}
               extensions={extensions}
             />
           </Box>
```