### PR TITLE
Improve MenuSelect aria-label behavior and a11y demo examples

### DIFF
--- a/src/RichTextEditor.tsx
+++ b/src/RichTextEditor.tsx
@@ -113,18 +113,12 @@ const RichTextEditor = forwardRef<RichTextEditorRef, RichTextEditorProps>(
       // behavior without requiring consumer changes, and including it should be
       // harmless in v2 versions that predate this option.
       shouldRerenderOnTransaction = true,
-      editorProps = {
-        attributes: {
-          "aria-label": "Editor Content",
-        },
-      },
       ...editorOptions
     }: RichTextEditorProps,
     ref,
   ) {
     const mergedEditorOptions = {
       editable,
-      editorProps,
       shouldRerenderOnTransaction,
       ...editorOptions,
     } satisfies UseEditorOptions;

--- a/src/controls/MenuSelect.tsx
+++ b/src/controls/MenuSelect.tsx
@@ -85,14 +85,7 @@ const MenuSelectTooltip = styled(MenuButtonTooltip, {
 /** A Select that is styled to work well with other menu bar controls. */
 export default function MenuSelect<T>(inProps: MenuSelectProps<T>) {
   const props = useThemeProps({ props: inProps, name: componentName });
-  const {
-    tooltipTitle,
-    classes = {},
-    sx,
-    "aria-label": ariaLabel = tooltipTitle,
-    slotProps = { input: { "aria-label": ariaLabel } },
-    ...selectProps
-  } = props;
+  const { tooltipTitle, classes = {}, sx, ...selectProps } = props;
 
   // We use a controlled tooltip here because otherwise it seems the tooltip can
   // get stuck open after selecting something (as it can re-trigger the
@@ -106,8 +99,15 @@ export default function MenuSelect<T>(inProps: MenuSelectProps<T>) {
       margin="none"
       variant="outlined"
       size="small"
-      slotProps={slotProps}
       {...selectProps}
+      inputProps={{
+        // Fall back to tooltipTitle as an accessible name for the combobox
+        // element if no aria-label is provided via `inputProps` or
+        // `slotProps.input`. Note that neither the Tooltip itself nor a
+        // top-level aria-label on Select would reach the combobox.
+        "aria-label": tooltipTitle,
+        ...selectProps.inputProps,
+      }}
       onMouseEnter={(...args) => {
         setTooltipOpen(true);
         selectProps.onMouseEnter?.(...args);

--- a/src/controls/MenuSelectFontFamily.tsx
+++ b/src/controls/MenuSelectFontFamily.tsx
@@ -183,7 +183,6 @@ export default function MenuSelectFontFamily(
         return options.find((option) => option.value === value)?.label ?? value;
       }}
       displayEmpty
-      aria-label="Font families"
       tooltipTitle="Font"
       {...menuSelectProps}
       // We don't want to pass any non-string falsy values here, always falling

--- a/src/controls/MenuSelectFontSize.tsx
+++ b/src/controls/MenuSelectFontSize.tsx
@@ -247,7 +247,6 @@ export default function MenuSelectFontSize(inProps: MenuSelectFontSizeProps) {
         return stripPxFromValue(value);
       }}
       displayEmpty
-      aria-label="Font sizes"
       tooltipTitle="Font size"
       {...menuSelectProps}
       // We don't want to pass any non-string falsy values here, always falling

--- a/src/controls/MenuSelectHeading.tsx
+++ b/src/controls/MenuSelectHeading.tsx
@@ -333,7 +333,6 @@ export default function MenuSelectHeading(inProps: MenuSelectHeadingProps) {
         }
         return result ?? selected;
       }}
-      aria-label="Text headings"
       tooltipTitle="Styles"
       {...menuSelectProps}
       value={selectedValue}

--- a/src/controls/MenuSelectTextAlign.tsx
+++ b/src/controls/MenuSelectTextAlign.tsx
@@ -270,7 +270,6 @@ export default function MenuSelectTextAlign(inProps: MenuSelectTextAlignProps) {
           </span>
         );
       }}
-      aria-label="Text alignments"
       tooltipTitle="Align"
       value={selectedValue}
       displayEmpty

--- a/src/demo/App.tsx
+++ b/src/demo/App.tsx
@@ -68,7 +68,11 @@ export default function App() {
             <IconButton
               onClick={togglePaletteMode}
               color="inherit"
-              aria-label="Dark mode toggle"
+              aria-label={
+                theme.palette.mode === "dark"
+                  ? "Switch to light mode"
+                  : "Switch to dark mode"
+              }
             >
               {theme.palette.mode === "dark" ? (
                 <Brightness7Icon />
@@ -80,7 +84,7 @@ export default function App() {
         </Toolbar>
       </AppBar>
 
-      <Box sx={{ p: 3, maxWidth: 1207, margin: "0 auto" }}>
+      <Box component="main" sx={{ p: 3, maxWidth: 1207, margin: "0 auto" }}>
         <Editor />
       </Box>
 

--- a/src/demo/Editor.tsx
+++ b/src/demo/Editor.tsx
@@ -137,6 +137,11 @@ export default function Editor({ disableStickyMenuBar }: Props) {
         content={exampleContent}
         editable={isEditable}
         editorProps={{
+          attributes: {
+            // For accessibility, you can provide an aria-label to the editor's
+            // contenteditable element
+            "aria-label": "Main editor content",
+          },
           handleDrop: handleDrop,
           handlePaste: handlePaste,
         }}
@@ -226,7 +231,7 @@ export default function Editor({ disableStickyMenuBar }: Props) {
         )}
       </RichTextEditor>
 
-      <Typography variant="h5" sx={{ mt: 5 }}>
+      <Typography variant="h5" component="h2" sx={{ mt: 5 }}>
         Saved result:
       </Typography>
 


### PR DESCRIPTION
There are a few accessibility issues that show up in the chrome devtools lighthouse accessibility analysis if you do not do anything to fix them in the client code.  This provides some reasonable defaults.

* MenuSelect don't have an aria-label on them (it needs to go on the input slot)
* The actual contenteditable area needs a label
* The demo has an unlabeled button

