### PR TITLE
Ignore CodeSandbox demo in link checks

### DIFF
--- a/.markdown-link-check-config.json
+++ b/.markdown-link-check-config.json
@@ -5,6 +5,9 @@
     },
     {
       "pattern": "^https://www\\.npmjs\\.com/"
+    },
+    {
+      "pattern": "^https://codesandbox\\.io/p/sandbox/mui-tiptap-demo-3zl2l6$"
     }
   ],
   "timeout": "10s",


### PR DESCRIPTION
Exempts the CodeSandbox demo URL from automated link checks because CodeSandbox returns HTTP 403 to bots.