### PR TITLE
Show the default mark color when opening highlight color-picker

### DIFF
--- a/src/controls/MenuButtonColorPicker.tsx
+++ b/src/controls/MenuButtonColorPicker.tsx
@@ -25,8 +25,12 @@ export type MenuButtonColorPickerProps = Omit<
 > & {
   /** The current CSS color string value. */
   value: string | undefined;
-  /** The value the color picker uses initially when no color has been chosen previously */
-  initialColorValue?: string;
+  /**
+   * The color shown in the color picker when it opens, if `value` is empty.
+   * Does not affect the button's color indicator bar (which remains transparent
+   * when `value` is empty).
+   */
+  defaultPickerColor?: string;
   /** Callback when the color changes. */
   onChange: (newColor: string) => void;
   /**
@@ -125,7 +129,7 @@ export default function MenuButtonColorPicker(
   const props = useThemeProps({ props: inProps, name: componentName });
   const {
     value: colorValue,
-    initialColorValue,
+    defaultPickerColor,
     onChange,
     swatchColors,
     labels,
@@ -203,7 +207,7 @@ export default function MenuButtonColorPicker(
         id={popperId}
         open={!!anchorEl}
         anchorEl={anchorEl}
-        value={colorValue || initialColorValue || ""}
+        value={colorValue || defaultPickerColor || ""}
         onSave={(newColor) => {
           onChange(newColor);
           handleClose();

--- a/src/controls/MenuButtonHighlightColor.tsx
+++ b/src/controls/MenuButtonHighlightColor.tsx
@@ -50,7 +50,7 @@ export default function MenuButtonHighlightColor({
       tooltipLabel="Highlight color"
       tooltipShortcutKeys={["mod", "Shift", "H"]}
       value={currentHighlightColor}
-      initialColorValue={defaultMarkColor}
+      defaultPickerColor={defaultMarkColor}
       onChange={(newColor) => {
         if (newColor) {
           editor?.chain().focus().setHighlight({ color: newColor }).run();


### PR DESCRIPTION
Use the defaultMarkColor when the highlight button is clicked instead of black when the button is first clicked, similar to how the keyboard binding works similarly to how the text color button works.
~~This also makes it so the icon has a defaultMarkColor bar under it before you have picked a color which helps identify what the button does.~~