### PR TITLE
Fix element type and styling of field container outline

### DIFF
--- a/src/FieldContainer.tsx
+++ b/src/FieldContainer.tsx
@@ -68,7 +68,7 @@ const FieldContainerRoot = styled(Box, {
   }),
 }));
 
-const FieldContainerNotchedOutline = styled("fieldset", {
+const FieldContainerNotchedOutline = styled("div", {
   name: componentName,
   slot: "notchedOutline" satisfies FieldContainerClassKey,
   overridesResolver: (props, styles) => styles.notchedOutline,


### PR DESCRIPTION
The element type was mistakenly changed in https://github.com/sjdemartini/mui-tiptap/pull/435/files#diff-63968e8195976fb3684757ba90476f5a3f9ba23dabc4e8872a4edf041fba486bL131, so visuals were subtly due to the outline having the wrong width since v1.24.0

### v1.24.0 - v1.28.0

Notice that the menu bar's bottom border extends beyond the notched outline, since the notched outline element is too narrow

<img width="1223" height="75" alt="Screenshot 2025-10-12 124544" src="https://github.com/user-attachments/assets/fc3b32ee-5379-4fab-9b5f-2ed8b3b69b2f" />


### After this PR

<img width="1197" height="70" alt="Screenshot 2025-10-12 124606" src="https://github.com/user-attachments/assets/94de77cc-44cb-498d-a400-e55fc27f7648" />
