### PR TITLE
Ignore registry errors for pnpm audit upstream problem

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -90,7 +90,10 @@ jobs:
           pnpm --dir example add -D "typescript@${{ matrix.typescript-version }}"
 
       - name: Dependencies audit
-        run: pnpm audit --audit-level=high
+        # Use --ignore-registry-errors to work around the npm registry retiring
+        # its legacy audit endpoint, which pnpm has not yet updated to support
+        # (https://github.com/pnpm/pnpm/issues/11265)
+        run: pnpm audit --audit-level=high --ignore-registry-errors
 
       - if: ${{ env.TIPTAP_MAJOR == '2' }}
         name: Swap out v3-specific dependencies for v2 versions


### PR DESCRIPTION
To allow CI to complete, in the meantime.

Failure seen here https://github.com/sjdemartini/mui-tiptap/actions/runs/24492213202/job/71579338899