### PR TITLE
Add aria-description for menu keyboard shortcuts

### DIFF
--- a/src/controls/MenuButton.tsx
+++ b/src/controls/MenuButton.tsx
@@ -6,6 +6,7 @@ import { styled, useThemeProps, type SxProps } from "@mui/material/styles";
 import { clsx } from "clsx";
 import type { ReactNode, RefObject } from "react";
 import { getUtilityComponentName } from "../styles";
+import { getShortcutKeysDescription } from "../utils/platform";
 import {
   menuButtonClasses,
   type MenuButtonClassKey,
@@ -110,6 +111,11 @@ export default function MenuButton(inProps: MenuButtonProps) {
     ...toggleButtonProps
   } = props;
 
+  // Expose keyboard shortcuts to screen readers. We use aria-description
+  // rather than aria-keyshortcuts due to inconsistent screen reader
+  // support for the latter.
+  const ariaDescription = getShortcutKeysDescription(tooltipShortcutKeys);
+
   return (
     <MenuButtonRoot
       className={clsx([menuButtonClasses.root, className, classes.root])}
@@ -132,6 +138,7 @@ export default function MenuButton(inProps: MenuButtonProps) {
           // and MenuButtonTooltip's direct child is its `contentWrapper`
           // anyway, not the button itself.
           aria-label={tooltipLabel}
+          aria-description={ariaDescription}
           {...toggleButtonProps}
         >
           {children ??

--- a/src/controls/MenuSelectHeading.tsx
+++ b/src/controls/MenuSelectHeading.tsx
@@ -8,6 +8,7 @@ import { useCallback, useMemo, type ReactNode } from "react";
 import { useRichTextEditorContext } from "../context";
 import { getEditorStyles, getUtilityComponentName } from "../styles";
 import { getAttributesForEachSelected } from "../utils/getAttributesForEachSelected";
+import { getShortcutKeysDescription } from "../utils/platform";
 import MenuButtonTooltip, {
   type MenuButtonTooltipProps,
 } from "./MenuButtonTooltip";
@@ -207,12 +208,24 @@ export default function MenuSelectHeading(inProps: MenuSelectHeadingProps) {
   const props = useThemeProps({ props: inProps, name: componentName });
   const {
     labels,
-    shortcutKeys,
+    shortcutKeys: shortcutKeyOverrides,
     hideShortcuts = false,
     classes = {},
     sx,
     ...menuSelectProps
   } = props;
+  const shortcutKeys = hideShortcuts
+    ? undefined
+    : {
+        paragraph: shortcutKeyOverrides?.paragraph ?? ["mod", "alt", "0"],
+        heading1: shortcutKeyOverrides?.heading1 ?? ["mod", "alt", "1"],
+        heading2: shortcutKeyOverrides?.heading2 ?? ["mod", "alt", "2"],
+        heading3: shortcutKeyOverrides?.heading3 ?? ["mod", "alt", "3"],
+        heading4: shortcutKeyOverrides?.heading4 ?? ["mod", "alt", "4"],
+        heading5: shortcutKeyOverrides?.heading5 ?? ["mod", "alt", "5"],
+        heading6: shortcutKeyOverrides?.heading6 ?? ["mod", "alt", "6"],
+      };
+
   const editor = useRichTextEditorContext();
 
   const handleHeadingType: (
@@ -354,14 +367,11 @@ export default function MenuSelectHeading(inProps: MenuSelectHeadingProps) {
       <MenuItem
         value={HEADING_OPTION_VALUES.Paragraph}
         disabled={!isCurrentlyParagraphOrHeading && !canSetParagraph}
+        aria-description={getShortcutKeysDescription(shortcutKeys?.paragraph)}
       >
         <MenuSelectMenuOption
           label=""
-          shortcutKeys={
-            hideShortcuts
-              ? undefined
-              : (shortcutKeys?.paragraph ?? ["mod", "alt", "0"])
-          }
+          shortcutKeys={shortcutKeys?.paragraph}
           placement="right"
           classes={{
             contentWrapper: clsx([
@@ -380,14 +390,11 @@ export default function MenuSelectHeading(inProps: MenuSelectHeadingProps) {
         <MenuItem
           value={HEADING_OPTION_VALUES.Heading1}
           disabled={!canSetHeading}
+          aria-description={getShortcutKeysDescription(shortcutKeys?.heading1)}
         >
           <MenuSelectHeadingOption1
             label=""
-            shortcutKeys={
-              hideShortcuts
-                ? undefined
-                : (shortcutKeys?.heading1 ?? ["mod", "alt", "1"])
-            }
+            shortcutKeys={shortcutKeys?.heading1}
             placement="right"
             className={clsx([
               menuSelectHeadingClasses.menuOption,
@@ -407,14 +414,11 @@ export default function MenuSelectHeading(inProps: MenuSelectHeadingProps) {
         <MenuItem
           value={HEADING_OPTION_VALUES.Heading2}
           disabled={!canSetHeading}
+          aria-description={getShortcutKeysDescription(shortcutKeys?.heading2)}
         >
           <MenuSelectHeadingOption2
             label=""
-            shortcutKeys={
-              hideShortcuts
-                ? undefined
-                : (shortcutKeys?.heading2 ?? ["mod", "alt", "2"])
-            }
+            shortcutKeys={shortcutKeys?.heading2}
             placement="right"
             className={clsx([
               menuSelectHeadingClasses.menuOption,
@@ -434,14 +438,11 @@ export default function MenuSelectHeading(inProps: MenuSelectHeadingProps) {
         <MenuItem
           value={HEADING_OPTION_VALUES.Heading3}
           disabled={!canSetHeading}
+          aria-description={getShortcutKeysDescription(shortcutKeys?.heading3)}
         >
           <MenuSelectHeadingOption3
             label=""
-            shortcutKeys={
-              hideShortcuts
-                ? undefined
-                : (shortcutKeys?.heading3 ?? ["mod", "alt", "3"])
-            }
+            shortcutKeys={shortcutKeys?.heading3}
             placement="right"
             className={clsx([
               menuSelectHeadingClasses.menuOption,
@@ -461,14 +462,11 @@ export default function MenuSelectHeading(inProps: MenuSelectHeadingProps) {
         <MenuItem
           value={HEADING_OPTION_VALUES.Heading4}
           disabled={!canSetHeading}
+          aria-description={getShortcutKeysDescription(shortcutKeys?.heading4)}
         >
           <MenuSelectHeadingOption4
             label=""
-            shortcutKeys={
-              hideShortcuts
-                ? undefined
-                : (shortcutKeys?.heading4 ?? ["mod", "alt", "4"])
-            }
+            shortcutKeys={shortcutKeys?.heading4}
             placement="right"
             className={clsx([
               menuSelectHeadingClasses.menuOption,
@@ -488,14 +486,11 @@ export default function MenuSelectHeading(inProps: MenuSelectHeadingProps) {
         <MenuItem
           value={HEADING_OPTION_VALUES.Heading5}
           disabled={!canSetHeading}
+          aria-description={getShortcutKeysDescription(shortcutKeys?.heading5)}
         >
           <MenuSelectHeadingOption5
             label=""
-            shortcutKeys={
-              hideShortcuts
-                ? undefined
-                : (shortcutKeys?.heading5 ?? ["mod", "alt", "5"])
-            }
+            shortcutKeys={shortcutKeys?.heading5}
             placement="right"
             className={clsx([
               menuSelectHeadingClasses.menuOption,
@@ -515,14 +510,11 @@ export default function MenuSelectHeading(inProps: MenuSelectHeadingProps) {
         <MenuItem
           value={HEADING_OPTION_VALUES.Heading6}
           disabled={!canSetHeading}
+          aria-description={getShortcutKeysDescription(shortcutKeys?.heading6)}
         >
           <MenuSelectHeadingOption6
             label=""
-            shortcutKeys={
-              hideShortcuts
-                ? undefined
-                : (shortcutKeys?.heading6 ?? ["mod", "alt", "6"])
-            }
+            shortcutKeys={shortcutKeys?.heading6}
             placement="right"
             className={clsx([
               menuSelectHeadingClasses.menuOption,

--- a/src/controls/MenuSelectTextAlign.tsx
+++ b/src/controls/MenuSelectTextAlign.tsx
@@ -22,6 +22,7 @@ import MenuButtonTooltip, {
 // without needing to list extension-text-align as a peer dependency.
 // eslint-disable-next-line import/no-extraneous-dependencies
 import type { TextAlignOptions } from "@tiptap/extension-text-align";
+import { getShortcutKeysDescription } from "../utils/platform";
 import { MENU_BUTTON_FONT_SIZE_DEFAULT } from "./MenuButton";
 import MenuSelect, { type MenuSelectProps } from "./MenuSelect";
 import {
@@ -301,6 +302,9 @@ export default function MenuSelectTextAlign(inProps: MenuSelectTextAlignProps) {
             // Add an accessible label, since no text is included within the
             // menu item
             aria-label={alignmentOption.label ?? alignmentOption.value}
+            aria-description={getShortcutKeysDescription(
+              alignmentOption.shortcutKeys,
+            )}
             className={clsx([
               menuSelectTextAlignClasses.menuItem,
               classes.menuItem,

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -24,6 +24,22 @@ export function getModShortcutKey(): string {
   return isMac() ? "⌘" : "Ctrl";
 }
 
+/**
+ * Format an array of shortcut keys (e.g. ["mod", "Shift", "B"]) into a
+ * human-readable string (e.g. "Ctrl + Shift + B" or "⌘ + Shift + B"), suitable
+ * for use as an aria-description. Returns undefined if the array is empty or
+ * undefined.
+ */
+export function getShortcutKeysDescription(
+  shortcutKeys: string[] | undefined,
+): string | undefined {
+  return shortcutKeys?.length
+    ? shortcutKeys
+        .map((key) => (key === "mod" ? getModShortcutKey() : key))
+        .join(" + ")
+    : undefined;
+}
+
 /** Return true if the user is using a touch-based device. */
 export function isTouchDevice(): boolean {
   if (isTouchDeviceResult === undefined) {


### PR DESCRIPTION
Alternative approach to https://github.com/sjdemartini/mui-tiptap/pull/509 that separates from the the standard (and more important) aria-label for the element. And extends to using it in other places besides just the menu button.