### PR TITLE
Ensure npm version supports OIDC and fix package.json repo format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,11 @@ jobs:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
 
+      # Ensure npm 11.5.1 or later is installed
+      # (https://docs.npmjs.com/trusted-publishers#github-actions-configuration)
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - run: pnpm install
 
       - run: pnpm run build

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
   "homepage": "https://github.com/sjdemartini/mui-tiptap",
   "bugs": "https://github.com/sjdemartini/mui-tiptap/issues",
   "author": "Steven DeMartini <sjdemartini@users.noreply.github.com>",
-  "repository": "github:sjdemartini/mui-tiptap",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sjdemartini/mui-tiptap.git"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Should presumably fix
https://github.com/sjdemartini/mui-tiptap/actions/runs/18438933742/job/52537010201#step:7:558 and resolve this warning about the package.json format https://github.com/sjdemartini/mui-tiptap/actions/runs/18438933742/job/52537010201#step:7:24 (fixed with `npm pkg fix` as suggested).