### PR TITLE
Add editor.isDestroyed check before can in disabled check 

### DIFF
--- a/src/__tests__/controls/isEditorActive.test.ts
+++ b/src/__tests__/controls/isEditorActive.test.ts
@@ -1,0 +1,29 @@
+import type { Editor } from "@tiptap/core";
+import { describe, expect, it } from "vitest";
+import { isEditorActive } from "../../controls/isEditorActive";
+
+function makeEditor(overrides: Partial<Editor>): Editor {
+  return {
+    isEditable: true,
+    isDestroyed: false,
+    ...overrides,
+  } as Editor;
+}
+
+describe("isEditorActive()", () => {
+  it("returns false when the editor is null", () => {
+    expect(isEditorActive(null)).toBe(false);
+  });
+
+  it("returns false when the editor is not editable", () => {
+    expect(isEditorActive(makeEditor({ isEditable: false }))).toBe(false);
+  });
+
+  it("returns false when the editor is destroyed", () => {
+    expect(isEditorActive(makeEditor({ isDestroyed: true }))).toBe(false);
+  });
+
+  it("returns true when the editor is editable and not destroyed", () => {
+    expect(isEditorActive(makeEditor({}))).toBe(true);
+  });
+});

--- a/src/controls/MenuButtonAddImage.tsx
+++ b/src/controls/MenuButtonAddImage.tsx
@@ -1,6 +1,7 @@
 import AddPhotoAlternate from "@mui/icons-material/AddPhotoAlternate";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonAddImageProps = Partial<MenuButtonProps> & {
   /**
@@ -35,7 +36,7 @@ export default function MenuButtonAddImage({
       tooltipLabel="Insert image"
       IconComponent={AddPhotoAlternate}
       disabled={
-        !editor?.isEditable ||
+        !isEditorActive(editor) ||
         // We can use any URL here for testing `can` (to see if an image can be
         // added to the editor currently)
         !editor.can().setImage({ src: "http://example.com" })

--- a/src/controls/MenuButtonAddTable.tsx
+++ b/src/controls/MenuButtonAddTable.tsx
@@ -1,5 +1,6 @@
 import { useRichTextEditorContext } from "../context";
 import { Table } from "../icons";
+import { isEditorActive } from "./isEditorActive";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
 export type MenuButtonAddTableProps = Partial<MenuButtonProps>;
@@ -10,7 +11,7 @@ export default function MenuButtonAddTable(props: MenuButtonAddTableProps) {
     <MenuButton
       tooltipLabel="Insert table"
       IconComponent={Table}
-      disabled={!editor?.isEditable || !editor.can().insertTable()}
+      disabled={!isEditorActive(editor) || !editor.can().insertTable()}
       onClick={() =>
         editor
           ?.chain()

--- a/src/controls/MenuButtonAlignCenter.tsx
+++ b/src/controls/MenuButtonAlignCenter.tsx
@@ -2,6 +2,7 @@
 import FormatAlignCenterIcon from "@mui/icons-material/FormatAlignCenter";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonAlignCenterProps = Partial<MenuButtonProps>;
 
@@ -15,7 +16,7 @@ export default function MenuButtonAlignCenter(
       tooltipShortcutKeys={["mod", "Shift", "E"]}
       IconComponent={FormatAlignCenterIcon}
       selected={editor?.isActive({ textAlign: "center" }) ?? false}
-      disabled={!editor?.isEditable || !editor.can().setTextAlign("center")}
+      disabled={!isEditorActive(editor) || !editor.can().setTextAlign("center")}
       onClick={() => editor?.chain().focus().setTextAlign("center").run()}
       {...props}
     />

--- a/src/controls/MenuButtonAlignJustify.tsx
+++ b/src/controls/MenuButtonAlignJustify.tsx
@@ -2,6 +2,7 @@
 import FormatAlignJustifyIcon from "@mui/icons-material/FormatAlignJustify";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonAlignJustifyProps = Partial<MenuButtonProps>;
 
@@ -15,7 +16,9 @@ export default function MenuButtonAlignJustify(
       tooltipShortcutKeys={["mod", "Shift", "J"]}
       IconComponent={FormatAlignJustifyIcon}
       selected={editor?.isActive({ textAlign: "justify" }) ?? false}
-      disabled={!editor?.isEditable || !editor.can().setTextAlign("justify")}
+      disabled={
+        !isEditorActive(editor) || !editor.can().setTextAlign("justify")
+      }
       onClick={() => editor?.chain().focus().setTextAlign("justify").run()}
       {...props}
     />

--- a/src/controls/MenuButtonAlignLeft.tsx
+++ b/src/controls/MenuButtonAlignLeft.tsx
@@ -2,6 +2,7 @@
 import FormatAlignLeftIcon from "@mui/icons-material/FormatAlignLeft";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonAlignLeftProps = Partial<MenuButtonProps>;
 
@@ -13,7 +14,7 @@ export default function MenuButtonAlignLeft(props: MenuButtonAlignLeftProps) {
       tooltipShortcutKeys={["mod", "Shift", "L"]}
       IconComponent={FormatAlignLeftIcon}
       selected={editor?.isActive({ textAlign: "left" }) ?? false}
-      disabled={!editor?.isEditable || !editor.can().setTextAlign("left")}
+      disabled={!isEditorActive(editor) || !editor.can().setTextAlign("left")}
       onClick={() => editor?.chain().focus().setTextAlign("left").run()}
       {...props}
     />

--- a/src/controls/MenuButtonAlignRight.tsx
+++ b/src/controls/MenuButtonAlignRight.tsx
@@ -2,6 +2,7 @@
 import FormatAlignRightIcon from "@mui/icons-material/FormatAlignRight";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonAlignRightProps = Partial<MenuButtonProps>;
 
@@ -13,7 +14,7 @@ export default function MenuButtonAlignRight(props: MenuButtonAlignRightProps) {
       tooltipShortcutKeys={["mod", "Shift", "R"]}
       IconComponent={FormatAlignRightIcon}
       selected={editor?.isActive({ textAlign: "right" }) ?? false}
-      disabled={!editor?.isEditable || !editor.can().setTextAlign("right")}
+      disabled={!isEditorActive(editor) || !editor.can().setTextAlign("right")}
       onClick={() => editor?.chain().focus().setTextAlign("right").run()}
       {...props}
     />

--- a/src/controls/MenuButtonBlockquote.tsx
+++ b/src/controls/MenuButtonBlockquote.tsx
@@ -2,6 +2,7 @@
 import FormatQuote from "@mui/icons-material/FormatQuote";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonBlockquoteProps = Partial<MenuButtonProps>;
 
@@ -13,7 +14,7 @@ export default function MenuButtonBlockquote(props: MenuButtonBlockquoteProps) {
       tooltipShortcutKeys={["mod", "Shift", "B"]}
       IconComponent={FormatQuote}
       selected={editor?.isActive("blockquote") ?? false}
-      disabled={!editor?.isEditable || !editor.can().toggleBlockquote()}
+      disabled={!isEditorActive(editor) || !editor.can().toggleBlockquote()}
       onClick={() => editor?.chain().focus().toggleBlockquote().run()}
       {...props}
     />

--- a/src/controls/MenuButtonBold.tsx
+++ b/src/controls/MenuButtonBold.tsx
@@ -2,6 +2,7 @@
 import FormatBold from "@mui/icons-material/FormatBold";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonBoldProps = Partial<MenuButtonProps>;
 
@@ -13,7 +14,7 @@ export default function MenuButtonBold(props: MenuButtonBoldProps) {
       tooltipShortcutKeys={["mod", "B"]}
       IconComponent={FormatBold}
       selected={editor?.isActive("bold") ?? false}
-      disabled={!editor?.isEditable || !editor.can().toggleBold()}
+      disabled={!isEditorActive(editor) || !editor.can().toggleBold()}
       onClick={() => editor?.chain().focus().toggleBold().run()}
       {...props}
     />

--- a/src/controls/MenuButtonBulletedList.tsx
+++ b/src/controls/MenuButtonBulletedList.tsx
@@ -2,6 +2,7 @@
 import FormatListBulleted from "@mui/icons-material/FormatListBulleted";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonBulletedListProps = Partial<MenuButtonProps>;
 
@@ -15,7 +16,7 @@ export default function MenuButtonBulletedList(
       tooltipShortcutKeys={["mod", "Shift", "8"]}
       IconComponent={FormatListBulleted}
       selected={editor?.isActive("bulletList") ?? false}
-      disabled={!editor?.isEditable || !editor.can().toggleBulletList()}
+      disabled={!isEditorActive(editor) || !editor.can().toggleBulletList()}
       onClick={() => editor?.chain().focus().toggleBulletList().run()}
       {...props}
     />

--- a/src/controls/MenuButtonCode.tsx
+++ b/src/controls/MenuButtonCode.tsx
@@ -2,6 +2,7 @@
 import Code from "@mui/icons-material/Code";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonCodeProps = Partial<MenuButtonProps>;
 
@@ -13,7 +14,7 @@ export default function MenuButtonCode(props: MenuButtonCodeProps) {
       tooltipShortcutKeys={["mod", "E"]}
       IconComponent={Code}
       selected={editor?.isActive("code") ?? false}
-      disabled={!editor?.isEditable || !editor.can().toggleCode()}
+      disabled={!isEditorActive(editor) || !editor.can().toggleCode()}
       onClick={() => editor?.chain().focus().toggleCode().run()}
       {...props}
     />

--- a/src/controls/MenuButtonCodeBlock.tsx
+++ b/src/controls/MenuButtonCodeBlock.tsx
@@ -1,6 +1,7 @@
 /// <reference types="@tiptap/extension-code-block" />
 import { useRichTextEditorContext } from "../context";
 import { CodeBlock } from "../icons";
+import { isEditorActive } from "./isEditorActive";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
 export type MenuButtonCodeBlockProps = Partial<MenuButtonProps>;
@@ -13,7 +14,7 @@ export default function MenuButtonCodeBlock(props: MenuButtonCodeBlockProps) {
       tooltipShortcutKeys={["mod", "Alt", "C"]}
       IconComponent={CodeBlock}
       selected={editor?.isActive("codeBlock") ?? false}
-      disabled={!editor?.isEditable || !editor.can().toggleCodeBlock()}
+      disabled={!isEditorActive(editor) || !editor.can().toggleCodeBlock()}
       onClick={() => editor?.chain().focus().toggleCodeBlock().run()}
       {...props}
     />

--- a/src/controls/MenuButtonHighlightColor.tsx
+++ b/src/controls/MenuButtonHighlightColor.tsx
@@ -1,6 +1,7 @@
 /// <reference types="@tiptap/extension-highlight" />
 import { useRichTextEditorContext } from "../context";
 import { FormatInkHighlighterNoBar } from "../icons";
+import { isEditorActive } from "./isEditorActive";
 import MenuButtonColorPicker, {
   type MenuButtonColorPickerProps,
 } from "./MenuButtonColorPicker";
@@ -58,7 +59,7 @@ export default function MenuButtonHighlightColor({
           editor?.chain().focus().unsetHighlight().run();
         }
       }}
-      disabled={!editor?.isEditable || !editor.can().toggleHighlight()}
+      disabled={!isEditorActive(editor) || !editor.can().toggleHighlight()}
       {...menuButtonProps}
       labels={{
         removeColorButton: "None",

--- a/src/controls/MenuButtonHighlightToggle.tsx
+++ b/src/controls/MenuButtonHighlightToggle.tsx
@@ -1,6 +1,7 @@
 /// <reference types="@tiptap/extension-highlight" />
 import { useRichTextEditorContext } from "../context";
 import { FormatInkHighlighter } from "../icons";
+import { isEditorActive } from "./isEditorActive";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
 
 export type MenuButtonHighlightToggleProps = Partial<MenuButtonProps>;
@@ -25,7 +26,7 @@ export default function MenuButtonHighlightToggle({
       tooltipLabel="Highlight"
       tooltipShortcutKeys={["mod", "Shift", "H"]}
       selected={editor?.isActive("highlight") ?? false}
-      disabled={!editor?.isEditable || !editor.can().toggleHighlight()}
+      disabled={!isEditorActive(editor) || !editor.can().toggleHighlight()}
       onClick={() => editor?.chain().focus().toggleHighlight().run()}
       {...menuButtonProps}
     />

--- a/src/controls/MenuButtonHorizontalRule.tsx
+++ b/src/controls/MenuButtonHorizontalRule.tsx
@@ -2,6 +2,7 @@
 import HorizontalRuleIcon from "@mui/icons-material/HorizontalRule";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonHorizontalRuleProps = Partial<MenuButtonProps>;
 
@@ -13,7 +14,7 @@ export default function MenuButtonHorizontalRule(
     <MenuButton
       tooltipLabel="Insert horizontal line"
       IconComponent={HorizontalRuleIcon}
-      disabled={!editor?.isEditable || !editor.can().setHorizontalRule()}
+      disabled={!isEditorActive(editor) || !editor.can().setHorizontalRule()}
       onClick={() => editor?.chain().focus().setHorizontalRule().run()}
       {...props}
     />

--- a/src/controls/MenuButtonIndent.tsx
+++ b/src/controls/MenuButtonIndent.tsx
@@ -1,6 +1,7 @@
 import FormatIndentIncrease from "@mui/icons-material/FormatIndentIncrease";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonIndentProps = Partial<MenuButtonProps>;
 
@@ -11,7 +12,9 @@ export default function MenuButtonIndent(props: MenuButtonIndentProps) {
       tooltipLabel="Indent"
       tooltipShortcutKeys={["Tab"]}
       IconComponent={FormatIndentIncrease}
-      disabled={!editor?.isEditable || !editor.can().sinkListItem("listItem")}
+      disabled={
+        !isEditorActive(editor) || !editor.can().sinkListItem("listItem")
+      }
       onClick={() => editor?.chain().focus().sinkListItem("listItem").run()}
       {...props}
     />

--- a/src/controls/MenuButtonItalic.tsx
+++ b/src/controls/MenuButtonItalic.tsx
@@ -2,6 +2,7 @@
 import FormatItalic from "@mui/icons-material/FormatItalic";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonItalicProps = Partial<MenuButtonProps>;
 
@@ -13,7 +14,7 @@ export default function MenuButtonItalic(props: MenuButtonItalicProps) {
       tooltipShortcutKeys={["mod", "I"]}
       IconComponent={FormatItalic}
       selected={editor?.isActive("italic") ?? false}
-      disabled={!editor?.isEditable || !editor.can().toggleItalic()}
+      disabled={!isEditorActive(editor) || !editor.can().toggleItalic()}
       onClick={() => editor?.chain().focus().toggleItalic().run()}
       {...props}
     />

--- a/src/controls/MenuButtonOrderedList.tsx
+++ b/src/controls/MenuButtonOrderedList.tsx
@@ -2,6 +2,7 @@
 import FormatListNumbered from "@mui/icons-material/FormatListNumbered";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonOrderedListProps = Partial<MenuButtonProps>;
 
@@ -15,7 +16,7 @@ export default function MenuButtonOrderedList(
       tooltipShortcutKeys={["mod", "Shift", "7"]}
       IconComponent={FormatListNumbered}
       selected={editor?.isActive("orderedList") ?? false}
-      disabled={!editor?.isEditable || !editor.can().toggleOrderedList()}
+      disabled={!isEditorActive(editor) || !editor.can().toggleOrderedList()}
       onClick={() => editor?.chain().focus().toggleOrderedList().run()}
       {...props}
     />

--- a/src/controls/MenuButtonRedo.tsx
+++ b/src/controls/MenuButtonRedo.tsx
@@ -2,6 +2,7 @@
 import RedoIcon from "@mui/icons-material/Redo";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonRedoProps = Partial<MenuButtonProps>;
 
@@ -12,7 +13,7 @@ export default function MenuButtonRedo(props: MenuButtonRedoProps) {
       tooltipLabel="Redo"
       tooltipShortcutKeys={["mod", "Shift", "Z"]}
       IconComponent={RedoIcon}
-      disabled={!editor?.isEditable || !editor.can().redo()}
+      disabled={!isEditorActive(editor) || !editor.can().redo()}
       onClick={() => editor?.chain().focus().redo().run()}
       {...props}
     />

--- a/src/controls/MenuButtonRemoveFormatting.tsx
+++ b/src/controls/MenuButtonRemoveFormatting.tsx
@@ -1,6 +1,7 @@
 import FormatClear from "@mui/icons-material/FormatClear";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonRemoveFormattingProps = Partial<MenuButtonProps>;
 
@@ -16,7 +17,7 @@ export default function MenuButtonRemoveFormatting(
     <MenuButton
       tooltipLabel="Remove inline formatting"
       IconComponent={FormatClear}
-      disabled={!editor?.isEditable || !editor.can().unsetAllMarks()}
+      disabled={!isEditorActive(editor) || !editor.can().unsetAllMarks()}
       onClick={() => editor?.chain().focus().unsetAllMarks().run()}
       {...props}
     />

--- a/src/controls/MenuButtonStrikethrough.tsx
+++ b/src/controls/MenuButtonStrikethrough.tsx
@@ -2,6 +2,7 @@
 import StrikethroughS from "@mui/icons-material/StrikethroughS";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonStrikethroughProps = Partial<MenuButtonProps>;
 
@@ -15,7 +16,7 @@ export default function MenuButtonStrikethrough(
       tooltipShortcutKeys={["mod", "Shift", "S"]}
       IconComponent={StrikethroughS}
       selected={editor?.isActive("strike") ?? false}
-      disabled={!editor?.isEditable || !editor.can().toggleStrike()}
+      disabled={!isEditorActive(editor) || !editor.can().toggleStrike()}
       onClick={() => editor?.chain().focus().toggleStrike().run()}
       {...props}
     />

--- a/src/controls/MenuButtonSubscript.tsx
+++ b/src/controls/MenuButtonSubscript.tsx
@@ -2,6 +2,7 @@
 import Subscript from "@mui/icons-material/Subscript";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonSubscriptProps = Partial<MenuButtonProps>;
 
@@ -13,7 +14,7 @@ export default function MenuButtonSubscript(props: MenuButtonSubscriptProps) {
       tooltipShortcutKeys={["mod", ","]}
       IconComponent={Subscript}
       selected={editor?.isActive("subscript") ?? false}
-      disabled={!editor?.isEditable || !editor.can().toggleSubscript()}
+      disabled={!isEditorActive(editor) || !editor.can().toggleSubscript()}
       onClick={() => editor?.chain().focus().toggleSubscript().run()}
       {...props}
     />

--- a/src/controls/MenuButtonSuperscript.tsx
+++ b/src/controls/MenuButtonSuperscript.tsx
@@ -2,6 +2,7 @@
 import Superscript from "@mui/icons-material/Superscript";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonSuperscriptProps = Partial<MenuButtonProps>;
 
@@ -15,7 +16,7 @@ export default function MenuButtonSuperscript(
       tooltipShortcutKeys={["mod", "."]}
       IconComponent={Superscript}
       selected={editor?.isActive("superscript") ?? false}
-      disabled={!editor?.isEditable || !editor.can().toggleSuperscript()}
+      disabled={!isEditorActive(editor) || !editor.can().toggleSuperscript()}
       onClick={() => editor?.chain().focus().toggleSuperscript().run()}
       {...props}
     />

--- a/src/controls/MenuButtonTaskList.tsx
+++ b/src/controls/MenuButtonTaskList.tsx
@@ -2,6 +2,7 @@
 import Checklist from "@mui/icons-material/Checklist";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonTaskListProps = Partial<MenuButtonProps>;
 
@@ -13,7 +14,7 @@ export default function MenuButtonTaskList(props: MenuButtonTaskListProps) {
       tooltipShortcutKeys={["mod", "Shift", "9"]}
       IconComponent={Checklist}
       selected={editor?.isActive("taskList") ?? false}
-      disabled={!editor?.isEditable || !editor.can().toggleTaskList()}
+      disabled={!isEditorActive(editor) || !editor.can().toggleTaskList()}
       onClick={() => editor?.chain().focus().toggleTaskList().run()}
       {...props}
     />

--- a/src/controls/MenuButtonTextColor.tsx
+++ b/src/controls/MenuButtonTextColor.tsx
@@ -6,6 +6,7 @@ import { getAttributesForEachSelected } from "../utils";
 import MenuButtonColorPicker, {
   type MenuButtonColorPickerProps,
 } from "./MenuButtonColorPicker";
+import { isEditorActive } from "./isEditorActive";
 
 export interface MenuButtonTextColorProps
   extends Partial<MenuButtonColorPickerProps> {
@@ -76,7 +77,7 @@ export default function MenuButtonTextColor({
       onChange={(newColor) => {
         editor?.chain().focus().setColor(newColor).run();
       }}
-      disabled={!editor?.isEditable || !editor.can().setColor("#000")}
+      disabled={!isEditorActive(editor) || !editor.can().setColor("#000")}
       {...menuButtonProps}
       labels={{ removeColorButton: "Reset", ...menuButtonProps.labels }}
     />

--- a/src/controls/MenuButtonUnderline.tsx
+++ b/src/controls/MenuButtonUnderline.tsx
@@ -2,6 +2,7 @@
 import FormatUnderlinedIcon from "@mui/icons-material/FormatUnderlined";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonUnderlineProps = Partial<MenuButtonProps>;
 
@@ -13,7 +14,7 @@ export default function MenuButtonUnderline(props: MenuButtonUnderlineProps) {
       tooltipShortcutKeys={["mod", "U"]}
       IconComponent={FormatUnderlinedIcon}
       selected={editor?.isActive("underline") ?? false}
-      disabled={!editor?.isEditable || !editor.can().toggleUnderline()}
+      disabled={!isEditorActive(editor) || !editor.can().toggleUnderline()}
       onClick={() => editor?.chain().focus().toggleUnderline().run()}
       {...props}
     />

--- a/src/controls/MenuButtonUndo.tsx
+++ b/src/controls/MenuButtonUndo.tsx
@@ -2,6 +2,7 @@
 import UndoIcon from "@mui/icons-material/Undo";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonUndoProps = Partial<MenuButtonProps>;
 
@@ -12,7 +13,7 @@ export default function MenuButtonUndo(props: MenuButtonUndoProps) {
       tooltipLabel="Undo"
       tooltipShortcutKeys={["mod", "Z"]}
       IconComponent={UndoIcon}
-      disabled={!editor?.isEditable || !editor.can().undo()}
+      disabled={!isEditorActive(editor) || !editor.can().undo()}
       onClick={() => editor?.chain().focus().undo().run()}
       {...props}
     />

--- a/src/controls/MenuButtonUnindent.tsx
+++ b/src/controls/MenuButtonUnindent.tsx
@@ -1,6 +1,7 @@
 import FormatIndentDecrease from "@mui/icons-material/FormatIndentDecrease";
 import { useRichTextEditorContext } from "../context";
 import MenuButton, { type MenuButtonProps } from "./MenuButton";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuButtonUnindentProps = Partial<MenuButtonProps>;
 
@@ -11,7 +12,9 @@ export default function MenuButtonUnindent(props: MenuButtonUnindentProps) {
       tooltipLabel="Unindent"
       tooltipShortcutKeys={["Shift", "Tab"]}
       IconComponent={FormatIndentDecrease}
-      disabled={!editor?.isEditable || !editor.can().liftListItem("listItem")}
+      disabled={
+        !isEditorActive(editor) || !editor.can().liftListItem("listItem")
+      }
       onClick={() => editor?.chain().focus().liftListItem("listItem").run()}
       {...props}
     />

--- a/src/controls/MenuSelectFontFamily.tsx
+++ b/src/controls/MenuSelectFontFamily.tsx
@@ -13,6 +13,7 @@ import {
   type MenuSelectFontFamilyClassKey,
   type MenuSelectFontFamilyClasses,
 } from "./MenuSelectFontFamily.classes";
+import { isEditorActive } from "./isEditorActive";
 
 export type FontFamilySelectOption = {
   /**
@@ -174,7 +175,7 @@ export default function MenuSelectFontFamily(
       }}
       disabled={
         // Pass an arbitrary value just to check `can()`
-        !editor?.isEditable || !editor.can().setFontFamily("serif")
+        !isEditorActive(editor) || !editor.can().setFontFamily("serif")
       }
       renderValue={(value) => {
         if (!value || value === MULTIPLE_FAMILIES_SELECTED_VALUE) {

--- a/src/controls/MenuSelectFontSize.tsx
+++ b/src/controls/MenuSelectFontSize.tsx
@@ -15,6 +15,7 @@ import {
   type MenuSelectFontSizeClassKey,
   type MenuSelectFontSizeClasses,
 } from "./MenuSelectFontSize.classes";
+import { isEditorActive } from "./isEditorActive";
 
 export type FontSizeSelectOptionObject = {
   /**
@@ -228,7 +229,7 @@ export default function MenuSelectFontSize(inProps: MenuSelectFontSizeProps) {
       }}
       disabled={
         // Pass an arbitrary value to can().setFontSize() just to check `can()`
-        !editor?.isEditable || !editor.can().setFontSize("12px")
+        !isEditorActive(editor) || !editor.can().setFontSize("12px")
       }
       renderValue={(value) => {
         if (!value || value === MULTIPLE_SIZES_SELECTED_VALUE) {

--- a/src/controls/MenuSelectHeading.tsx
+++ b/src/controls/MenuSelectHeading.tsx
@@ -18,6 +18,7 @@ import {
   type MenuSelectHeadingClassKey,
   type MenuSelectHeadingClasses,
 } from "./MenuSelectHeading.classes";
+import { isEditorActive } from "./isEditorActive";
 
 export type MenuSelectHeadingProps = Omit<
   MenuSelectProps<HeadingOptionValue | "">,
@@ -281,7 +282,7 @@ export default function MenuSelectHeading(inProps: MenuSelectHeadingProps) {
   }
 
   const isCurrentlyParagraphOrHeading = selectedValue !== "";
-  const canSetParagraph = !!editor?.can().setParagraph();
+  const canSetParagraph = isEditorActive(editor) && editor.can().setParagraph();
 
   // Figure out which settings the user has enabled with the heading extension
   const enabledHeadingLevels: Set<Level> = useMemo(() => {

--- a/src/controls/isEditorActive.ts
+++ b/src/controls/isEditorActive.ts
@@ -1,0 +1,5 @@
+import type { Editor } from "@tiptap/core";
+
+export function isEditorActive(editor: Editor | null): editor is Editor {
+  return editor != null && editor.isEditable && !editor.isDestroyed;
+}


### PR DESCRIPTION
Each component did trigger a error when checking editor.can() since .can does not account for editor.isDestoryed. To fix the issue we need to check editor.isDestroyed.

Uncaught TypeError: Cannot read properties of null (reading 'can')
    at Editor.can (dist-DkBkF8sp.js?v=40af215c:14805:30)
    at MenuButtonAlignRight (MenuButtonAlignRight.js:9:377)
    at renderWithHooks (react-dom.development.js:16305:18)
    at mountIndeterminateComponent (react-dom.development.js:20074:13)
    at beginWork (react-dom.development.js:21587:16)
    at HTMLUnknownElement.callCallback (react-dom.development.js:4164:14)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:4213:16)
    at invokeGuardedCallback (react-dom.development.js:4277:31)
    at beginWork$1 (react-dom.development.js:27451:7)
    at performUnitOfWork (react-dom.development.js:26557:12)