### PR TITLE
Switch slotted component names from MuiTiptap-Foo to MuiTiptapFoo #479

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ You can override styles in several different ways, following standard [MUI conve
    const theme = createTheme({
      components: {
        // Override the behavior for the mui-tiptap `FieldContainer`
-       "MuiTiptap-FieldContainer": {
+       MuiTiptapFieldContainer: {
          defaultProps: {
            // If no `variant` value is set, use "standard"
            variant: "standard",
@@ -398,9 +398,9 @@ You can override styles in several different ways, following standard [MUI conve
 
 4. Apply styles based on utility class names of mui-tiptap components. These are useful for applying CSS externally, or for nested component styling when using `sx` or `styleOverrides`.
 
-   For instance, for the `RichTextField` component, the `"MuiTiptap-RichTextField-root"` class name is applied to its root element, a separate class will be included on that element based on the current variant (like `"MuiTiptap-RichTextField-outlined"`), and its inner content element gets the `"MuiTiptap-RichTextField-content"` class.
+   For instance, for the `RichTextField` component, the `"MuiTiptapRichTextField-root"` class name is applied to its root element, a separate class will be included on that element based on the current variant (like `"MuiTiptap-RichTextField-outlined"`), and its inner content element gets the `"MuiTiptap-RichTextField-content"` class.
 
-   You can import helper objects from mui-tiptap to avoid hard-coding these, like `import { richTextFieldClasses } from "mui-tiptap";`, and access them like `richTextFieldClasses.content` for the `"MuiTiptap-RichTextField-content"` value.
+   You can import helper objects from mui-tiptap to avoid hard-coding these, like `import { richTextFieldClasses } from "mui-tiptap";`, and access them like `richTextFieldClasses.content` for the `"MuiTiptapRichTextField-content"` value.
 
 ## Localization
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -33,7 +33,7 @@ export default function App() {
         },
 
         components: {
-          "MuiTiptap-MenuBar": {
+          MuiTiptapMenuBar: {
             styleOverrides: {
               root: ({ theme }) => ({
                 backgroundColor:

--- a/src/__tests__/styles.test.ts
+++ b/src/__tests__/styles.test.ts
@@ -8,29 +8,27 @@ import {
 describe("getUtilityComponentName()", () => {
   it("returns component name with MuiTiptap prefix", () => {
     expect(getUtilityComponentName("RichTextContent")).toBe(
-      "MuiTiptap-RichTextContent",
+      "MuiTiptapRichTextContent",
     );
-    expect(getUtilityComponentName("MenuButton")).toBe("MuiTiptap-MenuButton");
-    expect(getUtilityComponentName("ColorPicker")).toBe(
-      "MuiTiptap-ColorPicker",
-    );
+    expect(getUtilityComponentName("MenuButton")).toBe("MuiTiptapMenuButton");
+    expect(getUtilityComponentName("ColorPicker")).toBe("MuiTiptapColorPicker");
   });
 });
 
 describe("getUtilityClass()", () => {
   it("returns utility class with component name and slot", () => {
-    expect(getUtilityClass("Foo", "root")).toBe("MuiTiptap-Foo-root");
+    expect(getUtilityClass("Foo", "root")).toBe("MuiTiptapFoo-root");
     expect(getUtilityClass("RichTextField", "content")).toBe(
-      "MuiTiptap-RichTextField-content",
+      "MuiTiptapRichTextField-content",
     );
   });
 
   it("handles special characters in component name and slot", () => {
     expect(getUtilityClass("MenuFoo", "sub-element")).toBe(
-      "MuiTiptap-MenuFoo-sub-element",
+      "MuiTiptapMenuFoo-sub-element",
     );
     expect(getUtilityClass("MenuFoo", "sub_element")).toBe(
-      "MuiTiptap-MenuFoo-sub_element",
+      "MuiTiptapMenuFoo-sub_element",
     );
   });
 });
@@ -39,8 +37,8 @@ describe("getUtilityClasses()", () => {
   it("returns record mapping slots to utility classes", () => {
     const result = getUtilityClasses("Foo", ["root", "disabled"]);
     expect(result).toEqual({
-      root: "MuiTiptap-Foo-root",
-      disabled: "MuiTiptap-Foo-disabled",
+      root: "MuiTiptapFoo-root",
+      disabled: "MuiTiptapFoo-disabled",
     });
   });
 

--- a/src/controls/ColorPicker.tsx
+++ b/src/controls/ColorPicker.tsx
@@ -118,7 +118,7 @@ export type ColorPickerProps = {
    *
    * And in your CSS:
    *
-   *   .MuiTiptap-ColorPicker-swatchContainer.hide {
+   *   .MuiTiptapColorPicker-swatchContainer.hide {
    *     display: none;
    *   }
    */

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -60,179 +60,179 @@ type Theme = Omit<MuiTheme, "components">;
 
 declare module "@mui/material/styles" {
   interface ComponentNameToClassKey {
-    "MuiTiptap-ColorPicker": ColorPickerClassKey;
-    "MuiTiptap-ColorPickerPopper": ColorPickerPopperClassKey;
-    "MuiTiptap-ColorSwatchButton": ColorSwatchButtonClassKey;
-    "MuiTiptap-ControlledBubbleMenu": ControlledBubbleMenuClassKey;
-    "MuiTiptap-FieldContainer": FieldContainerClassKey;
-    "MuiTiptap-HeadingWithAnchorComponent": HeadingWithAnchorComponentClassKey;
-    "MuiTiptap-LinkBubbleMenu": LinkBubbleMenuClassKey;
-    "MuiTiptap-MenuBar": MenuBarClassKey;
-    "MuiTiptap-MenuButton": MenuButtonClassKey;
-    "MuiTiptap-MenuButtonColorPicker": MenuButtonColorPickerClassKey;
-    "MuiTiptap-MenuButtonTooltip": MenuButtonTooltipClassKey;
-    "MuiTiptap-MenuControlsContainer": MenuControlsContainerClassKey;
-    "MuiTiptap-MenuDivider": MenuDividerClassKey;
-    "MuiTiptap-MenuSelect": MenuSelectClassKey;
-    "MuiTiptap-MenuSelectFontFamily": MenuSelectFontFamilyClassKey;
-    "MuiTiptap-MenuSelectFontSize": MenuSelectFontSizeClassKey;
-    "MuiTiptap-MenuSelectHeading": MenuSelectHeadingClassKey;
-    "MuiTiptap-MenuSelectTextAlign": MenuSelectTextAlignClassKey;
-    "MuiTiptap-ResizableImageComponent": ResizableImageComponentClassKey;
-    "MuiTiptap-ResizableImageResizer": ResizableImageResizerClassKey;
-    "MuiTiptap-RichTextContent": RichTextContentClassKey;
-    "MuiTiptap-RichTextField": RichTextFieldClassKey;
-    "MuiTiptap-TableBubbleMenu": TableBubbleMenuClassKey;
-    "MuiTiptap-ViewLinkMenuContent": ViewLinkMenuContentClassKey;
+    MuiTiptapColorPicker: ColorPickerClassKey;
+    MuiTiptapColorPickerPopper: ColorPickerPopperClassKey;
+    MuiTiptapColorSwatchButton: ColorSwatchButtonClassKey;
+    MuiTiptapControlledBubbleMenu: ControlledBubbleMenuClassKey;
+    MuiTiptapFieldContainer: FieldContainerClassKey;
+    MuiTiptapHeadingWithAnchorComponent: HeadingWithAnchorComponentClassKey;
+    MuiTiptapLinkBubbleMenu: LinkBubbleMenuClassKey;
+    MuiTiptapMenuBar: MenuBarClassKey;
+    MuiTiptapMenuButton: MenuButtonClassKey;
+    MuiTiptapMenuButtonColorPicker: MenuButtonColorPickerClassKey;
+    MuiTiptapMenuButtonTooltip: MenuButtonTooltipClassKey;
+    MuiTiptapMenuControlsContainer: MenuControlsContainerClassKey;
+    MuiTiptapMenuDivider: MenuDividerClassKey;
+    MuiTiptapMenuSelect: MenuSelectClassKey;
+    MuiTiptapMenuSelectFontFamily: MenuSelectFontFamilyClassKey;
+    MuiTiptapMenuSelectFontSize: MenuSelectFontSizeClassKey;
+    MuiTiptapMenuSelectHeading: MenuSelectHeadingClassKey;
+    MuiTiptapMenuSelectTextAlign: MenuSelectTextAlignClassKey;
+    MuiTiptapResizableImageComponent: ResizableImageComponentClassKey;
+    MuiTiptapResizableImageResizer: ResizableImageResizerClassKey;
+    MuiTiptapRichTextContent: RichTextContentClassKey;
+    MuiTiptapRichTextField: RichTextFieldClassKey;
+    MuiTiptapTableBubbleMenu: TableBubbleMenuClassKey;
+    MuiTiptapViewLinkMenuContent: ViewLinkMenuContentClassKey;
   }
 
   interface ComponentsPropsList {
-    "MuiTiptap-ColorPicker": Partial<ColorPickerProps>;
-    "MuiTiptap-ColorPickerPopper": Partial<ColorPickerPopperProps>;
-    "MuiTiptap-ColorSwatchButton": Partial<ColorSwatchButtonProps>;
-    "MuiTiptap-ControlledBubbleMenu": Partial<ControlledBubbleMenuProps>;
-    "MuiTiptap-FieldContainer": Partial<FieldContainerProps>;
-    "MuiTiptap-HeadingWithAnchorComponent": Partial<HeadingWithAnchorComponentProps>;
-    "MuiTiptap-LinkBubbleMenu": Partial<LinkBubbleMenuProps>;
-    "MuiTiptap-MenuBar": Partial<MenuBarProps>;
-    "MuiTiptap-MenuButton": Partial<MenuButtonProps>;
-    "MuiTiptap-MenuButtonColorPicker": Partial<MenuButtonColorPickerProps>;
-    "MuiTiptap-MenuButtonTooltip": Partial<MenuButtonTooltipProps>;
-    "MuiTiptap-MenuControlsContainer": Partial<MenuControlsContainerProps>;
-    "MuiTiptap-MenuDivider": Partial<MenuDividerProps>;
-    "MuiTiptap-MenuSelect": Partial<MenuSelectProps<unknown>>;
-    "MuiTiptap-MenuSelectFontFamily": Partial<MenuSelectFontFamilyProps>;
-    "MuiTiptap-MenuSelectFontSize": Partial<MenuSelectFontSizeProps>;
-    "MuiTiptap-MenuSelectHeading": Partial<MenuSelectHeadingProps>;
-    "MuiTiptap-MenuSelectTextAlign": Partial<MenuSelectTextAlignProps>;
-    "MuiTiptap-ResizableImageComponent": Partial<ResizableImageComponentProps>;
-    "MuiTiptap-ResizableImageResizer": Partial<ResizableImageResizerProps>;
-    "MuiTiptap-RichTextContent": Partial<RichTextContentProps>;
-    "MuiTiptap-RichTextField": Partial<RichTextFieldProps>;
-    "MuiTiptap-TableBubbleMenu": Partial<TableBubbleMenuProps>;
-    "MuiTiptap-ViewLinkMenuContent": Partial<ViewLinkMenuContentProps>;
+    MuiTiptapColorPicker: Partial<ColorPickerProps>;
+    MuiTiptapColorPickerPopper: Partial<ColorPickerPopperProps>;
+    MuiTiptapColorSwatchButton: Partial<ColorSwatchButtonProps>;
+    MuiTiptapControlledBubbleMenu: Partial<ControlledBubbleMenuProps>;
+    MuiTiptapFieldContainer: Partial<FieldContainerProps>;
+    MuiTiptapHeadingWithAnchorComponent: Partial<HeadingWithAnchorComponentProps>;
+    MuiTiptapLinkBubbleMenu: Partial<LinkBubbleMenuProps>;
+    MuiTiptapMenuBar: Partial<MenuBarProps>;
+    MuiTiptapMenuButton: Partial<MenuButtonProps>;
+    MuiTiptapMenuButtonColorPicker: Partial<MenuButtonColorPickerProps>;
+    MuiTiptapMenuButtonTooltip: Partial<MenuButtonTooltipProps>;
+    MuiTiptapMenuControlsContainer: Partial<MenuControlsContainerProps>;
+    MuiTiptapMenuDivider: Partial<MenuDividerProps>;
+    MuiTiptapMenuSelect: Partial<MenuSelectProps<unknown>>;
+    MuiTiptapMenuSelectFontFamily: Partial<MenuSelectFontFamilyProps>;
+    MuiTiptapMenuSelectFontSize: Partial<MenuSelectFontSizeProps>;
+    MuiTiptapMenuSelectHeading: Partial<MenuSelectHeadingProps>;
+    MuiTiptapMenuSelectTextAlign: Partial<MenuSelectTextAlignProps>;
+    MuiTiptapResizableImageComponent: Partial<ResizableImageComponentProps>;
+    MuiTiptapResizableImageResizer: Partial<ResizableImageResizerProps>;
+    MuiTiptapRichTextContent: Partial<RichTextContentProps>;
+    MuiTiptapRichTextField: Partial<RichTextFieldProps>;
+    MuiTiptapTableBubbleMenu: Partial<TableBubbleMenuProps>;
+    MuiTiptapViewLinkMenuContent: Partial<ViewLinkMenuContentProps>;
   }
 
   interface Components {
-    "MuiTiptap-ColorPicker"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-ColorPicker"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-ColorPicker"];
-      variants?: ComponentsVariants["MuiTiptap-ColorPicker"];
+    MuiTiptapColorPicker?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapColorPicker"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapColorPicker"];
+      variants?: ComponentsVariants["MuiTiptapColorPicker"];
     };
-    "MuiTiptap-ColorPickerPopper"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-ColorPickerPopper"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-ColorPickerPopper"];
-      variants?: ComponentsVariants["MuiTiptap-ColorPickerPopper"];
+    MuiTiptapColorPickerPopper?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapColorPickerPopper"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapColorPickerPopper"];
+      variants?: ComponentsVariants["MuiTiptapColorPickerPopper"];
     };
-    "MuiTiptap-ColorSwatchButton"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-ColorSwatchButton"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-ColorSwatchButton"];
-      variants?: ComponentsVariants["MuiTiptap-ColorSwatchButton"];
+    MuiTiptapColorSwatchButton?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapColorSwatchButton"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapColorSwatchButton"];
+      variants?: ComponentsVariants["MuiTiptapColorSwatchButton"];
     };
-    "MuiTiptap-ControlledBubbleMenu"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-ControlledBubbleMenu"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-ControlledBubbleMenu"];
-      variants?: ComponentsVariants["MuiTiptap-ControlledBubbleMenu"];
+    MuiTiptapControlledBubbleMenu?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapControlledBubbleMenu"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapControlledBubbleMenu"];
+      variants?: ComponentsVariants["MuiTiptapControlledBubbleMenu"];
     };
-    "MuiTiptap-FieldContainer"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-FieldContainer"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-FieldContainer"];
-      variants?: ComponentsVariants["MuiTiptap-FieldContainer"];
+    MuiTiptapFieldContainer?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapFieldContainer"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapFieldContainer"];
+      variants?: ComponentsVariants["MuiTiptapFieldContainer"];
     };
-    "MuiTiptap-HeadingWithAnchorComponent"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-HeadingWithAnchorComponent"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-HeadingWithAnchorComponent"];
-      variants?: ComponentsVariants["MuiTiptap-HeadingWithAnchorComponent"];
+    MuiTiptapHeadingWithAnchorComponent?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapHeadingWithAnchorComponent"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapHeadingWithAnchorComponent"];
+      variants?: ComponentsVariants["MuiTiptapHeadingWithAnchorComponent"];
     };
-    "MuiTiptap-LinkBubbleMenu"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-LinkBubbleMenu"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-LinkBubbleMenu"];
-      variants?: ComponentsVariants["MuiTiptap-LinkBubbleMenu"];
+    MuiTiptapLinkBubbleMenu?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapLinkBubbleMenu"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapLinkBubbleMenu"];
+      variants?: ComponentsVariants["MuiTiptapLinkBubbleMenu"];
     };
-    "MuiTiptap-MenuBar"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-MenuBar"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuBar"];
-      variants?: ComponentsVariants["MuiTiptap-MenuBar"];
+    MuiTiptapMenuBar?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapMenuBar"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapMenuBar"];
+      variants?: ComponentsVariants["MuiTiptapMenuBar"];
     };
-    "MuiTiptap-MenuButton"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-MenuButton"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuButton"];
-      variants?: ComponentsVariants["MuiTiptap-MenuButton"];
+    MuiTiptapMenuButton?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapMenuButton"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapMenuButton"];
+      variants?: ComponentsVariants["MuiTiptapMenuButton"];
     };
-    "MuiTiptap-MenuButtonColorPicker"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-MenuButtonColorPicker"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuButtonColorPicker"];
-      variants?: ComponentsVariants["MuiTiptap-MenuButtonColorPicker"];
+    MuiTiptapMenuButtonColorPicker?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapMenuButtonColorPicker"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapMenuButtonColorPicker"];
+      variants?: ComponentsVariants["MuiTiptapMenuButtonColorPicker"];
     };
-    "MuiTiptap-MenuButtonTooltip"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-MenuButtonTooltip"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuButtonTooltip"];
-      variants?: ComponentsVariants["MuiTiptap-MenuButtonTooltip"];
+    MuiTiptapMenuButtonTooltip?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapMenuButtonTooltip"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapMenuButtonTooltip"];
+      variants?: ComponentsVariants["MuiTiptapMenuButtonTooltip"];
     };
-    "MuiTiptap-MenuControlsContainer"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-MenuControlsContainer"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuControlsContainer"];
-      variants?: ComponentsVariants["MuiTiptap-MenuControlsContainer"];
+    MuiTiptapMenuControlsContainer?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapMenuControlsContainer"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapMenuControlsContainer"];
+      variants?: ComponentsVariants["MuiTiptapMenuControlsContainer"];
     };
-    "MuiTiptap-MenuDivider"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-MenuDivider"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuDivider"];
-      variants?: ComponentsVariants["MuiTiptap-MenuDivider"];
+    MuiTiptapMenuDivider?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapMenuDivider"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapMenuDivider"];
+      variants?: ComponentsVariants["MuiTiptapMenuDivider"];
     };
-    "MuiTiptap-MenuSelect"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-MenuSelect"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuSelect"];
-      variants?: ComponentsVariants["MuiTiptap-MenuSelect"];
+    MuiTiptapMenuSelect?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapMenuSelect"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapMenuSelect"];
+      variants?: ComponentsVariants["MuiTiptapMenuSelect"];
     };
-    "MuiTiptap-MenuSelectFontFamily"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-MenuSelectFontFamily"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuSelectFontFamily"];
-      variants?: ComponentsVariants["MuiTiptap-MenuSelectFontFamily"];
+    MuiTiptapMenuSelectFontFamily?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapMenuSelectFontFamily"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapMenuSelectFontFamily"];
+      variants?: ComponentsVariants["MuiTiptapMenuSelectFontFamily"];
     };
-    "MuiTiptap-MenuSelectFontSize"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-MenuSelectFontSize"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuSelectFontSize"];
-      variants?: ComponentsVariants["MuiTiptap-MenuSelectFontSize"];
+    MuiTiptapMenuSelectFontSize?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapMenuSelectFontSize"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapMenuSelectFontSize"];
+      variants?: ComponentsVariants["MuiTiptapMenuSelectFontSize"];
     };
-    "MuiTiptap-MenuSelectHeading"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-MenuSelectHeading"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuSelectHeading"];
-      variants?: ComponentsVariants["MuiTiptap-MenuSelectHeading"];
+    MuiTiptapMenuSelectHeading?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapMenuSelectHeading"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapMenuSelectHeading"];
+      variants?: ComponentsVariants["MuiTiptapMenuSelectHeading"];
     };
-    "MuiTiptap-MenuSelectTextAlign"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-MenuSelectTextAlign"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-MenuSelectTextAlign"];
-      variants?: ComponentsVariants["MuiTiptap-MenuSelectTextAlign"];
+    MuiTiptapMenuSelectTextAlign?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapMenuSelectTextAlign"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapMenuSelectTextAlign"];
+      variants?: ComponentsVariants["MuiTiptapMenuSelectTextAlign"];
     };
-    "MuiTiptap-ResizableImageComponent"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-ResizableImageComponent"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-ResizableImageComponent"];
-      variants?: ComponentsVariants["MuiTiptap-ResizableImageComponent"];
+    MuiTiptapResizableImageComponent?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapResizableImageComponent"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapResizableImageComponent"];
+      variants?: ComponentsVariants["MuiTiptapResizableImageComponent"];
     };
-    "MuiTiptap-ResizableImageResizer"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-ResizableImageResizer"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-ResizableImageResizer"];
-      variants?: ComponentsVariants["MuiTiptap-ResizableImageResizer"];
+    MuiTiptapResizableImageResizer?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapResizableImageResizer"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapResizableImageResizer"];
+      variants?: ComponentsVariants["MuiTiptapResizableImageResizer"];
     };
-    "MuiTiptap-RichTextContent"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-RichTextContent"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-RichTextContent"];
-      variants?: ComponentsVariants["MuiTiptap-RichTextContent"];
+    MuiTiptapRichTextContent?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapRichTextContent"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapRichTextContent"];
+      variants?: ComponentsVariants["MuiTiptapRichTextContent"];
     };
-    "MuiTiptap-RichTextField"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-RichTextField"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-RichTextField"];
-      variants?: ComponentsVariants["MuiTiptap-RichTextField"];
+    MuiTiptapRichTextField?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapRichTextField"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapRichTextField"];
+      variants?: ComponentsVariants["MuiTiptapRichTextField"];
     };
-    "MuiTiptap-TableBubbleMenu"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-TableBubbleMenu"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-TableBubbleMenu"];
-      variants?: ComponentsVariants["MuiTiptap-TableBubbleMenu"];
+    MuiTiptapTableBubbleMenu?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapTableBubbleMenu"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapTableBubbleMenu"];
+      variants?: ComponentsVariants["MuiTiptapTableBubbleMenu"];
     };
-    "MuiTiptap-ViewLinkMenuContent"?: {
-      defaultProps?: ComponentsPropsList["MuiTiptap-ViewLinkMenuContent"];
-      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptap-ViewLinkMenuContent"];
-      variants?: ComponentsVariants["MuiTiptap-ViewLinkMenuContent"];
+    MuiTiptapViewLinkMenuContent?: {
+      defaultProps?: ComponentsPropsList["MuiTiptapViewLinkMenuContent"];
+      styleOverrides?: ComponentsOverrides<Theme>["MuiTiptapViewLinkMenuContent"];
+      variants?: ComponentsVariants["MuiTiptapViewLinkMenuContent"];
     };
   }
 }

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -539,21 +539,21 @@ export function getImageBackgroundColorStyles(theme: Pick<Theme, "palette">): {
  * The default prefix for all styled component names (used by consumers in `styleOverrides`)
  * and utility classes generated for mui-tiptap components.
  */
-const COMPONENT_NAME_AND_UTILITY_CLASS_PREFIX = "MuiTiptap-";
+const COMPONENT_NAME_AND_UTILITY_CLASS_PREFIX = "MuiTiptap";
 
 /**
  * Get the utility name for a given component, used with `styled` to specify the
  * component name used in the MUI `theme` and `styleOverrides`.
  *
  * @param name The name without the prefix, ex: "RichTextContent".
- * @returns The full component name, ex: "MuiTiptap-RichTextContent".
+ * @returns The full component name, ex: "MuiTiptapRichTextContent".
  */
 export function getUtilityComponentName(name: string): string {
   return `${COMPONENT_NAME_AND_UTILITY_CLASS_PREFIX}${name}`;
 }
 
 /**
- * Get a utility class of the form "MuiTiptap-Foo-root" for the <Foo />
+ * Get a utility class of the form "MuiTiptapFoo-root" for the <Foo />
  * component and "root" (root element) slot.
  *
  * For convenience in users targeting certain CSS selectors to override
@@ -577,7 +577,7 @@ export function getUtilityClass(componentName: string, slot: string): string {
  * These returned utility classes are used for targeting and overriding styles
  * in nested components.
  *
- * Ex: {"root": "MuiTiptap-Foo-root"} for the <Foo /> component.
+ * Ex: {"root": "MuiTiptapFoo-root"} for the <Foo /> component.
  */
 export function getUtilityClasses<T extends string>(
   componentName: string,


### PR DESCRIPTION
Per the issue in github this updates the component names everywhere.  It requires a release note so that people use the right class names after the update.
https://github.com/sjdemartini/mui-tiptap/issues/479