### PR TITLE
feat: support css vars

### DIFF
--- a/src/ControlledBubbleMenu.tsx
+++ b/src/ControlledBubbleMenu.tsx
@@ -120,7 +120,7 @@ const ControlledBubbleMenuPaper = styled(Paper, {
   slot: "paper" satisfies ControlledBubbleMenuClassKey,
   overridesResolver: (props, styles) => styles.paper,
 })(({ theme }) => ({
-  backgroundColor: theme.palette.background.default,
+  backgroundColor: (theme.vars || theme).palette.background.default,
 }));
 
 // The `BubbleMenu` React component provided by Tiptap in @tiptap/react and the

--- a/src/FieldContainer.tsx
+++ b/src/FieldContainer.tsx
@@ -55,14 +55,14 @@ const FieldContainerRoot = styled(Box, {
   // https://github.com/mui-org/material-ui/blob/a4972c5931e637611f6421ed2a5cc3f78207cbb2/packages/material-ui/src/OutlinedInput/OutlinedInput.js#L9-L37
   // https://github.com/mui/material-ui/blob/a4972c5931e637611f6421ed2a5cc3f78207cbb2/packages/material-ui/src/OutlinedInput/NotchedOutline.js
   ...(ownerState.variant === "outlined" && {
-    borderRadius: theme.shape.borderRadius,
+    borderRadius: (theme.vars || theme).shape.borderRadius,
     padding: 1,
     position: "relative",
 
     ...(!ownerState.focused &&
       !ownerState.disabled && {
         [`&:hover .${fieldContainerClasses.notchedOutline}`]: {
-          borderColor: theme.palette.text.primary,
+          borderColor: (theme.vars || theme).palette.text.primary,
         },
       }),
   }),
@@ -87,12 +87,12 @@ const FieldContainerNotchedOutline = styled("div", {
   zIndex: Z_INDEXES.NOTCHED_OUTLINE,
 
   ...(ownerState.focused && {
-    borderColor: theme.palette.primary.main,
+    borderColor: (theme.vars || theme).palette.primary.main,
     borderWidth: 2,
   }),
 
   ...(ownerState.disabled && {
-    borderColor: theme.palette.action.disabled,
+    borderColor: (theme.vars || theme).palette.action.disabled,
   }),
 }));
 

--- a/src/MenuBar.tsx
+++ b/src/MenuBar.tsx
@@ -64,7 +64,7 @@ const MenuBarRoot = styled(Collapse, {
     props.ownerState.disableSticky ? styles.nonSticky : styles.sticky,
   ],
 })<{ ownerState: MenuBarOwnerState }>(({ theme, ownerState }) => ({
-  borderBottomColor: theme.palette.divider,
+  borderBottomColor: (theme.vars || theme).palette.divider,
   borderBottomStyle: "solid",
   borderBottomWidth: 1,
 
@@ -74,7 +74,7 @@ const MenuBarRoot = styled(Collapse, {
         position: "sticky",
         top: ownerState.stickyOffset,
         zIndex: Z_INDEXES.MENU_BAR,
-        background: theme.palette.background.default,
+        background: (theme.vars || theme).palette.background.default,
       }),
 }));
 

--- a/src/controls/ColorPickerPopper.tsx
+++ b/src/controls/ColorPickerPopper.tsx
@@ -130,7 +130,7 @@ const ColorPickerPopperRoot = styled(Popper, {
   // modal, consistent with recommendations here
   // https://github.com/mui/material-ui/issues/14216. See
   // https://github.com/sjdemartini/mui-tiptap/issues/206.
-  zIndex: theme.zIndex.tooltip,
+  zIndex: (theme.vars || theme).zIndex.tooltip,
   // This width seems to work well to allow exactly 8 swatches, as well as the
   // default button content
   width: 235,

--- a/src/controls/ColorSwatchButton.tsx
+++ b/src/controls/ColorSwatchButton.tsx
@@ -68,11 +68,11 @@ const ColorSwatchButtonRoot = styled("button", {
   height: theme.spacing(2.5),
   width: theme.spacing(2.5),
   minWidth: theme.spacing(2.5),
-  borderRadius: theme.shape.borderRadius,
+  borderRadius: (theme.vars || theme).shape.borderRadius,
   borderColor:
     theme.palette.mode === "dark"
-      ? theme.palette.grey[700]
-      : theme.palette.grey[400],
+      ? (theme.vars || theme).palette.grey[700]
+      : (theme.vars || theme).palette.grey[400],
   borderStyle: "solid",
   borderWidth: 1,
   cursor: "pointer",

--- a/src/controls/ColorSwatchButton.tsx
+++ b/src/controls/ColorSwatchButton.tsx
@@ -85,7 +85,7 @@ const ColorSwatchButtonRoot = styled("button", {
     // To indicate that a color hasn't been chosen, we'll use a checkerboard pattern
     // (https://stackoverflow.com/a/65129916/4543977)
     background: `repeating-conic-gradient(
-      ${theme.palette.grey[400]} 0% 25%, ${theme.palette.common.white} 0% 50%)
+      ${(theme.vars || theme).palette.grey[400]} 0% 25%, ${(theme.vars || theme).palette.common.white} 0% 50%)
       50% / 12px 12px`,
     backgroundClip: "content-box",
   }),

--- a/src/controls/MenuButtonColorPicker.tsx
+++ b/src/controls/MenuButtonColorPicker.tsx
@@ -118,7 +118,7 @@ const MenuButtonColorPickerIndicatorIcon = styled(FormatColorBar, {
     fontSize: MENU_BUTTON_FONT_SIZE_DEFAULT,
     position: "absolute",
     ...(ownerState.disabled && {
-      color: theme.palette.action.disabled,
+      color: (theme.vars || theme).palette.action.disabled,
     }),
   }),
 );

--- a/src/controls/MenuButtonTooltip.tsx
+++ b/src/controls/MenuButtonTooltip.tsx
@@ -86,7 +86,7 @@ const MenuButtonTooltipShortcutKey = styled("span", {
   lineHeight: "19px",
   padding: "0 4px",
   minWidth: 17,
-  borderRadius: theme.shape.borderRadius,
+  borderRadius: (theme.vars || theme).shape.borderRadius,
   display: "inline-block",
 
   "&:not(:first-of-type)": {

--- a/src/controls/MenuSelect.tsx
+++ b/src/controls/MenuSelect.tsx
@@ -42,13 +42,13 @@ const MenuSelectRoot = styled(Select, {
     // dropdown arrow icon
     // https://github.com/mui/material-ui/blob/2cb9664b16d5a862a3796add7c8e3b088b47acb5/packages/mui-material/src/ToggleButton/ToggleButton.js#L60,
     // https://github.com/mui/material-ui/blob/0b7beb93c9015da6e35c2a31510f679126cf0de1/packages/mui-material/src/NativeSelect/NativeSelectInput.js#L96
-    color: theme.palette.action.active,
+    color: (theme.vars || theme).palette.action.active,
   },
 
   [`&.${selectClasses.disabled} .${svgIconClasses.root}`]: {
     // Matching
     // https://github.com/mui/material-ui/blob/2cb9664b16d5a862a3796add7c8e3b088b47acb5/packages/mui-material/src/ToggleButton/ToggleButton.js#L65
-    color: theme.palette.action.disabled,
+    color: (theme.vars || theme).palette.action.disabled,
   },
 
   [`& .${selectClasses.select}`]: {

--- a/src/controls/MenuSelectTextAlign.tsx
+++ b/src/controls/MenuSelectTextAlign.tsx
@@ -125,7 +125,7 @@ const MenuSelectTextAlignIcon = styled("span", {
   // dropdown arrow icon color
   // https://github.com/mui/material-ui/blob/2cb9664b16d5a862a3796add7c8e3b088b47acb5/packages/mui-material/src/ToggleButton/ToggleButton.js#L60,
   // https://github.com/mui/material-ui/blob/0b7beb93c9015da6e35c2a31510f679126cf0de1/packages/mui-material/src/NativeSelect/NativeSelectInput.js#L96
-  color: theme.palette.action.active,
+  color: (theme.vars || theme).palette.action.active,
 }));
 
 const MenuSelectTextAlignRoot = styled(MenuSelect<string>, {

--- a/src/demo/App.tsx
+++ b/src/demo/App.tsx
@@ -34,6 +34,8 @@ export default function App() {
   const theme = useMemo(
     () =>
       createTheme({
+        // Uncomment this line to enable css vars
+        // cssVariables: true,
         palette: {
           mode: paletteMode,
           secondary: {

--- a/src/demo/Editor.tsx
+++ b/src/demo/Editor.tsx
@@ -165,7 +165,8 @@ export default function Editor({ disableStickyMenuBar }: Props) {
               sx={{
                 borderTopStyle: "solid",
                 borderTopWidth: 1,
-                borderTopColor: (theme) => theme.palette.divider,
+                borderTopColor: (theme) =>
+                  (theme.vars || theme).palette.divider,
                 py: 1,
                 px: 1.5,
               }}

--- a/src/extensions/HeadingWithAnchorComponent.tsx
+++ b/src/extensions/HeadingWithAnchorComponent.tsx
@@ -78,7 +78,7 @@ const HeadingWithAnchorComponentLink = styled("a", {
 })(({ theme }) => ({
   position: "absolute",
   left: -21,
-  color: `${theme.palette.text.secondary} !important`,
+  color: `${(theme.vars || theme).palette.text.secondary} !important`,
   opacity: 0, // This is changed by the root hover above
   transition: theme.transitions.create("opacity"),
   textDecoration: "none",

--- a/src/extensions/ResizableImageComponent.tsx
+++ b/src/extensions/ResizableImageComponent.tsx
@@ -83,7 +83,7 @@ const ResizableImageComponentImage = styled("img", {
       // This "selected" state outline style is copied from our standard editor
       // styles (which are kept there as well so they appear even if not using our
       // custom resizable image).
-      outline: `3px solid ${theme.palette.primary.main}`,
+      outline: `3px solid ${(theme.vars || theme).palette.primary.main}`,
     }),
   }),
 );

--- a/src/extensions/ResizableImageResizer.tsx
+++ b/src/extensions/ResizableImageResizer.tsx
@@ -38,7 +38,7 @@ const ResizableImageResizerRoot = styled("div", {
   right: -3,
   width: 12,
   height: 12,
-  background: theme.palette.primary.main,
+  background: (theme.vars || theme).palette.primary.main,
   cursor: "nwse-resize",
 }));
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -125,7 +125,7 @@ export function getEditorStyles(
     },
 
     '& a:not([data-type="mention"])': {
-      color: theme.palette.primary.main,
+      color: (theme.vars || theme).palette.primary.main,
       textDecoration: "none",
 
       "&:hover": {
@@ -215,8 +215,8 @@ export function getEditorStyles(
         left: 0,
         display: "block",
         width: 4,
-        borderRadius: theme.shape.borderRadius,
-        background: theme.palette.text.disabled,
+        borderRadius: (theme.vars || theme).shape.borderRadius,
+        background: (theme.vars || theme).palette.text.disabled,
         content: '""',
       },
     },
@@ -225,12 +225,12 @@ export function getEditorStyles(
       padding: "2px 3px 1px",
       borderWidth: 1,
       borderStyle: "solid",
-      borderColor: theme.palette.divider,
+      borderColor: (theme.vars || theme).palette.divider,
       borderRadius: 3,
-      backgroundColor: theme.palette.action.hover,
+      backgroundColor: (theme.vars || theme).palette.action.hover,
       color:
         theme.palette.mode === "dark"
-          ? theme.palette.secondary.main
+          ? (theme.vars || theme).palette.secondary.main
           : darken(theme.palette.secondary.dark, 0.1),
     },
 
@@ -240,9 +240,9 @@ export function getEditorStyles(
       padding: theme.spacing(1),
       borderWidth: 1,
       borderStyle: "solid",
-      borderColor: theme.palette.divider,
-      borderRadius: theme.shape.borderRadius,
-      background: theme.palette.action.hover,
+      borderColor: (theme.vars || theme).palette.divider,
+      borderRadius: (theme.vars || theme).shape.borderRadius,
+      background: (theme.vars || theme).palette.action.hover,
       // By default the line-height of some monospace fonts (like "Ubuntu Mono")
       // appears to be a bit taller than necessary in pre block format
       lineHeight: 1.4,
@@ -258,8 +258,8 @@ export function getEditorStyles(
       // Setting the line-height here prevents the at-mentions from bumping up against
       // one another on consecutive lines
       lineHeight: "1.3em",
-      borderRadius: theme.shape.borderRadius,
-      color: theme.palette.primary.main,
+      borderRadius: (theme.vars || theme).shape.borderRadius,
+      color: (theme.vars || theme).palette.primary.main,
       background:
         theme.palette.mode === "dark"
           ? alpha(darken(theme.palette.primary.dark, 0.7), 0.5)
@@ -288,7 +288,7 @@ export function getEditorStyles(
       // Behavior when an image (node) is selected, at which point it can be deleted,
       // moved, etc.
       "&.ProseMirror-selectednode": {
-        outline: `3px solid ${theme.palette.primary.main}`,
+        outline: `3px solid ${(theme.vars || theme).palette.primary.main}`,
       },
     },
 
@@ -296,10 +296,10 @@ export function getEditorStyles(
       borderWidth: 0,
       borderTopWidth: "thin",
       borderStyle: "solid",
-      borderColor: theme.palette.text.secondary,
+      borderColor: (theme.vars || theme).palette.text.secondary,
 
       "&.ProseMirror-selectednode": {
-        borderColor: theme.palette.primary.main,
+        borderColor: (theme.vars || theme).palette.primary.main,
       },
     },
 
@@ -323,8 +323,8 @@ export function getEditorStyles(
         borderStyle: "solid",
         borderColor:
           theme.palette.mode === "dark"
-            ? theme.palette.grey[500]
-            : theme.palette.grey[400],
+            ? (theme.vars || theme).palette.grey[500]
+            : (theme.vars || theme).palette.grey[400],
         padding: "3px 5px",
         verticalAlign: "top",
         boxSizing: "border-box",
@@ -338,7 +338,7 @@ export function getEditorStyles(
       "& th": {
         fontWeight: 500,
         textAlign: "left",
-        backgroundColor: theme.palette.action.selected,
+        backgroundColor: (theme.vars || theme).palette.action.selected,
       },
     },
 
@@ -379,7 +379,7 @@ export function getEditorStyles(
         // This z-index proved necessary to ensure the handle sits above the
         // background of any cell (header and non-header)
         zIndex: Z_INDEXES.TABLE_ELEMENT,
-        backgroundColor: theme.palette.primary.light,
+        backgroundColor: (theme.vars || theme).palette.primary.light,
         pointerEvents: "none",
       },
 
@@ -409,7 +409,7 @@ export function getEditorStyles(
     // Based on the example styles from https://tiptap.dev/api/extensions/placeholder,
     // this adds the placeholder text at the top
     "& p.is-editor-empty:first-of-type::before": {
-      color: theme.palette.text.disabled,
+      color: (theme.vars || theme).palette.text.disabled,
       content: "attr(data-placeholder)",
       float: "left",
       height: 0,
@@ -420,7 +420,7 @@ export function getEditorStyles(
       // Override the default color provided for the Gapcursor extension (for better
       // dark/light mode compatibility)
       // https://github.com/ueberdosis/tiptap/blob/ab4a0e2507b4b92c46d293a0bb06bb00a04af6e0/packages/core/src/style.ts#L47
-      borderColor: theme.palette.text.primary,
+      borderColor: (theme.vars || theme).palette.text.primary,
     },
 
     // These styles were based on Tiptap's example here


### PR DESCRIPTION
Hello!

This PR aims to better support MUI css variables ([docs here](https://mui.com/material-ui/customization/css-theme-variables/usage/)).

For the most part, it just change `theme.palette` to `(theme.vars || theme).palette`. This is the [recommended](https://mui.com/material-ui/customization/css-theme-variables/usage/#using-theme-variables) way to support css vars when they're defined, while allowing a fallback / backwards compatibility for the classic theme object.

**How I tested**

1. Type checking passes
2. Formatting passes
3. Linting fails, but that appears to be a pre-existing error
4. I experimented with the demo and example by setting `cssVariables: true` in the theme object

**Notes**

1. I didn't change theme.palette.mode usage, which is not recommended but I'm not aware of a clean solution at the moment
2. There are a small number of palette usages I didn't change. Search for "`theme.palette`" to find them
3. I did not change `alpha`, `lighten`, or `darken` functions. I believe those should become `theme.alpha`, `theme.lighten`, and `theme.darken` but I'm not sure in which MUI version those were introduced so it _may_ be a breaking change